### PR TITLE
[RW-10323][risk=no] Add copy code button to export dataset

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -294,8 +294,8 @@ public class DataSetController implements DataSetApiDelegate {
       notebookFile = createNotebookObject(dataSetExportRequest.getKernelType());
     }
 
-    List<String> codeCells = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
-    notebookFile = addCells(notebookFile, codeCells);
+    notebookFile =
+        addCells(notebookFile, dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace));
 
     notebooksService.saveNotebook(bucketName, dataSetExportRequest.getNotebookName(), notebookFile);
 

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -253,16 +253,19 @@ public class DataSetController implements DataSetApiDelegate {
 
     JSONObject notebookFile = createNotebookObject(dataSetExportRequest.getKernelType());
 
-    dataSetService
-        .generateCodeCells(dataSetExportRequest, dbWorkspace)
-        .forEach(
-            cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
+    List<String> codeCells = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
+
+    String rawCode = String.join(System.lineSeparator(), codeCells);
+    codeCells.forEach(
+        cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
 
     return ResponseEntity.ok(
         new ReadOnlyNotebookResponse()
             .html(
                 notebooksService.convertJupyterNotebookToHtml(
-                    notebookFile.toString().getBytes(StandardCharsets.UTF_8))));
+                    notebookFile.toString().getBytes(StandardCharsets.UTF_8)))
+            .text(rawCode));
+  }
   }
 
   @Override
@@ -289,10 +292,10 @@ public class DataSetController implements DataSetApiDelegate {
       notebookFile = createNotebookObject(dataSetExportRequest.getKernelType());
     }
 
-    dataSetService
-        .generateCodeCells(dataSetExportRequest, dbWorkspace)
-        .forEach(
-            cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
+    List<String> x = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
+
+    x.forEach(
+        cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
 
     notebooksService.saveNotebook(bucketName, dataSetExportRequest.getNotebookName(), notebookFile);
 

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.inject.Provider;
@@ -73,8 +72,6 @@ public class DataSetController implements DataSetApiDelegate {
   public static final String EMPTY_CELL_MARKER = "";
   public static final String WHOLE_GENOME_VALUE = "VCF Files";
 
-  private static final Logger log = Logger.getLogger(DataSetController.class.getName());
-
   private final DataSetService dataSetService;
 
   private final Provider<DbUser> userProvider;
@@ -85,6 +82,15 @@ public class DataSetController implements DataSetApiDelegate {
   private final GenomicExtractionService genomicExtractionService;
   private final WorkspaceAuthService workspaceAuthService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  public JSONObject addCells(JSONObject originalJson, List<String> codeCells) {
+    JSONObject newJson = new JSONObject(originalJson.toString());
+
+    codeCells.forEach(
+        cell -> newJson.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
+
+    return newJson;
+  }
 
   @Autowired
   DataSetController(
@@ -255,8 +261,7 @@ public class DataSetController implements DataSetApiDelegate {
 
     List<String> codeCells = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
 
-    codeCells.forEach(
-        cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
+    notebookFile = addCells(notebookFile, codeCells);
 
     return ResponseEntity.ok(
         new ReadOnlyNotebookResponse()

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -255,7 +255,6 @@ public class DataSetController implements DataSetApiDelegate {
 
     List<String> codeCells = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
 
-    String rawCode = String.join(System.lineSeparator(), codeCells);
     codeCells.forEach(
         cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
 
@@ -264,7 +263,7 @@ public class DataSetController implements DataSetApiDelegate {
             .html(
                 notebooksService.convertJupyterNotebookToHtml(
                     notebookFile.toString().getBytes(StandardCharsets.UTF_8)))
-            .text(rawCode));
+            .text(String.join(System.lineSeparator(), codeCells)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DataSetController.java
@@ -266,7 +266,6 @@ public class DataSetController implements DataSetApiDelegate {
                     notebookFile.toString().getBytes(StandardCharsets.UTF_8)))
             .text(rawCode));
   }
-  }
 
   @Override
   public ResponseEntity<EmptyResponse> exportToNotebook(
@@ -292,10 +291,10 @@ public class DataSetController implements DataSetApiDelegate {
       notebookFile = createNotebookObject(dataSetExportRequest.getKernelType());
     }
 
-    List<String> x = dataSetService.generateCodeCells(dataSetExportRequest, dbWorkspace);
-
-    x.forEach(
-        cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
+    dataSetService
+        .generateCodeCells(dataSetExportRequest, dbWorkspace)
+        .forEach(
+            cell -> notebookFile.getJSONArray("cells").put(createNotebookCodeCellWithString(cell)));
 
     notebooksService.saveNotebook(bucketName, dataSetExportRequest.getNotebookName(), notebookFile);
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8052,6 +8052,8 @@ components:
       properties:
         html:
           type: string
+        text:
+          type: string
     SurveysResponse:
       required:
       - items

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -441,6 +441,7 @@ export const IconButton = ({
   hover = {},
   tooltip = '',
   disabled = false,
+  title = '',
   ...props
 }) => {
   return (
@@ -459,7 +460,7 @@ export const IconButton = ({
         disabled={disabled}
         {...props}
       >
-        <Icon disabled={disabled} style={style} />
+        <Icon disabled={disabled} style={style} title={title} />
       </TerraUIInteractive>
     </TooltipTrigger>
   );

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -460,7 +460,7 @@ export const IconButton = ({
         disabled={disabled}
         {...props}
       >
-        <Icon disabled={disabled} style={style} title={title} />
+        <Icon {...{ title, disabled, style }} />
       </TerraUIInteractive>
     </TooltipTrigger>
   );

--- a/ui/src/app/components/buttons.tsx
+++ b/ui/src/app/components/buttons.tsx
@@ -127,6 +127,20 @@ const buttonVariants = {
     },
     hover: { backgroundColor: colors.primary, color: colors.white },
   },
+  secondaryOutline: {
+    style: {
+      ...styles.baseNew,
+      backgroundColor: 'transparent',
+      color: colors.primary,
+      borderStyle: 'solid',
+      borderWidth: '1px',
+    },
+    disabledStyle: {
+      borderColor: colorWithWhiteness(colors.dark, disabledAlpha),
+      color: colorWithWhiteness(colors.dark, disabledAlpha),
+    },
+    hover: { backgroundColor: colors.primary, color: colors.white },
+  },
   secondaryLight: {
     style: {
       ...styles.baseNew,

--- a/ui/src/app/components/icons.tsx
+++ b/ui/src/app/components/icons.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as fp from 'lodash/fp';
-import { faCircle } from '@fortawesome/free-regular-svg-icons';
+import { faCircle, faCopy } from '@fortawesome/free-regular-svg-icons';
 import {
   faBan,
   faCaretRight,
@@ -182,6 +182,7 @@ export const Check = (props) => <Icon shape={faCheck} {...props} />;
 export const CheckCircle = (props) => <Icon shape={faCheckCircle} {...props} />;
 export const Circle = (props) => <Icon shape={faCircle} {...props} />;
 export const Clock = (props) => <Icon shape={faClock} {...props} />;
+export const Copy = (props) => <Icon shape={faCopy} {...props} />;
 export const ExclamationTriangle = (props) => (
   <Icon shape={faExclamationTriangle} color={colors.danger} {...props} />
 );

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -485,59 +485,67 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('Auto reload code preview if genomics analysis tool is changed', async () => {
-  //   const expectedDatasetRequest = {
-  //     dataSetId: dataset.id,
-  //     name: dataset.name,
-  //     domainValuePairs: dataset.domainValuePairs,
-  //   };
-  //   datasetApiStub.codePreview = {
-  //     html: '<div id="notebook">print("hello world!")</div>',
-  //   };
-  //   testProps.dataset.prePackagedConceptSet = [
-  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
-  //   ];
-  //   const { container } = render(component(testProps));
-  //   const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
-  //
-  //   container.querySelector('[data-test-id="code-preview-button"]').simulate('click');
-  //   expect(previewSpy).toHaveBeenCalledWith(
-  //     workspace.namespace,
-  //     workspace.id,
-  //     expect.objectContaining({
-  //       dataSetRequest: expectedDatasetRequest,
-  //       kernelType: KernelTypeEnum.PYTHON,
-  //       genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
-  //     })
-  //   );
-  //
-  //   container
-  //     .querySelector('[data-test-id="genomics-tool-PLINK"]')
-  //     .first()
-  //     .simulate('click');
-  //   expect(previewSpy).toHaveBeenCalledWith(
-  //     workspace.namespace,
-  //     workspace.id,
-  //     expect.objectContaining({
-  //       dataSetRequest: expectedDatasetRequest,
-  //       kernelType: KernelTypeEnum.PYTHON,
-  //       genomicsAnalysisTool:
-  //         DataSetExportRequestGenomicsAnalysisToolEnum.PLINK,
-  //     })
-  //   );
-  //
-  //   container
-  //     .querySelector('[data-test-id="genomics-tool-NONE"]')
-  //     .first()
-  //     .simulate('click');
-  //   expect(previewSpy).toHaveBeenCalledWith(
-  //     workspace.namespace,
-  //     workspace.id,
-  //     expect.objectContaining({
-  //       dataSetRequest: expectedDatasetRequest,
-  //       kernelType: KernelTypeEnum.PYTHON,
-  //       genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.NONE,
-  //     })
-  //   );
-  // });
+  it('Auto reload code preview if genomics analysis tool is changed', async () => {
+    const expectedDatasetRequest = {
+      dataSetId: dataset.id,
+      name: dataset.name,
+      domainValuePairs: dataset.domainValuePairs,
+    };
+    datasetApiStub.codePreview = {
+      html: '<div id="notebook">print("hello world!")</div>',
+    };
+    testProps.dataset.prePackagedConceptSet = [
+      PrePackagedConceptSetEnum.WHOLE_GENOME,
+    ];
+    const { container, unmount } = render(component(testProps));
+    const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
+
+    const seeCodePreviewButton = findSeeCodePreviewButton();
+    fireEvent.click(seeCodePreviewButton);
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Please Wait')).toBeNull();
+    });
+
+    expect(previewSpy).toHaveBeenCalledWith(
+      workspace.namespace,
+      workspace.id,
+      expect.objectContaining({
+        dataSetRequest: expectedDatasetRequest,
+        kernelType: KernelTypeEnum.PYTHON,
+        genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
+      })
+    );
+
+    const plinkjRadioButtonLabel = screen.getByRole('radio', {
+      name: 'PLINK',
+    });
+    fireEvent.click(plinkjRadioButtonLabel);
+
+    expect(previewSpy).toHaveBeenCalledWith(
+      workspace.namespace,
+      workspace.id,
+      expect.objectContaining({
+        dataSetRequest: expectedDatasetRequest,
+        kernelType: KernelTypeEnum.PYTHON,
+        genomicsAnalysisTool:
+          DataSetExportRequestGenomicsAnalysisToolEnum.PLINK,
+      })
+    );
+
+    const otherjRadioButtonLabel = screen.getByRole('radio', {
+      name: 'Other VCF-compatible tool',
+    });
+    fireEvent.click(otherjRadioButtonLabel);
+    expect(previewSpy).toHaveBeenCalledWith(
+      workspace.namespace,
+      workspace.id,
+      expect.objectContaining({
+        dataSetRequest: expectedDatasetRequest,
+        kernelType: KernelTypeEnum.PYTHON,
+        genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.NONE,
+      })
+    );
+
+    unmount();
+  });
 });

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -11,7 +11,7 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
@@ -74,20 +74,20 @@ describe('ExportDatasetModal', () => {
     await user.type(findNotebookNameInput(), newNotebookName);
   };
 
-  const clickExportButton = () => {
-    fireEvent.click(findExportButton());
+  const clickExportButton = async () => {
+    await user.click(findExportButton());
   };
 
-  const clickSeeCodePreviewButton = () => {
-    fireEvent.click(findSeeCodePreviewButton());
+  const clickSeeCodePreviewButton = async () => {
+    await user.click(findSeeCodePreviewButton());
   };
 
-  const clickHideCodePreviewButton = () => {
-    fireEvent.click(findHideCodePreviewButton());
+  const clickHideCodePreviewButton = async () => {
+    await user.click(findHideCodePreviewButton());
   };
 
-  const hoverOverExportButton = () => {
-    fireEvent.mouseEnter(findExportButton());
+  const hoverOverExportButton = async () => {
+    await user.pointer([{ pointerName: 'mouse', target: findExportButton() }]);
   };
 
   beforeEach(() => {
@@ -137,7 +137,7 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     await changeNotebookName(notebookName);
-    clickExportButton();
+    await clickExportButton();
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -165,7 +165,7 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     await changeNotebookName(notebookName);
-    clickExportButton();
+    await clickExportButton();
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
@@ -185,11 +185,11 @@ describe('ExportDatasetModal', () => {
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     changeNotebookName('');
-    clickExportButton();
+    await clickExportButton();
 
     expect(exportSpy).not.toHaveBeenCalled();
 
-    hoverOverExportButton();
+    await hoverOverExportButton();
 
     await screen.findByText("Notebook name can't be blank");
   });
@@ -207,11 +207,11 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     await changeNotebookName(existingNotebookName);
-    clickExportButton();
+    await clickExportButton();
 
     expect(exportSpy).not.toHaveBeenCalled();
 
-    hoverOverExportButton();
+    await hoverOverExportButton();
 
     await screen.findByText('Notebook name already exists');
   });
@@ -227,12 +227,12 @@ describe('ExportDatasetModal', () => {
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
-    changeNotebookName(existingNotebookName);
+    await changeNotebookName(existingNotebookName);
 
-    clickExportButton();
+    await clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();
 
-    hoverOverExportButton();
+    await hoverOverExportButton();
     await screen.findByText('Notebook name already exists');
   });
 
@@ -260,16 +260,16 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     const notebookDropdown = screen.getByText(/\(create a new notebook\)/i);
-    fireEvent.mouseDown(notebookDropdown);
+    await user.click(notebookDropdown);
 
     const existingNotebookOption = screen.getByText(notebookName);
-    fireEvent.click(existingNotebookOption);
+    await user.click(existingNotebookOption);
 
     await waitFor(() => {
       expect(screen.queryByLabelText('Notebook Name')).toBeNull();
     });
 
-    clickExportButton();
+    await clickExportButton();
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
@@ -298,7 +298,7 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
 
     await waitUntilDoneLoading();
 
@@ -323,7 +323,7 @@ describe('ExportDatasetModal', () => {
       name: 'R',
     });
 
-    fireEvent.click(rRadioButton);
+    await user.click(rRadioButton);
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
@@ -337,7 +337,7 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     const hideCodePreviewButton = findHideCodePreviewButton();
-    fireEvent.click(hideCodePreviewButton);
+    await user.click(hideCodePreviewButton);
 
     await waitFor(() => {
       iframe = screen.queryByTestId('export-preview-frame');
@@ -374,7 +374,7 @@ describe('ExportDatasetModal', () => {
       name: 'R',
     });
 
-    fireEvent.click(rRadioButton);
+    await user.click(rRadioButton);
 
     const hailRadio = screen.queryByRole('radio', {
       name: 'Hail',
@@ -429,7 +429,7 @@ describe('ExportDatasetModal', () => {
     await waitUntilDoneLoading();
 
     await changeNotebookName(notebookName);
-    clickExportButton();
+    await clickExportButton();
 
     expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
       dataSetRequest: expectedDatasetRequest,
@@ -458,7 +458,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
 
     await waitUntilDoneLoading();
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
     await waitUntilDoneLoading();
 
     expect(previewSpy).toHaveBeenCalledWith(
@@ -471,10 +471,10 @@ describe('ExportDatasetModal', () => {
       })
     );
 
-    const plinkjRadioButtonLabel = screen.getByRole('radio', {
+    const plinkRadioButton = screen.getByRole('radio', {
       name: 'PLINK',
     });
-    fireEvent.click(plinkjRadioButtonLabel);
+    await user.click(plinkRadioButton);
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
@@ -489,10 +489,10 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    const otherjRadioButtonLabel = screen.getByRole('radio', {
+    const otherRadioButton = screen.getByRole('radio', {
       name: 'Other VCF-compatible tool',
     });
-    fireEvent.click(otherjRadioButtonLabel);
+    await user.click(otherRadioButton);
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -533,7 +533,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
     await waitUntilDoneLoading();
 
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
 
     await waitUntilDoneLoading();
     await user.click(screen.getByLabelText('Dataset query copy icon button'));
@@ -574,11 +574,11 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
 
     expect(previewSpy).not.toHaveBeenCalled();
 
-    clickExportButton();
+    await clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();
 
     await user.click(findCopyCodeButton());
@@ -595,7 +595,7 @@ describe('ExportDatasetModal', () => {
 
     component(testProps);
     await waitUntilDoneLoading();
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
 
     await changeNotebookName('New Notebook Name');
     expect(screen.queryByDisplayValue('New Notebook Name')).toBeNull();
@@ -613,12 +613,12 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickHideCodePreviewButton();
+    await clickHideCodePreviewButton();
     // When clicking hide, it should immediately disappear,
     // so if it is still here, then it was disabled.
     expect(findHideCodePreviewButton()).toBeInTheDocument();
 
-    clickExportButton();
+    await clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();
 
     await user.click(findCopyCodeButton());
@@ -638,7 +638,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
     await waitUntilDoneLoading();
     await changeNotebookName('Notebook Name');
-    clickExportButton();
+    await clickExportButton();
 
     await changeNotebookName('New Notebook Name');
     expect(screen.queryByDisplayValue('New Notebook Name')).toBeNull();
@@ -656,10 +656,10 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
     expect(previewSpy).toHaveBeenCalledTimes(0);
 
-    clickExportButton();
+    await clickExportButton();
     // Should only be called the initial time and not allow a
     // subsequent click.
     expect(exportSpy).toHaveBeenCalledTimes(1);
@@ -697,11 +697,11 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickSeeCodePreviewButton();
+    await clickSeeCodePreviewButton();
     // Should only be called on the initial click
     expect(previewSpy).toHaveBeenCalledTimes(1);
 
-    clickExportButton();
+    await clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();
 
     // The button's text becomes a spinner while loading, so you

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -11,8 +11,7 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
-import { renderModal } from '../../../../testing/react-test-helpers';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
@@ -21,6 +20,7 @@ import {
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
 
+import { renderModal } from 'testing/react-test-helpers';
 import { DataSetApiStub } from 'testing/stubs/data-set-api-stub';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
@@ -657,9 +657,7 @@ describe('ExportDatasetModal', () => {
     expect(plinkRadioButton).not.toBeChecked();
 
     clickShowCodePreviewButton();
-    // When clicking see, it should immediately disappear,
-    // so if it is still here, then it was disabled.
-    expect(findSeeCodePreviewButton()).toBeInTheDocument();
+    expect(previewSpy).toHaveBeenCalledTimes(0);
 
     clickExportButton();
     // Should only be called the initial time and not allow a
@@ -700,9 +698,8 @@ describe('ExportDatasetModal', () => {
     expect(plinkRadioButton).not.toBeChecked();
 
     clickShowCodePreviewButton();
-    // When clicking see, it should immediately disappear,
-    // so if it is still here, then it was disabled.
-    expect(findSeeCodePreviewButton()).toBeInTheDocument();
+    // Should only be called on the initial click
+    expect(previewSpy).toHaveBeenCalledTimes(1);
 
     clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -12,7 +12,6 @@ import {
 } from 'generated/fetch';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import {

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -244,44 +244,58 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('should export to an existing notebook with the correct kernel type', async () => {
-  //   const notebookName = 'existing notebook';
-  //   const datasetName = 'dataset';
-  //   const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
-  //   dataset.name = datasetName;
-  //   notebooksApiStub.notebookList = [
-  //     {
-  //       name: expectedNotebookName,
-  //     },
-  //   ];
-  //   notebooksApiStub.notebookKernel = KernelTypeEnum.R;
-  //
-  //   const expectedDatasetRequest = {
-  //     dataSetId: dataset.id,
-  //     name: datasetName,
-  //     domainValuePairs: dataset.domainValuePairs,
-  //   };
-  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-  //
-  //   const { container } = render(component(testProps));
-  //   act(() => {
-  //     container.querySelector(Select).props().onChange(notebookName);
-  //   });
-  //
-  //   findExportButton(container).simulate('click');
-  //
-  //   expect(exportSpy).toHaveBeenCalledWith(
-  //     workspace.namespace,
-  //     workspace.id,
-  //     expect.objectContaining({
-  //       dataSetRequest: expectedDatasetRequest,
-  //       newNotebook: false,
-  //       notebookName: expectedNotebookName,
-  //       kernelType: KernelTypeEnum.R,
-  //     })
-  //   );
-  // });
-  //
+  it('should export to an existing notebook with the correct kernel type', async () => {
+    const notebookName = 'existing notebook';
+    const datasetName = 'dataset';
+    const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
+    dataset.name = datasetName;
+    notebooksApiStub.notebookList = [
+      {
+        name: expectedNotebookName,
+      },
+    ];
+    notebooksApiStub.notebookKernel = KernelTypeEnum.R;
+
+    const expectedDatasetRequest = {
+      dataSetId: dataset.id,
+      name: datasetName,
+      domainValuePairs: dataset.domainValuePairs,
+    };
+    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+
+    const { container, unmount } = render(component(testProps));
+
+    await waitUntilDoneLoading();
+
+    const notebookDropdown = screen.getByText(/\(create a new notebook\)/i);
+    fireEvent.mouseDown(notebookDropdown);
+
+    screen.logTestingPlaygroundURL();
+
+    const existingNotebookOption = screen.getByText(notebookName);
+    fireEvent.click(existingNotebookOption);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Notebook Name')).toBeNull();
+    });
+
+    const exportButton = findExportButton();
+    fireEvent.click(exportButton);
+
+    expect(exportSpy).toHaveBeenCalledWith(
+      workspace.namespace,
+      workspace.id,
+      expect.objectContaining({
+        dataSetRequest: expectedDatasetRequest,
+        newNotebook: false,
+        notebookName: expectedNotebookName,
+        kernelType: KernelTypeEnum.R,
+      })
+    );
+
+    unmount();
+  });
+
   // it('should show code preview, auto reload on kernel switch, and hide code preview', async () => {
   //   const expectedDatasetRequest = {
   //     dataSetId: dataset.id,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -11,7 +11,9 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
+import { renderModal } from '../../../../testing/react-test-helpers';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import {
@@ -29,15 +31,20 @@ describe('ExportDatasetModal', () => {
   let testProps;
   let notebooksApiStub;
   let datasetApiStub;
-  let unmount;
 
   const component = (props) => {
-    return <ExportDatasetModal {...props} />;
+    return renderModal(<ExportDatasetModal {...props} />);
   };
 
   function findExportButton() {
     return screen.getByRole('button', {
       name: /export/i,
+    });
+  }
+
+  function findCopyCodeButton() {
+    return screen.getByRole('button', {
+      name: /copy code/i,
     });
   }
 
@@ -99,23 +106,16 @@ describe('ExportDatasetModal', () => {
   });
 
   afterEach(() => {
-    // React-modal makes changes to the ownerDocument where
-    // a modal is found when the modal is closed. Since we are using
-    // React Testing Library(RTL), components are generally tested in
-    // isolation, so we have little concept of an owning document.
-    // By using RTL's umount method, we are able to cleanup our
-    // modal before its cleanup functionality is called.
-    unmount();
     jest.resetAllMocks();
   });
 
   it('should render', async () => {
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     await screen.findByText('Export Dataset');
   });
 
   it('should export to a new notebook', async () => {
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -143,7 +143,7 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should export to a new notebook if the user types in the file suffix', async () => {
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'MyNotebook.ipynb';
     const expectedNotebookName = notebookName;
@@ -172,7 +172,7 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should disable export if no name is provided', async () => {
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     changeNotebookName('');
@@ -192,7 +192,7 @@ describe('ExportDatasetModal', () => {
         name: existingNotebookName,
       },
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
@@ -214,7 +214,7 @@ describe('ExportDatasetModal', () => {
         name: existingNotebookName,
       },
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
@@ -246,7 +246,7 @@ describe('ExportDatasetModal', () => {
     };
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
 
     await waitUntilDoneLoading();
 
@@ -284,7 +284,7 @@ describe('ExportDatasetModal', () => {
     datasetApiStub.codePreview = {
       html: '<div id="notebook">print("hello world!")</div>',
     };
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
     await waitUntilDoneLoading();
@@ -341,7 +341,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
 
     await screen.findByRole('radio', {
       name: 'Hail',
@@ -360,7 +360,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
 
     const rRadioButtonLabel = screen.getByRole('radio', {
       name: 'R',
@@ -386,7 +386,7 @@ describe('ExportDatasetModal', () => {
 
   it('Remove genomics analysis tools if no WGS', async () => {
     testProps.dataset.prePackagedConceptSet = [];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
 
     const hailRadio = screen.queryByRole('radio', {
       name: 'Hail',
@@ -408,7 +408,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -445,7 +445,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    ({ unmount } = render(component(testProps)));
+    component(testProps);
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
     const seeCodePreviewButton = findSeeCodePreviewButton();

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -78,7 +78,7 @@ describe('ExportDatasetModal', () => {
     fireEvent.click(findExportButton());
   };
 
-  const clickShowCodePreviewButton = () => {
+  const clickSeeCodePreviewButton = () => {
     fireEvent.click(findSeeCodePreviewButton());
   };
 
@@ -298,7 +298,7 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
 
     await waitUntilDoneLoading();
 
@@ -458,7 +458,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
 
     await waitUntilDoneLoading();
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
     await waitUntilDoneLoading();
 
     expect(previewSpy).toHaveBeenCalledWith(
@@ -533,7 +533,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
     await waitUntilDoneLoading();
 
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
 
     await waitUntilDoneLoading();
     await user.click(screen.getByLabelText('Dataset query copy icon button'));
@@ -574,7 +574,7 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
 
     expect(previewSpy).not.toHaveBeenCalled();
 
@@ -595,7 +595,7 @@ describe('ExportDatasetModal', () => {
 
     component(testProps);
     await waitUntilDoneLoading();
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
 
     await changeNotebookName('New Notebook Name');
     expect(screen.queryByDisplayValue('New Notebook Name')).toBeNull();
@@ -656,7 +656,7 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
     expect(previewSpy).toHaveBeenCalledTimes(0);
 
     clickExportButton();
@@ -697,7 +697,7 @@ describe('ExportDatasetModal', () => {
     await user.click(plinkRadioButton);
     expect(plinkRadioButton).not.toBeChecked();
 
-    clickShowCodePreviewButton();
+    clickSeeCodePreviewButton();
     // Should only be called on the initial click
     expect(previewSpy).toHaveBeenCalledTimes(1);
 

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -1,6 +1,7 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { mount } from 'enzyme';
 
 import {
   DataSetApi,
@@ -11,6 +12,14 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Select } from 'app/components/inputs';
 import { Tooltip } from 'app/components/popups';
 import {
@@ -23,7 +32,6 @@ import {
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
 
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { DataSetApiStub } from 'testing/stubs/data-set-api-stub';
 import { NotebooksApiStub } from 'testing/stubs/notebooks-api-stub';
 import { workspaceDataStub } from 'testing/stubs/workspaces';
@@ -34,16 +42,28 @@ describe('ExportDatasetModal', () => {
   let testProps;
   let notebooksApiStub;
   let datasetApiStub;
+  let modalRoot;
 
   const component = (props) => {
     return <ExportDatasetModal {...props} />;
   };
 
-  function findExportButton(wrapper) {
-    return wrapper.find('[data-test-id="export-data-set"]').first();
+  function findExportButton() {
+    return screen.getByRole('button', {
+      name: /export/i,
+    });
+  }
+
+  function findNotebookNameInput() {
+    return screen.getByLabelText('Notebook Name');
   }
 
   beforeEach(() => {
+    // // Setup a DOM element as a render target
+    // modalRoot = document.createElement('div');
+    // modalRoot.setAttribute('id', 'popup-root');
+    // document.body.appendChild(modalRoot);
+
     window.open = jest.fn();
     dataset = {
       id: 1,
@@ -66,16 +86,25 @@ describe('ExportDatasetModal', () => {
   });
 
   afterEach(() => {
+    // console.log('A');
     jest.clearAllMocks();
   });
 
-  it('should render', () => {
-    const wrapper = mount(component(testProps));
-    expect(wrapper.exists()).toBeTruthy();
+  it('should render', async () => {
+    const popupRoot = document.createElement('div');
+    popupRoot.setAttribute('id', 'popup-root');
+    const user = userEvent.setup();
+    const { container, unmount } = render(component(testProps));
+    await screen.findByText('Export Dataset');
+    unmount();
   });
 
   it('should export to a new notebook', async () => {
-    const wrapper = mount(component(testProps));
+    const popupRoot = document.createElement('div');
+    popupRoot.setAttribute('id', 'popup-root');
+    document.body.appendChild(popupRoot);
+    const { container, unmount } = render(component(testProps));
+    const notebookNameInput = findNotebookNameInput();
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -85,11 +114,8 @@ describe('ExportDatasetModal', () => {
       domainValuePairs: dataset.domainValuePairs,
     };
 
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', { target: { value: notebookName } });
-    findExportButton(wrapper).simulate('click');
+    fireEvent.change(notebookNameInput, { target: { value: notebookName } });
+    fireEvent.click(findExportButton());
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -101,10 +127,13 @@ describe('ExportDatasetModal', () => {
         generateGenomicsAnalysisCode: false,
       })
     );
+    unmount();
   });
 
   it('should export to a new notebook if the user types in the file suffix', async () => {
-    const wrapper = mount(component(testProps));
+    const popupRoot = document.createElement('div');
+    popupRoot.setAttribute('id', 'popup-root');
+    const { container, unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'MyNotebook.ipynb';
     const expectedNotebookName = notebookName;
@@ -114,11 +143,11 @@ describe('ExportDatasetModal', () => {
       domainValuePairs: dataset.domainValuePairs,
     };
 
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', { target: { value: notebookName } });
-    findExportButton(wrapper).simulate('click');
+    const x = findNotebookNameInput();
+    fireEvent.change(x, {
+      target: { value: notebookName },
+    });
+    fireEvent.click(findExportButton());
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -130,287 +159,278 @@ describe('ExportDatasetModal', () => {
         generateGenomicsAnalysisCode: false,
       })
     );
+    unmount();
   });
 
-  it('should disable export if no name is provided', async () => {
-    const wrapper = mount(component(testProps));
-    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', { target: { value: '' } });
-    findExportButton(wrapper).simulate('click');
-    expect(findExportButton(wrapper).props().disabled).toBeTruthy();
-    expect(exportSpy).not.toHaveBeenCalled();
-
-    findExportButton(wrapper).simulate('mouseenter');
-    expect(wrapper.find(Tooltip).text()).toBe("Notebook name can't be blank");
-  });
-
-  it('should disable export if a conflicting name is provided, without the suffix', async () => {
-    const existingNotebookName = 'existing notebook.ipynb';
-    notebooksApiStub.notebookList = [
-      {
-        name: existingNotebookName,
-      },
-    ];
-    const wrapper = mount(component(testProps));
-    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', {
-        target: { value: dropJupyterNotebookFileSuffix(existingNotebookName) },
-      });
-    await waitOneTickAndUpdate(wrapper);
-    findExportButton(wrapper).simulate('click');
-    expect(findExportButton(wrapper).props().disabled).toBeTruthy();
-
-    findExportButton(wrapper).simulate('mouseenter');
-    expect(wrapper.find(Tooltip).text()).toBe('Notebook name already exists');
-    expect(exportSpy).not.toHaveBeenCalled();
-  });
-
-  it('should disable export if a conflicting name is provided, including the suffix', async () => {
-    const existingNotebookName = 'existing notebook.ipynb';
-    notebooksApiStub.notebookList = [
-      {
-        name: existingNotebookName,
-      },
-    ];
-    const wrapper = mount(component(testProps));
-    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', {
-        target: {
-          value: appendJupyterNotebookFileSuffix(existingNotebookName),
-        },
-      });
-    await waitOneTickAndUpdate(wrapper);
-    findExportButton(wrapper).simulate('click');
-    expect(findExportButton(wrapper).props().disabled).toBeTruthy();
-
-    findExportButton(wrapper).simulate('mouseenter');
-    expect(wrapper.find(Tooltip).text()).toBe('Notebook name already exists');
-    expect(exportSpy).not.toHaveBeenCalled();
-  });
-
-  it('should export to an existing notebook with the correct kernel type', async () => {
-    const notebookName = 'existing notebook';
-    const datasetName = 'dataset';
-    const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
-    dataset.name = datasetName;
-    notebooksApiStub.notebookList = [
-      {
-        name: expectedNotebookName,
-      },
-    ];
-    notebooksApiStub.notebookKernel = KernelTypeEnum.R;
-
-    const expectedDatasetRequest = {
-      dataSetId: dataset.id,
-      name: datasetName,
-      domainValuePairs: dataset.domainValuePairs,
-    };
-    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-
-    const wrapper = mount(component(testProps));
-    act(() => {
-      wrapper.find(Select).props().onChange(notebookName);
-    });
-    await waitOneTickAndUpdate(wrapper);
-
-    findExportButton(wrapper).simulate('click');
-
-    expect(exportSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        newNotebook: false,
-        notebookName: expectedNotebookName,
-        kernelType: KernelTypeEnum.R,
-      })
-    );
-  });
-
-  it('should show code preview, auto reload on kernel switch, and hide code preview', async () => {
-    const expectedDatasetRequest = {
-      dataSetId: dataset.id,
-      name: dataset.name,
-      domainValuePairs: dataset.domainValuePairs,
-    };
-    datasetApiStub.codePreview = {
-      html: '<div id="notebook">print("hello world!")</div>',
-    };
-    const wrapper = mount(component(testProps));
-    const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
-
-    wrapper.find('[data-test-id="code-preview-button"]').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    expect(previewSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        kernelType: KernelTypeEnum.PYTHON,
-      })
-    );
-    expect(wrapper.find('iframe').html()).toContain('hello world!');
-
-    wrapper.find('[data-test-id="kernel-type-r"]').first().simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(previewSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        kernelType: KernelTypeEnum.R,
-      })
-    );
-
-    wrapper.find('[data-test-id="code-preview-button"]').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('iframe').exists()).toBeFalsy();
-  });
-
-  it('Show genomics analysis tools if WGS is in the dataset', async () => {
-    testProps.dataset.prePackagedConceptSet = [
-      PrePackagedConceptSetEnum.WHOLE_GENOME,
-    ];
-    const wrapper = mount(component(testProps));
-
-    Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-      (tool) => {
-        expect(
-          wrapper.find(`[data-test-id="genomics-tool-${tool}"]`).exists()
-        ).toBeTruthy();
-      }
-    );
-  });
-
-  it('Remove genomics analysis tools if R is selected', async () => {
-    testProps.dataset.prePackagedConceptSet = [
-      PrePackagedConceptSetEnum.WHOLE_GENOME,
-    ];
-    const wrapper = mount(component(testProps));
-
-    wrapper.find('[data-test-id="kernel-type-r"]').first().simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-
-    Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-      (tool) => {
-        expect(
-          wrapper.find(`[data-test-id="genomics-tool-${tool}"]`).exists()
-        ).toBeFalsy();
-      }
-    );
-  });
-
-  it('Remove genomics analysis tools if no WGS', async () => {
-    testProps.dataset.prePackagedConceptSet = [];
-    const wrapper = mount(component(testProps));
-
-    Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-      (tool) => {
-        expect(
-          wrapper.find(`[data-test-id="genomics-tool-${tool}"]`).exists()
-        ).toBeFalsy();
-      }
-    );
-  });
-
-  it('Should export code with genomics analysis tool', async () => {
-    testProps.dataset.prePackagedConceptSet = [
-      PrePackagedConceptSetEnum.WHOLE_GENOME,
-    ];
-    const wrapper = mount(component(testProps));
-    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-    const notebookName = 'Notebook Name';
-    const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
-    const expectedDatasetRequest: DataSetRequest = {
-      dataSetId: dataset.id,
-      name: dataset.name,
-      domainValuePairs: dataset.domainValuePairs,
-    };
-
-    wrapper
-      .find('[data-test-id="notebook-name-input"]')
-      .first()
-      .simulate('change', { target: { value: notebookName } });
-    findExportButton(wrapper).simulate('click');
-    expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
-      dataSetRequest: expectedDatasetRequest,
-      newNotebook: true,
-      notebookName: expectedNotebookName,
-      kernelType: KernelTypeEnum.PYTHON,
-      generateGenomicsAnalysisCode: true,
-      genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
-    });
-  });
-
-  it('Auto reload code preview if genomics analysis tool is changed', async () => {
-    const expectedDatasetRequest = {
-      dataSetId: dataset.id,
-      name: dataset.name,
-      domainValuePairs: dataset.domainValuePairs,
-    };
-    datasetApiStub.codePreview = {
-      html: '<div id="notebook">print("hello world!")</div>',
-    };
-    testProps.dataset.prePackagedConceptSet = [
-      PrePackagedConceptSetEnum.WHOLE_GENOME,
-    ];
-    const wrapper = mount(component(testProps));
-    const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
-
-    wrapper.find('[data-test-id="code-preview-button"]').simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(previewSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        kernelType: KernelTypeEnum.PYTHON,
-        genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
-      })
-    );
-
-    wrapper
-      .find('[data-test-id="genomics-tool-PLINK"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(previewSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        kernelType: KernelTypeEnum.PYTHON,
-        genomicsAnalysisTool:
-          DataSetExportRequestGenomicsAnalysisToolEnum.PLINK,
-      })
-    );
-
-    wrapper
-      .find('[data-test-id="genomics-tool-NONE"]')
-      .first()
-      .simulate('click');
-    await waitOneTickAndUpdate(wrapper);
-    expect(previewSpy).toHaveBeenCalledWith(
-      workspace.namespace,
-      workspace.id,
-      expect.objectContaining({
-        dataSetRequest: expectedDatasetRequest,
-        kernelType: KernelTypeEnum.PYTHON,
-        genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.NONE,
-      })
-    );
-  });
+  // it('should disable export if no name is provided', async () => {
+  //   const { container } = render(component(testProps));
+  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+  //
+  //   container
+  //     .querySelector('[data-test-id="notebook-name-input"]')
+  //     .first()
+  //     .simulate('change', { target: { value: '' } });
+  //   findExportButton(container).simulate('click');
+  //   expect(findExportButton(container).props().disabled).toBeTruthy();
+  //   expect(exportSpy).not.toHaveBeenCalled();
+  //
+  //   findExportButton(container).simulate('mouseenter');
+  //   expect(container.querySelector(Tooltip).text()).toBe("Notebook name can't be blank");
+  // });
+  //
+  // it('should disable export if a conflicting name is provided, without the suffix', async () => {
+  //   const existingNotebookName = 'existing notebook.ipynb';
+  //   notebooksApiStub.notebookList = [
+  //     {
+  //       name: existingNotebookName,
+  //     },
+  //   ];
+  //   const { container } = render(component(testProps));
+  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+  //
+  //   container
+  //     .querySelector('[data-test-id="notebook-name-input"]')
+  //     .first()
+  //     .simulate('change', {
+  //       target: { value: dropJupyterNotebookFileSuffix(existingNotebookName) },
+  //     });
+  //   findExportButton(container).simulate('click');
+  //   expect(findExportButton(container).props().disabled).toBeTruthy();
+  //
+  //   findExportButton(container).simulate('mouseenter');
+  //   expect(container.querySelector(Tooltip).text()).toBe('Notebook name already exists');
+  //   expect(exportSpy).not.toHaveBeenCalled();
+  // });
+  //
+  // it('should disable export if a conflicting name is provided, including the suffix', async () => {
+  //   const existingNotebookName = 'existing notebook.ipynb';
+  //   notebooksApiStub.notebookList = [
+  //     {
+  //       name: existingNotebookName,
+  //     },
+  //   ];
+  //   const { container } = render(component(testProps));
+  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+  //
+  //   container
+  //     .querySelector('[data-test-id="notebook-name-input"]')
+  //     .first()
+  //     .simulate('change', {
+  //       target: {
+  //         value: appendJupyterNotebookFileSuffix(existingNotebookName),
+  //       },
+  //     });
+  //   findExportButton(container).simulate('click');
+  //   expect(findExportButton(container).props().disabled).toBeTruthy();
+  //
+  //   findExportButton(container).simulate('mouseenter');
+  //   expect(container.querySelector(Tooltip).text()).toBe('Notebook name already exists');
+  //   expect(exportSpy).not.toHaveBeenCalled();
+  // });
+  //
+  // it('should export to an existing notebook with the correct kernel type', async () => {
+  //   const notebookName = 'existing notebook';
+  //   const datasetName = 'dataset';
+  //   const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
+  //   dataset.name = datasetName;
+  //   notebooksApiStub.notebookList = [
+  //     {
+  //       name: expectedNotebookName,
+  //     },
+  //   ];
+  //   notebooksApiStub.notebookKernel = KernelTypeEnum.R;
+  //
+  //   const expectedDatasetRequest = {
+  //     dataSetId: dataset.id,
+  //     name: datasetName,
+  //     domainValuePairs: dataset.domainValuePairs,
+  //   };
+  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+  //
+  //   const { container } = render(component(testProps));
+  //   act(() => {
+  //     container.querySelector(Select).props().onChange(notebookName);
+  //   });
+  //
+  //   findExportButton(container).simulate('click');
+  //
+  //   expect(exportSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       newNotebook: false,
+  //       notebookName: expectedNotebookName,
+  //       kernelType: KernelTypeEnum.R,
+  //     })
+  //   );
+  // });
+  //
+  // it('should show code preview, auto reload on kernel switch, and hide code preview', async () => {
+  //   const expectedDatasetRequest = {
+  //     dataSetId: dataset.id,
+  //     name: dataset.name,
+  //     domainValuePairs: dataset.domainValuePairs,
+  //   };
+  //   datasetApiStub.codePreview = {
+  //     html: '<div id="notebook">print("hello world!")</div>',
+  //   };
+  //   const { container } = render(component(testProps));
+  //   const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
+  //
+  //   container.querySelector('[data-test-id="code-preview-button"]').simulate('click');
+  //
+  //   expect(previewSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       kernelType: KernelTypeEnum.PYTHON,
+  //     })
+  //   );
+  //   expect(container.querySelector('iframe').html()).toContain('hello world!');
+  //
+  //   container.querySelector('[data-test-id="kernel-type-r"]').first().simulate('click');
+  //   expect(previewSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       kernelType: KernelTypeEnum.R,
+  //     })
+  //   );
+  //
+  //   container.querySelector('[data-test-id="code-preview-button"]').simulate('click');
+  //   expect(container.querySelector('iframe').exists()).toBeFalsy();
+  // });
+  //
+  // it('Show genomics analysis tools if WGS is in the dataset', async () => {
+  //   testProps.dataset.prePackagedConceptSet = [
+  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
+  //   ];
+  //   const { container } = render(component(testProps));
+  //
+  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
+  //     (tool) => {
+  //       expect(
+  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
+  //       ).toBeTruthy();
+  //     }
+  //   );
+  // });
+  //
+  // it('Remove genomics analysis tools if R is selected', async () => {
+  //   testProps.dataset.prePackagedConceptSet = [
+  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
+  //   ];
+  //   const { container } = render(component(testProps));
+  //
+  //   container.querySelector('[data-test-id="kernel-type-r"]').first().simulate('click');
+  //
+  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
+  //     (tool) => {
+  //       expect(
+  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
+  //       ).toBeFalsy();
+  //     }
+  //   );
+  // });
+  //
+  // it('Remove genomics analysis tools if no WGS', async () => {
+  //   testProps.dataset.prePackagedConceptSet = [];
+  //   const { container } = render(component(testProps));
+  //
+  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
+  //     (tool) => {
+  //       expect(
+  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
+  //       ).toBeFalsy();
+  //     }
+  //   );
+  // });
+  //
+  // it('Should export code with genomics analysis tool', async () => {
+  //   testProps.dataset.prePackagedConceptSet = [
+  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
+  //   ];
+  //   const { container } = render(component(testProps));
+  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+  //   const notebookName = 'Notebook Name';
+  //   const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
+  //   const expectedDatasetRequest: DataSetRequest = {
+  //     dataSetId: dataset.id,
+  //     name: dataset.name,
+  //     domainValuePairs: dataset.domainValuePairs,
+  //   };
+  //
+  //   container
+  //     .querySelector('[data-test-id="notebook-name-input"]')
+  //     .first()
+  //     .simulate('change', { target: { value: notebookName } });
+  //   findExportButton(container).simulate('click');
+  //   expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
+  //     dataSetRequest: expectedDatasetRequest,
+  //     newNotebook: true,
+  //     notebookName: expectedNotebookName,
+  //     kernelType: KernelTypeEnum.PYTHON,
+  //     generateGenomicsAnalysisCode: true,
+  //     genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
+  //   });
+  // });
+  //
+  // it('Auto reload code preview if genomics analysis tool is changed', async () => {
+  //   const expectedDatasetRequest = {
+  //     dataSetId: dataset.id,
+  //     name: dataset.name,
+  //     domainValuePairs: dataset.domainValuePairs,
+  //   };
+  //   datasetApiStub.codePreview = {
+  //     html: '<div id="notebook">print("hello world!")</div>',
+  //   };
+  //   testProps.dataset.prePackagedConceptSet = [
+  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
+  //   ];
+  //   const { container } = render(component(testProps));
+  //   const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
+  //
+  //   container.querySelector('[data-test-id="code-preview-button"]').simulate('click');
+  //   expect(previewSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       kernelType: KernelTypeEnum.PYTHON,
+  //       genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
+  //     })
+  //   );
+  //
+  //   container
+  //     .querySelector('[data-test-id="genomics-tool-PLINK"]')
+  //     .first()
+  //     .simulate('click');
+  //   expect(previewSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       kernelType: KernelTypeEnum.PYTHON,
+  //       genomicsAnalysisTool:
+  //         DataSetExportRequestGenomicsAnalysisToolEnum.PLINK,
+  //     })
+  //   );
+  //
+  //   container
+  //     .querySelector('[data-test-id="genomics-tool-NONE"]')
+  //     .first()
+  //     .simulate('click');
+  //   expect(previewSpy).toHaveBeenCalledWith(
+  //     workspace.namespace,
+  //     workspace.id,
+  //     expect.objectContaining({
+  //       dataSetRequest: expectedDatasetRequest,
+  //       kernelType: KernelTypeEnum.PYTHON,
+  //       genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.NONE,
+  //     })
+  //   );
+  // });
 });

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -378,21 +378,27 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('Show genomics analysis tools if WGS is in the dataset', async () => {
-  //   testProps.dataset.prePackagedConceptSet = [
-  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
-  //   ];
-  //   const { container } = render(component(testProps));
-  //
-  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-  //     (tool) => {
-  //       expect(
-  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
-  //       ).toBeTruthy();
-  //     }
-  //   );
-  // });
-  //
+  it('Show genomics analysis tools if WGS is in the dataset', async () => {
+    testProps.dataset.prePackagedConceptSet = [
+      PrePackagedConceptSetEnum.WHOLE_GENOME,
+    ];
+    const { container, unmount } = render(component(testProps));
+
+    await screen.findByRole('radio', {
+      name: 'Hail',
+    });
+
+    await screen.findByRole('radio', {
+      name: 'PLINK',
+    });
+
+    await screen.findByRole('radio', {
+      name: 'Other VCF-compatible tool',
+    });
+
+    unmount();
+  });
+
   // it('Remove genomics analysis tools if R is selected', async () => {
   //   testProps.dataset.prePackagedConceptSet = [
   //     PrePackagedConceptSetEnum.WHOLE_GENOME,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -77,12 +77,21 @@ describe('ExportDatasetModal', () => {
       expect(screen.queryByLabelText('Please Wait')).toBeNull();
     });
 
-  beforeEach(() => {
-    // // Setup a DOM element as a render target
-    // modalRoot = document.createElement('div');
-    // modalRoot.setAttribute('id', 'popup-root');
-    // document.body.appendChild(modalRoot);
+  const changeNotebookName = (newNotebookName) => {
+    fireEvent.change(findNotebookNameInput(), {
+      target: { value: newNotebookName },
+    });
+  };
 
+  const clickExportButton = () => {
+    fireEvent.click(findExportButton());
+  };
+
+  const hoverOverExportButton = () => {
+    fireEvent.mouseEnter(findExportButton());
+  };
+
+  beforeEach(() => {
     window.open = jest.fn();
     dataset = {
       id: 1,
@@ -105,13 +114,10 @@ describe('ExportDatasetModal', () => {
   });
 
   afterEach(() => {
-    // console.log('A');
     jest.resetAllMocks();
   });
 
   it('should render', async () => {
-    const popupRoot = document.createElement('div');
-    popupRoot.setAttribute('id', 'popup-root');
     const user = userEvent.setup();
     const { container, unmount } = render(component(testProps));
     await screen.findByText('Export Dataset');
@@ -119,11 +125,7 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should export to a new notebook', async () => {
-    const popupRoot = document.createElement('div');
-    popupRoot.setAttribute('id', 'popup-root');
-    document.body.appendChild(popupRoot);
     const { container, unmount } = render(component(testProps));
-    const notebookNameInput = findNotebookNameInput();
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -135,8 +137,8 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    fireEvent.change(notebookNameInput, { target: { value: notebookName } });
-    fireEvent.click(findExportButton());
+    changeNotebookName(notebookName);
+    clickExportButton();
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -152,8 +154,6 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should export to a new notebook if the user types in the file suffix', async () => {
-    const popupRoot = document.createElement('div');
-    popupRoot.setAttribute('id', 'popup-root');
     const { container, unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'MyNotebook.ipynb';
@@ -166,11 +166,9 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    const notebookNameInput = findNotebookNameInput();
-    fireEvent.change(notebookNameInput, {
-      target: { value: notebookName },
-    });
-    fireEvent.click(findExportButton());
+    changeNotebookName(notebookName);
+    clickExportButton();
+
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
       workspace.id,
@@ -189,16 +187,12 @@ describe('ExportDatasetModal', () => {
     const { container, unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
-    const notebookNameInput = findNotebookNameInput();
-    fireEvent.change(notebookNameInput, {
-      target: { value: '' },
-    });
+    changeNotebookName('');
+    clickExportButton();
 
-    const exportButton = findExportButton();
-    fireEvent.click(exportButton);
     expect(exportSpy).not.toHaveBeenCalled();
 
-    fireEvent.mouseEnter(exportButton);
+    hoverOverExportButton();
 
     await screen.findByText("Notebook name can't be blank");
     unmount();
@@ -216,16 +210,12 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    const notebookNameInput = findNotebookNameInput();
-    fireEvent.change(notebookNameInput, {
-      target: { value: dropJupyterNotebookFileSuffix(existingNotebookName) },
-    });
+    changeNotebookName(existingNotebookName);
+    clickExportButton();
 
-    const exportButton = findExportButton();
-    fireEvent.click(exportButton);
     expect(exportSpy).not.toHaveBeenCalled();
 
-    fireEvent.mouseEnter(exportButton);
+    hoverOverExportButton();
 
     await screen.findByText('Notebook name already exists');
     unmount();
@@ -242,17 +232,12 @@ describe('ExportDatasetModal', () => {
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
+    changeNotebookName(existingNotebookName);
 
-    const notebookNameInput = findNotebookNameInput();
-    fireEvent.change(notebookNameInput, {
-      target: { value: appendJupyterNotebookFileSuffix(existingNotebookName) },
-    });
-
-    const exportButton = findExportButton();
-    fireEvent.click(exportButton);
+    clickExportButton();
     expect(exportSpy).not.toHaveBeenCalled();
 
-    fireEvent.mouseEnter(exportButton);
+    hoverOverExportButton();
     await screen.findByText('Notebook name already exists');
 
     unmount();
@@ -291,8 +276,7 @@ describe('ExportDatasetModal', () => {
       expect(screen.queryByLabelText('Notebook Name')).toBeNull();
     });
 
-    const exportButton = findExportButton();
-    fireEvent.click(exportButton);
+    clickExportButton();
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
@@ -326,9 +310,7 @@ describe('ExportDatasetModal', () => {
     const seeCodePreviewButton = findSeeCodePreviewButton();
     fireEvent.click(seeCodePreviewButton);
 
-    await waitFor(() => {
-      expect(screen.queryByLabelText('Please Wait')).toBeNull();
-    });
+    await waitUntilDoneLoading();
 
     let iframe;
     await waitFor(() => {
@@ -364,10 +346,8 @@ describe('ExportDatasetModal', () => {
 
     const hideCodePreviewButton = findHideCodePreviewButton();
 
-    await waitFor(() => {
-      expect(screen.queryByLabelText('Please Wait')).toBeNull();
-    });
-    screen.logTestingPlaygroundURL();
+    await waitUntilDoneLoading();
+
     fireEvent.click(hideCodePreviewButton);
 
     await waitFor(() => {
@@ -467,12 +447,8 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    const notebookNameInput = findNotebookNameInput();
-    fireEvent.change(notebookNameInput, {
-      target: { value: appendJupyterNotebookFileSuffix(notebookName) },
-    });
-    const exportButton = findExportButton();
-    fireEvent.click(exportButton);
+    changeNotebookName(notebookName);
+    clickExportButton();
 
     expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
       dataSetRequest: expectedDatasetRequest,
@@ -502,9 +478,7 @@ describe('ExportDatasetModal', () => {
 
     const seeCodePreviewButton = findSeeCodePreviewButton();
     fireEvent.click(seeCodePreviewButton);
-    await waitFor(() => {
-      expect(screen.queryByLabelText('Please Wait')).toBeNull();
-    });
+    await waitUntilDoneLoading();
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -399,23 +399,36 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('Remove genomics analysis tools if R is selected', async () => {
-  //   testProps.dataset.prePackagedConceptSet = [
-  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
-  //   ];
-  //   const { container } = render(component(testProps));
-  //
-  //   container.querySelector('[data-test-id="kernel-type-r"]').first().simulate('click');
-  //
-  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-  //     (tool) => {
-  //       expect(
-  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
-  //       ).toBeFalsy();
-  //     }
-  //   );
-  // });
-  //
+  it('Remove genomics analysis tools if R is selected', async () => {
+    testProps.dataset.prePackagedConceptSet = [
+      PrePackagedConceptSetEnum.WHOLE_GENOME,
+    ];
+    const { container, unmount } = render(component(testProps));
+
+    const rRadioButtonLabel = screen.getByRole('radio', {
+      name: 'R',
+    });
+
+    fireEvent.click(rRadioButtonLabel);
+
+    const hailRadio = screen.queryByRole('radio', {
+      name: 'Hail',
+    });
+    expect(hailRadio).toBeNull();
+
+    const plinkRadio = screen.queryByRole('radio', {
+      name: 'PLINK',
+    });
+    expect(plinkRadio).toBeNull();
+
+    const otherRadio = screen.queryByRole('radio', {
+      name: 'Other VCF-compatible tool',
+    });
+    expect(otherRadio).toBeNull();
+
+    unmount();
+  });
+
   // it('Remove genomics analysis tools if no WGS', async () => {
   //   testProps.dataset.prePackagedConceptSet = [];
   //   const { container } = render(component(testProps));

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -79,6 +79,10 @@ describe('ExportDatasetModal', () => {
     fireEvent.click(findExportButton());
   };
 
+  const clickShowCodePreviewButton = () => {
+    fireEvent.click(findSeeCodePreviewButton());
+  };
+
   const hoverOverExportButton = () => {
     fireEvent.mouseEnter(findExportButton());
   };
@@ -289,8 +293,7 @@ describe('ExportDatasetModal', () => {
 
     await waitUntilDoneLoading();
 
-    const seeCodePreviewButton = findSeeCodePreviewButton();
-    fireEvent.click(seeCodePreviewButton);
+    clickShowCodePreviewButton();
 
     await waitUntilDoneLoading();
 
@@ -448,8 +451,7 @@ describe('ExportDatasetModal', () => {
     component(testProps);
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
-    const seeCodePreviewButton = findSeeCodePreviewButton();
-    fireEvent.click(seeCodePreviewButton);
+    clickShowCodePreviewButton();
     await waitUntilDoneLoading();
 
     expect(previewSpy).toHaveBeenCalledWith(
@@ -491,5 +493,40 @@ describe('ExportDatasetModal', () => {
         genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.NONE,
       })
     );
+  });
+
+  it('Dataset copied to clipboard when "copy code" button is clicked', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    component(testProps);
+
+    // Act
+    await user.click(findCopyCodeButton());
+
+    // Assert
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe('expected text');
+    // Assert tooltip is shown
+    await screen.findByText('Dataset query copied to clipboard');
+  });
+
+  it('Dataset copied to clipboard when "copy code" icon button is clicked in expanded view', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    component(testProps);
+
+    // Act
+    await waitUntilDoneLoading();
+
+    clickShowCodePreviewButton();
+
+    await waitUntilDoneLoading();
+    await user.click(screen.getByLabelText('Dataset query copy icon button'));
+
+    // Assert
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe('expected text');
+    // Assert tooltip is shown
+    await screen.findByText('Dataset query copied to clipboard');
   });
 });

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -344,10 +344,9 @@ describe('ExportDatasetModal', () => {
       })
     );
 
-    const hideCodePreviewButton = findHideCodePreviewButton();
-
     await waitUntilDoneLoading();
 
+    const hideCodePreviewButton = findHideCodePreviewButton();
     fireEvent.click(hideCodePreviewButton);
 
     await waitFor(() => {

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -429,19 +429,28 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('Remove genomics analysis tools if no WGS', async () => {
-  //   testProps.dataset.prePackagedConceptSet = [];
-  //   const { container } = render(component(testProps));
-  //
-  //   Object.keys(DataSetExportRequestGenomicsAnalysisToolEnum).forEach(
-  //     (tool) => {
-  //       expect(
-  //         container.querySelector(`[data-test-id="genomics-tool-${tool}"]`).exists()
-  //       ).toBeFalsy();
-  //     }
-  //   );
-  // });
-  //
+  it('Remove genomics analysis tools if no WGS', async () => {
+    testProps.dataset.prePackagedConceptSet = [];
+    const { container, unmount } = render(component(testProps));
+
+    const hailRadio = screen.queryByRole('radio', {
+      name: 'Hail',
+    });
+    expect(hailRadio).toBeNull();
+
+    const plinkRadio = screen.queryByRole('radio', {
+      name: 'PLINK',
+    });
+    expect(plinkRadio).toBeNull();
+
+    const otherRadio = screen.queryByRole('radio', {
+      name: 'Other VCF-compatible tool',
+    });
+    expect(otherRadio).toBeNull();
+
+    unmount();
+  });
+
   // it('Should export code with genomics analysis tool', async () => {
   //   testProps.dataset.prePackagedConceptSet = [
   //     PrePackagedConceptSetEnum.WHOLE_GENOME,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -448,9 +448,11 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    component(testProps);
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
+    component(testProps);
+
+    await waitUntilDoneLoading();
     clickShowCodePreviewButton();
     await waitUntilDoneLoading();
 
@@ -480,6 +482,8 @@ describe('ExportDatasetModal', () => {
       })
     );
 
+    await waitUntilDoneLoading();
+
     const otherjRadioButtonLabel = screen.getByRole('radio', {
       name: 'Other VCF-compatible tool',
     });
@@ -498,14 +502,19 @@ describe('ExportDatasetModal', () => {
   it('Dataset copied to clipboard when "copy code" button is clicked', async () => {
     // Arrange
     const user = userEvent.setup();
-    component(testProps);
+    datasetApiStub.codePreview = {
+      text: '<div id="notebook">print("hello world!")</div>',
+    };
 
     // Act
+    component(testProps);
     await user.click(findCopyCodeButton());
 
     // Assert
     const clipboardText = await navigator.clipboard.readText();
-    expect(clipboardText).toBe('expected text');
+    expect(clipboardText).toBe(
+      '<div id="notebook">print("hello world!")</div>'
+    );
     // Assert tooltip is shown
     await screen.findByText('Dataset query copied to clipboard');
   });
@@ -513,9 +522,12 @@ describe('ExportDatasetModal', () => {
   it('Dataset copied to clipboard when "copy code" icon button is clicked in expanded view', async () => {
     // Arrange
     const user = userEvent.setup();
-    component(testProps);
+    datasetApiStub.codePreview = {
+      text: '<div id="notebook">print("hello world!")</div>',
+    };
 
     // Act
+    component(testProps);
     await waitUntilDoneLoading();
 
     clickShowCodePreviewButton();
@@ -525,7 +537,9 @@ describe('ExportDatasetModal', () => {
 
     // Assert
     const clipboardText = await navigator.clipboard.readText();
-    expect(clipboardText).toBe('expected text');
+    expect(clipboardText).toBe(
+      '<div id="notebook">print("hello world!")</div>'
+    );
     // Assert tooltip is shown
     await screen.findByText('Dataset query copied to clipboard');
   });

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -119,13 +119,13 @@ describe('ExportDatasetModal', () => {
 
   it('should render', async () => {
     const user = userEvent.setup();
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     await screen.findByText('Export Dataset');
     unmount();
   });
 
   it('should export to a new notebook', async () => {
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -154,7 +154,7 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should export to a new notebook if the user types in the file suffix', async () => {
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'MyNotebook.ipynb';
     const expectedNotebookName = notebookName;
@@ -184,7 +184,7 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should disable export if no name is provided', async () => {
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     changeNotebookName('');
@@ -205,7 +205,7 @@ describe('ExportDatasetModal', () => {
         name: existingNotebookName,
       },
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
@@ -228,7 +228,7 @@ describe('ExportDatasetModal', () => {
         name: existingNotebookName,
       },
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
     await waitUntilDoneLoading();
@@ -262,7 +262,7 @@ describe('ExportDatasetModal', () => {
     };
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
 
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
 
     await waitUntilDoneLoading();
 
@@ -302,7 +302,7 @@ describe('ExportDatasetModal', () => {
     datasetApiStub.codePreview = {
       html: '<div id="notebook">print("hello world!")</div>',
     };
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
     await waitUntilDoneLoading();
@@ -361,7 +361,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
 
     await screen.findByRole('radio', {
       name: 'Hail',
@@ -382,7 +382,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
 
     const rRadioButtonLabel = screen.getByRole('radio', {
       name: 'R',
@@ -410,7 +410,7 @@ describe('ExportDatasetModal', () => {
 
   it('Remove genomics analysis tools if no WGS', async () => {
     testProps.dataset.prePackagedConceptSet = [];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
 
     const hailRadio = screen.queryByRole('radio', {
       name: 'Hail',
@@ -434,7 +434,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
     const notebookName = 'Notebook Name';
     const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
@@ -472,7 +472,7 @@ describe('ExportDatasetModal', () => {
     testProps.dataset.prePackagedConceptSet = [
       PrePackagedConceptSetEnum.WHOLE_GENOME,
     ];
-    const { container, unmount } = render(component(testProps));
+    const { unmount } = render(component(testProps));
     const previewSpy = jest.spyOn(dataSetApi(), 'previewExportToNotebook');
 
     const seeCodePreviewButton = findSeeCodePreviewButton();

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import {
   DataSetApi,
@@ -12,22 +11,9 @@ import {
   PrePackagedConceptSetEnum,
 } from 'generated/fetch';
 
-import {
-  cleanup,
-  fireEvent,
-  getByText,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Select } from 'app/components/inputs';
-import { Tooltip } from 'app/components/popups';
-import {
-  appendJupyterNotebookFileSuffix,
-  dropJupyterNotebookFileSuffix,
-} from 'app/pages/analysis/util';
+import { appendJupyterNotebookFileSuffix } from 'app/pages/analysis/util';
 import { ExportDatasetModal } from 'app/pages/data/data-set/export-dataset-modal';
 import {
   dataSetApi,
@@ -42,9 +28,9 @@ describe('ExportDatasetModal', () => {
   let dataset;
   let workspace;
   let testProps;
+  ``;
   let notebooksApiStub;
   let datasetApiStub;
-  let modalRoot;
 
   const component = (props) => {
     return <ExportDatasetModal {...props} />;
@@ -118,7 +104,6 @@ describe('ExportDatasetModal', () => {
   });
 
   it('should render', async () => {
-    const user = userEvent.setup();
     const { unmount } = render(component(testProps));
     await screen.findByText('Export Dataset');
     unmount();

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -451,35 +451,40 @@ describe('ExportDatasetModal', () => {
     unmount();
   });
 
-  // it('Should export code with genomics analysis tool', async () => {
-  //   testProps.dataset.prePackagedConceptSet = [
-  //     PrePackagedConceptSetEnum.WHOLE_GENOME,
-  //   ];
-  //   const { container } = render(component(testProps));
-  //   const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
-  //   const notebookName = 'Notebook Name';
-  //   const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
-  //   const expectedDatasetRequest: DataSetRequest = {
-  //     dataSetId: dataset.id,
-  //     name: dataset.name,
-  //     domainValuePairs: dataset.domainValuePairs,
-  //   };
-  //
-  //   container
-  //     .querySelector('[data-test-id="notebook-name-input"]')
-  //     .first()
-  //     .simulate('change', { target: { value: notebookName } });
-  //   findExportButton(container).simulate('click');
-  //   expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
-  //     dataSetRequest: expectedDatasetRequest,
-  //     newNotebook: true,
-  //     notebookName: expectedNotebookName,
-  //     kernelType: KernelTypeEnum.PYTHON,
-  //     generateGenomicsAnalysisCode: true,
-  //     genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
-  //   });
-  // });
-  //
+  it('Should export code with genomics analysis tool', async () => {
+    testProps.dataset.prePackagedConceptSet = [
+      PrePackagedConceptSetEnum.WHOLE_GENOME,
+    ];
+    const { container, unmount } = render(component(testProps));
+    const exportSpy = jest.spyOn(dataSetApi(), 'exportToNotebook');
+    const notebookName = 'Notebook Name';
+    const expectedNotebookName = appendJupyterNotebookFileSuffix(notebookName);
+    const expectedDatasetRequest: DataSetRequest = {
+      dataSetId: dataset.id,
+      name: dataset.name,
+      domainValuePairs: dataset.domainValuePairs,
+    };
+
+    await waitUntilDoneLoading();
+
+    const notebookNameInput = findNotebookNameInput();
+    fireEvent.change(notebookNameInput, {
+      target: { value: appendJupyterNotebookFileSuffix(notebookName) },
+    });
+    const exportButton = findExportButton();
+    fireEvent.click(exportButton);
+
+    expect(exportSpy).toHaveBeenCalledWith(workspace.namespace, workspace.id, {
+      dataSetRequest: expectedDatasetRequest,
+      newNotebook: true,
+      notebookName: expectedNotebookName,
+      kernelType: KernelTypeEnum.PYTHON,
+      generateGenomicsAnalysisCode: true,
+      genomicsAnalysisTool: DataSetExportRequestGenomicsAnalysisToolEnum.HAIL,
+    });
+    unmount();
+  });
+
   // it('Auto reload code preview if genomics analysis tool is changed', async () => {
   //   const expectedDatasetRequest = {
   //     dataSetId: dataset.id,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -150,7 +150,7 @@ export const ExportDatasetModal = ({
   const isNotebooksLoading = existingNotebooks === undefined;
   const isCodePreviewLoading = showCodePreview && !codePreview;
 
-  // Any state that necessiatates disabling all modal controls.
+  // Any state that necessitates disabling all modal controls.
   const modalLoading =
     isNotebooksLoading ||
     loadingNotebook ||

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -342,7 +342,7 @@ export const ExportDatasetModal = ({
   return (
     <AnimatedModal
       loading={isExporting || isNotebooksLoading || loadingNotebook}
-      width={!(showCodePreview && codePreview) ? 450 : 1200}
+      width={showCodePreview && codePreview ? 1200 : 450}
     >
       <FlexRow>
         <div style={{ width: 'calc(450px - 3rem)' }}>

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -375,7 +375,7 @@ export const ExportDatasetModal = ({
               <Button
                 type='primary'
                 data-test-id='export-data-set'
-                disabled={!isEmpty(errors)}
+                disabled={!isEmpty(errors) || isNotebooksLoading}
                 onClick={() => exportDataset()}
               >
                 Export

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -181,7 +181,7 @@ export const ExportDatasetModal = ({
         <RadioButton
           name='genomics-tool'
           style={{ marginRight: '0.375rem' }}
-          disabled={loadingNotebook || modalLoading}
+          disabled={modalLoading}
           data-test-id={'genomics-tool-' + genomicsTool}
           checked={genomicsAnalysisTool === genomicsTool}
           onChange={() => onChangeGenomicsAnalysisTool(genomicsTool)}
@@ -414,7 +414,7 @@ export const ExportDatasetModal = ({
             <FlexRow style={{ alignItems: 'center' }}>
               <Button
                 type='link'
-                disabled={isCodePreviewLoading || loadingCode || modalLoading}
+                disabled={isCodePreviewLoading || modalLoading}
                 data-test-id='code-preview-button'
                 onClick={() => onCodePreviewClick()}
                 style={{ padding: 0, margin: 0 }}
@@ -442,7 +442,7 @@ export const ExportDatasetModal = ({
             <Toast ref={toast} />
             <Button
               id='copyCodeButton'
-              disabled={loadingCode || loadingClipboard}
+              disabled={isCodePreviewLoading || modalLoading}
               type='secondaryOutline'
               onClick={onCopyCodeClick}
               style={{ marginRight: '3rem', minWidth: '120px' }}

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -291,7 +291,7 @@ export const ExportDatasetModal = ({
             </div>
 
             {creatingNewNotebook && (
-              <React.Fragment>
+              <label>
                 <SmallHeader style={{ fontSize: 14, marginTop: '1.5rem' }}>
                   Notebook Name
                 </SmallHeader>
@@ -300,7 +300,7 @@ export const ExportDatasetModal = ({
                   value={notebookNameWithoutSuffix}
                   data-test-id='notebook-name-input'
                 />
-              </React.Fragment>
+              </label>
             )}
 
             <div style={headerStyles.formLabel}>

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -180,6 +180,7 @@ export const ExportDatasetModal = ({
         style={styles.radioButtonLabel}
       >
         <RadioButton
+          name='genomics-tool'
           style={{ marginRight: '0.375rem' }}
           disabled={loadingNotebook || modalLoading}
           data-test-id={'genomics-tool-' + genomicsTool}
@@ -245,6 +246,7 @@ export const ExportDatasetModal = ({
   }
 
   function onCodePreviewClick() {
+    console.log('Yoinks!');
     if (!codePreview) {
       AnalyticsTracker.DatasetBuilder.SeeCodePreview();
     }
@@ -367,6 +369,7 @@ export const ExportDatasetModal = ({
                   onChange={(v) => setNotebookNameWithoutSuffix(v)}
                   value={notebookNameWithoutSuffix}
                   data-test-id='notebook-name-input'
+                  disabled={modalLoading}
                 />
               </label>
             )}
@@ -380,6 +383,7 @@ export const ExportDatasetModal = ({
                 <label key={i} style={styles.radioButtonLabel}>
                   <RadioButton
                     style={{ marginRight: '0.375rem' }}
+                    name='kernel-type'
                     data-test-id={'kernel-type-' + kernelTypeEnum.toLowerCase()}
                     disabled={modalLoading || !creatingNewNotebook}
                     checked={kernelType === kernelTypeEnum}
@@ -454,7 +458,7 @@ export const ExportDatasetModal = ({
               <Button
                 type='primary'
                 data-test-id='export-data-set'
-                disabled={!isEmpty(errors) || isNotebooksLoading}
+                disabled={!isEmpty(errors) || modalLoading}
                 onClick={() => exportDataset()}
               >
                 Export

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -478,6 +478,7 @@ export const ExportDatasetModal = ({
                 icon={Copy}
                 onClick={onCopyCodeClick}
                 style={{ height: '24px', width: '24px' }}
+                title='Dataset query copy icon button'
               />
             </div>
             {codePreview}

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -151,7 +151,7 @@ export const ExportDatasetModal = ({
   const isCodePreviewLoading = showCodePreview && !codePreview;
 
   // Any state that necessitates disabling all modal controls.
-  const modalLoading =
+  const shouldDisable =
     isNotebooksLoading ||
     loadingNotebook ||
     loadingClipboard ||
@@ -181,7 +181,7 @@ export const ExportDatasetModal = ({
         <RadioButton
           name='genomics-tool'
           style={{ marginRight: '0.375rem' }}
-          disabled={modalLoading}
+          disabled={shouldDisable}
           data-test-id={'genomics-tool-' + genomicsTool}
           checked={genomicsAnalysisTool === genomicsTool}
           onChange={() => onChangeGenomicsAnalysisTool(genomicsTool)}
@@ -350,7 +350,7 @@ export const ExportDatasetModal = ({
           <ModalBody>
             <div style={{ marginTop: '1.5rem' }}>
               <Select
-                isDisabled={modalLoading}
+                isDisabled={shouldDisable}
                 value={creatingNewNotebook ? '' : notebookNameWithoutSuffix}
                 data-test-id='select-notebook'
                 options={selectOptions}
@@ -367,7 +367,7 @@ export const ExportDatasetModal = ({
                   onChange={(v) => setNotebookNameWithoutSuffix(v)}
                   value={notebookNameWithoutSuffix}
                   data-test-id='notebook-name-input'
-                  disabled={modalLoading}
+                  disabled={shouldDisable}
                 />
               </label>
             )}
@@ -383,7 +383,7 @@ export const ExportDatasetModal = ({
                     style={{ marginRight: '0.375rem' }}
                     name='kernel-type'
                     data-test-id={'kernel-type-' + kernelTypeEnum.toLowerCase()}
-                    disabled={modalLoading || !creatingNewNotebook}
+                    disabled={shouldDisable || !creatingNewNotebook}
                     checked={kernelType === kernelTypeEnum}
                     onChange={() => onChangeKernelType(kernelTypeEnum)}
                   />
@@ -414,7 +414,7 @@ export const ExportDatasetModal = ({
             <FlexRow style={{ alignItems: 'center' }}>
               <Button
                 type='link'
-                disabled={isCodePreviewLoading || modalLoading}
+                disabled={isCodePreviewLoading || shouldDisable}
                 data-test-id='code-preview-button'
                 onClick={() => onCodePreviewClick()}
                 style={{ padding: 0, margin: 0 }}
@@ -442,7 +442,7 @@ export const ExportDatasetModal = ({
             <Toast ref={toast} />
             <Button
               id='copyCodeButton'
-              disabled={isCodePreviewLoading || modalLoading}
+              disabled={isCodePreviewLoading || shouldDisable}
               type='secondaryOutline'
               onClick={onCopyCodeClick}
               style={{ marginRight: '3rem', minWidth: '120px' }}
@@ -456,7 +456,7 @@ export const ExportDatasetModal = ({
               <Button
                 type='primary'
                 data-test-id='export-data-set'
-                disabled={!isEmpty(errors) || modalLoading}
+                disabled={!isEmpty(errors) || shouldDisable}
                 onClick={() => exportDataset()}
               >
                 Export

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -149,6 +149,7 @@ export const ExportDatasetModal = ({
     return (
       <iframe
         id='export-preview-frame'
+        data-testid='export-preview-frame'
         scrolling='yes'
         style={{ width: '100%', height: '100%', border: 'none' }}
         srcDoc={placeholder.outerHTML}

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -239,7 +239,6 @@ export const ExportDatasetModal = ({
   };
 
   const onCodePreviewClick = () => {
-    console.log('Yoinks!');
     if (!codePreview) {
       AnalyticsTracker.DatasetBuilder.SeeCodePreview();
     }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -291,7 +291,7 @@ export const ExportDatasetModal = ({
   // When code preview is showing, but codePreview does not
   // have a value, update code.
   useEffect(() => {
-    if (!codePreview && showCodePreview) {
+    if (showCodePreview && !codePreview) {
       getCode();
     }
   }, [codePreview, showCodePreview]);


### PR DESCRIPTION
Added copy code button to export dataset modal. This button gets its text representation from the same endpoint as preview because of significant overlap in functionality. I added logic to appropriately update preview and clipboard representation when relevant fields change. I also added logic to lock down functionality when modal is in the process of loading.

![image](https://github.com/all-of-us/workbench/assets/24514630/00b3c2bb-1b70-40ed-a324-c99fa6571b1b)
![image](https://github.com/all-of-us/workbench/assets/24514630/45330590-e645-434b-a752-8ef698c98b6d)


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
