### PR TITLE
[risk=low][RW-9376] Only show Persistent Disks for GCE, and only Standard disks for Dataproc

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel.enzyme.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.enzyme.spec.tsx
@@ -240,12 +240,6 @@ describe(RuntimeConfigurationPanel.name, () => {
   const pickMainDiskSize = (wrapper, diskSize) =>
     enterNumberInput(wrapper, '#standard-disk', diskSize);
 
-  const enableDetachable = (wrapper, detachable = true) =>
-    wrapper
-      .find({ name: detachable ? 'detachableDisk' : 'standardDisk' })
-      .first()
-      .simulate('change');
-
   const pickDetachableType = (wrapper, diskType: DiskType) =>
     pickDropdownOption(wrapper, '#disk-type', diskTypeLabels[diskType]);
 
@@ -363,7 +357,6 @@ describe(RuntimeConfigurationPanel.name, () => {
     await pickMainDiskSize(wrapper, MIN_DISK_SIZE_GB + 10);
 
     await pickPreset(wrapper, runtimePresets.generalAnalysis);
-    await enableDetachable(wrapper, true);
 
     await mustClickButton(wrapper, 'Create');
 
@@ -490,7 +483,8 @@ describe(RuntimeConfigurationPanel.name, () => {
   );
 
   it('should reattach to an existing disk by default, for deleted VMs', async () => {
-    setCurrentDisk(existingDisk());
+    const disk = existingDisk();
+    setCurrentDisk(disk);
     setCurrentRuntime({
       ...runtimeApiStub.runtime,
       status: RuntimeStatus.DELETED,
@@ -503,10 +497,7 @@ describe(RuntimeConfigurationPanel.name, () => {
     });
 
     const wrapper = await component();
-
-    const getDetachableRadio = () =>
-      wrapper.find({ name: 'detachableDisk' }).first();
-    expect(getDetachableRadio().prop('checked')).toBeTruthy();
+    expect(getDetachableDiskSize(wrapper)).toEqual(disk.size);
   });
 
   it('should allow configuration via dataproc preset from modified form', async () => {
@@ -1093,7 +1084,6 @@ describe(RuntimeConfigurationPanel.name, () => {
     const wrapper = await component();
     const getNextButton = () => wrapper.find({ 'aria-label': 'Next' }).first();
 
-    await enableDetachable(wrapper);
     await pickDetachableType(wrapper, DiskType.STANDARD);
 
     await pickDetachableDiskSize(wrapper, 49);

--- a/ui/src/app/components/runtime-configuration-panel.rtl.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.rtl.spec.tsx
@@ -37,6 +37,7 @@ import {
 
 import defaultServerConfig from 'testing/default-server-config';
 import {
+  debugAll,
   expectButtonElementDisabled,
   expectButtonElementEnabled,
   getDropdownOption,
@@ -1126,17 +1127,11 @@ describe(RuntimeConfigurationPanel.name, () => {
 
     component();
 
-    const detachablePdButton = screen.getByRole('radio', {
-      name: 'Detachable Disk',
-    });
-    expect(detachablePdButton).toBeInTheDocument();
-    expect(detachablePdButton).not.toBeDisabled();
-
-    const standardDiskButton = screen.getByRole('radio', {
-      name: 'Standard Disk',
-    });
-    expect(standardDiskButton).toBeInTheDocument();
-    expect(standardDiskButton).toBeDisabled();
+    debugAll();
+    expect(
+      screen.queryByText('Reattachable persistent disk')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Standard disk')).not.toBeInTheDocument();
   });
 
   it('should require standard disk / prevent detachable PD use for Dataproc', async () => {
@@ -1144,17 +1139,10 @@ describe(RuntimeConfigurationPanel.name, () => {
 
     component();
 
-    const detachablePdButton = screen.getByRole('radio', {
-      name: 'Detachable Disk',
-    });
-    expect(detachablePdButton).toBeInTheDocument();
-    expect(detachablePdButton).toBeDisabled();
-
-    const standardDiskButton = screen.getByRole('radio', {
-      name: 'Standard Disk',
-    });
-    expect(standardDiskButton).toBeInTheDocument();
-    expect(standardDiskButton).not.toBeDisabled();
+    expect(screen.queryByText('Standard disk')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Reattachable persistent disk')
+    ).not.toBeInTheDocument();
   });
 
   it('should allow Dataproc -> PD transition', async () => {
@@ -1164,22 +1152,16 @@ describe(RuntimeConfigurationPanel.name, () => {
 
     const { container } = component();
 
-    // confirm Dataproc by observing that PD is disabled
-    expect(
-      screen.getByRole('radio', {
-        name: 'Detachable Disk',
-      })
-    ).toBeDisabled();
+    // confirm Dataproc by observing that Standard disk is required
+    expect(screen.queryByText('Standard disk')).toBeInTheDocument();
 
     await pickComputeType(container, user, ComputeType.Standard);
 
     await waitFor(() => {
-      // confirm GCE by observing that PD is enabled
+      // confirm GCE by observing that PD is required
       expect(
-        screen.getByRole('radio', {
-          name: 'Detachable Disk',
-        })
-      ).not.toBeDisabled();
+        screen.queryByText('Reattachable persistent disk')
+      ).toBeInTheDocument();
     });
 
     clickExpectedButton('Next');
@@ -1238,23 +1220,9 @@ describe(RuntimeConfigurationPanel.name, () => {
     setCurrentRuntime(defaultGceRuntime());
 
     component();
-
     expect(
-      screen.queryByText(/only support reattachable persistent disks/)
+      screen.queryByText('Reattachable persistent disk')
     ).toBeInTheDocument();
-
-    const detachablePdButton = screen.getByRole('radio', {
-      name: 'Detachable Disk',
-    });
-    expect(detachablePdButton).toBeInTheDocument();
-    expect(detachablePdButton).toBeEnabled();
-    expect(detachablePdButton).toHaveProperty('checked');
-
-    const standardDiskButton = screen.getByRole('radio', {
-      name: 'Standard Disk',
-    });
-    expect(standardDiskButton).toBeInTheDocument();
-    expect(standardDiskButton).toBeDisabled();
-    expect(standardDiskButton).toHaveProperty('disabled');
+    expect(screen.queryByText('Standard disk')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/runtime-configuration-panel.rtl.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.rtl.spec.tsx
@@ -37,7 +37,6 @@ import {
 
 import defaultServerConfig from 'testing/default-server-config';
 import {
-  debugAll,
   expectButtonElementDisabled,
   expectButtonElementEnabled,
   getDropdownOption,
@@ -1127,7 +1126,6 @@ describe(RuntimeConfigurationPanel.name, () => {
 
     component();
 
-    debugAll();
     expect(
       screen.queryByText('Reattachable persistent disk')
     ).toBeInTheDocument();

--- a/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
@@ -71,27 +71,15 @@ export const DiskSelector = ({
           to learn more.
         </WarningMessage>
       )}
-      <TooltipTrigger
-        content={
-          'To create a new Standard VM environment, you will have to use a reattachable persistent disk'
-        }
-        disabled={computeType !== ComputeType.Standard}
-      >
+      {computeType === ComputeType.Dataproc && (
         <FlexRow style={styles.diskRow}>
           <RadioButton
             aria-label='Standard Disk'
             name='standardDisk'
             data-test-id='standard-disk-radio'
             style={styles.diskRadio}
-            disabled={disabled || computeType === ComputeType.Standard}
-            onChange={() =>
-              onChange({
-                ...diskConfig,
-                detachable: false,
-                detachableType: null,
-                existingDiskName: null,
-              })
-            }
+            disabled={true}
+            onChange={() => {}}
             checked={!diskConfig.detachable}
           />
           <FlexColumn>
@@ -102,9 +90,9 @@ export const DiskSelector = ({
             </span>
             {diskConfig.detachable || (
               <DiskSizeSelector
+                {...{ disabled }}
                 idPrefix='standard'
                 diskSize={diskConfig.size}
-                disabled={disabled || computeType === ComputeType.Standard}
                 style={{ marginTop: '11px' }}
                 onChange={(size: number) =>
                   onChange(
@@ -121,7 +109,7 @@ export const DiskSelector = ({
             )}
           </FlexColumn>
         </FlexRow>
-      </TooltipTrigger>
+      )}
       <TooltipTrigger
         content={disableDetachableReason}
         disabled={!disableDetachableReason}
@@ -132,21 +120,9 @@ export const DiskSelector = ({
             data-test-id='detachable-disk-radio'
             name='detachableDisk'
             style={styles.diskRadio}
-            onChange={() =>
-              onChange(
-                maybeWithExistingDiskName(
-                  {
-                    ...diskConfig,
-                    size: existingDisk?.size || diskConfig.size,
-                    detachable: true,
-                    detachableType: existingDisk?.diskType || DiskType.STANDARD,
-                  },
-                  existingDisk
-                )
-              )
-            }
+            disabled={true}
+            onChange={() => {}}
             checked={diskConfig.detachable}
-            disabled={disabled || !!disableDetachableReason}
           />
           <FlexColumn>
             <label style={styles.diskLabel}>Reattachable persistent disk</label>

--- a/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
@@ -6,7 +6,6 @@ import { Disk, DiskType } from 'generated/fetch';
 import { StyledExternalLink } from 'app/components/buttons';
 import { styles } from 'app/components/common-env-conf-panels/styles';
 import { FlexColumn, FlexRow } from 'app/components/flex';
-import { RadioButton } from 'app/components/inputs';
 import { WarningMessage } from 'app/components/messages';
 import { TooltipTrigger } from 'app/components/popups';
 import { AoU } from 'app/components/text-wrappers';
@@ -69,15 +68,6 @@ export const DiskSelector = ({
             to learn more.
           </WarningMessage>
           <FlexRow style={styles.diskRow}>
-            <RadioButton
-              aria-label='Detachable Disk'
-              data-test-id='detachable-disk-radio'
-              name='detachableDisk'
-              style={styles.diskRadio}
-              disabled={true}
-              onChange={() => {}}
-              checked={diskConfig.detachable}
-            />
             <FlexColumn>
               <label style={styles.diskLabel}>
                 Reattachable persistent disk
@@ -143,15 +133,6 @@ export const DiskSelector = ({
       ) : (
         <TooltipTrigger content='Reattachable disks are unsupported for this compute type'>
           <FlexRow style={styles.diskRow}>
-            <RadioButton
-              aria-label='Standard Disk'
-              name='standardDisk'
-              data-test-id='standard-disk-radio'
-              style={styles.diskRadio}
-              disabled={true}
-              onChange={() => {}}
-              checked={!diskConfig.detachable}
-            />
             <FlexColumn>
               <label style={styles.diskLabel}>Standard disk</label>
               <span>

--- a/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/disk-selector.tsx
@@ -31,9 +31,6 @@ export const DiskSelector = ({
   existingDisk,
   computeType,
 }: Props) => {
-  const disableDetachableReason: string | undefined =
-    computeType === ComputeType.Dataproc &&
-    'Reattachable disks are unsupported for this compute type';
   return (
     <FlexColumn
       style={{ ...styles.controlSection, gap: '11px', marginTop: '11px' }}
@@ -53,118 +50,120 @@ export const DiskSelector = ({
           </StyledExternalLink>
         </FlexRow>
       </FlexColumn>
-      {computeType === ComputeType.Standard && (
-        <WarningMessage>
-          <AoU /> will now only support reattachable persistent disks as the
-          storage disk option for Standard VMs and will discontinue standard
-          disks. You will continue to use standard disks with Dataproc clusters.
-          Refer to the
-          <a
-            href={
-              'https://support.researchallofus.org/hc/en-us/articles/5140493753620-Persistent-Disk'
-            }
-            target='_blank'
-          >
-            {' '}
-            article{' '}
-          </a>{' '}
-          to learn more.
-        </WarningMessage>
-      )}
-      {computeType === ComputeType.Dataproc && (
-        <FlexRow style={styles.diskRow}>
-          <RadioButton
-            aria-label='Standard Disk'
-            name='standardDisk'
-            data-test-id='standard-disk-radio'
-            style={styles.diskRadio}
-            disabled={true}
-            onChange={() => {}}
-            checked={!diskConfig.detachable}
-          />
-          <FlexColumn>
-            <label style={styles.diskLabel}>Standard disk</label>
-            <span>
-              A standard disk is created and deleted with your cloud
-              environment.
-            </span>
-            {diskConfig.detachable || (
-              <DiskSizeSelector
-                {...{ disabled }}
-                idPrefix='standard'
-                diskSize={diskConfig.size}
-                style={{ marginTop: '11px' }}
-                onChange={(size: number) =>
-                  onChange(
-                    maybeWithExistingDiskName(
-                      {
-                        ...diskConfig,
-                        size,
-                      },
-                      existingDisk
-                    )
-                  )
-                }
-              />
-            )}
-          </FlexColumn>
-        </FlexRow>
-      )}
-      <TooltipTrigger
-        content={disableDetachableReason}
-        disabled={!disableDetachableReason}
-      >
-        <FlexRow style={styles.diskRow}>
-          <RadioButton
-            aria-label='Detachable Disk'
-            data-test-id='detachable-disk-radio'
-            name='detachableDisk'
-            style={styles.diskRadio}
-            disabled={true}
-            onChange={() => {}}
-            checked={diskConfig.detachable}
-          />
-          <FlexColumn>
-            <label style={styles.diskLabel}>Reattachable persistent disk</label>
-            <span>
-              A reattachable disk is saved even when your compute environment is
-              deleted.
-            </span>
-            {diskConfig.detachable && (
-              <FlexRow style={{ ...styles.formGrid2, marginTop: '11px' }}>
-                <FlexRow style={styles.labelAndInput}>
-                  <label
-                    style={{ ...styles.label, minWidth: '4.5rem' }}
-                    htmlFor='disk-type'
-                  >
-                    Disk type
-                  </label>
-                  <Dropdown
-                    id={'disk-type'}
-                    options={[DiskType.STANDARD, DiskType.SSD].map((value) => ({
-                      label: diskTypeLabels[value],
-                      value,
-                    }))}
-                    style={{ width: '150px' }}
+      {computeType === ComputeType.Standard ? (
+        <>
+          <WarningMessage>
+            <AoU /> will now only support reattachable persistent disks as the
+            storage disk option for Standard VMs and will discontinue standard
+            disks. You will continue to use standard disks with Dataproc
+            clusters. Refer to the
+            <a
+              href={
+                'https://support.researchallofus.org/hc/en-us/articles/5140493753620-Persistent-Disk'
+              }
+              target='_blank'
+            >
+              {' '}
+              article{' '}
+            </a>{' '}
+            to learn more.
+          </WarningMessage>
+          <FlexRow style={styles.diskRow}>
+            <RadioButton
+              aria-label='Detachable Disk'
+              data-test-id='detachable-disk-radio'
+              name='detachableDisk'
+              style={styles.diskRadio}
+              disabled={true}
+              onChange={() => {}}
+              checked={diskConfig.detachable}
+            />
+            <FlexColumn>
+              <label style={styles.diskLabel}>
+                Reattachable persistent disk
+              </label>
+              <span>
+                A reattachable disk is saved even when your compute environment
+                is deleted.
+              </span>
+              {diskConfig.detachable && (
+                <FlexRow style={{ ...styles.formGrid2, marginTop: '11px' }}>
+                  <FlexRow style={styles.labelAndInput}>
+                    <label
+                      style={{ ...styles.label, minWidth: '4.5rem' }}
+                      htmlFor='disk-type'
+                    >
+                      Disk type
+                    </label>
+                    <Dropdown
+                      id={'disk-type'}
+                      options={[DiskType.STANDARD, DiskType.SSD].map(
+                        (value) => ({
+                          label: diskTypeLabels[value],
+                          value,
+                        })
+                      )}
+                      style={{ width: '150px' }}
+                      disabled={disabled}
+                      onChange={({ value }) =>
+                        onChange(
+                          maybeWithExistingDiskName(
+                            {
+                              ...diskConfig,
+                              detachableType: value,
+                            },
+                            existingDisk
+                          )
+                        )
+                      }
+                      value={diskConfig.detachableType}
+                    />
+                  </FlexRow>
+                  <DiskSizeSelector
+                    idPrefix='detachable'
+                    diskSize={diskConfig.size}
                     disabled={disabled}
-                    onChange={({ value }) =>
+                    onChange={(size: number) =>
                       onChange(
                         maybeWithExistingDiskName(
                           {
                             ...diskConfig,
-                            detachableType: value,
+                            size,
                           },
                           existingDisk
                         )
                       )
                     }
-                    value={diskConfig.detachableType}
                   />
                 </FlexRow>
+              )}
+            </FlexColumn>
+          </FlexRow>
+        </>
+      ) : (
+        <TooltipTrigger content='Reattachable disks are unsupported for this compute type'>
+          <FlexRow style={styles.diskRow}>
+            <RadioButton
+              aria-label='Standard Disk'
+              name='standardDisk'
+              data-test-id='standard-disk-radio'
+              style={styles.diskRadio}
+              disabled={true}
+              onChange={() => {}}
+              checked={!diskConfig.detachable}
+            />
+            <FlexColumn>
+              <label style={styles.diskLabel}>Standard disk</label>
+              <span>
+                A standard disk is created and deleted with your cloud
+                environment.
+              </span>
+              {diskConfig.detachable || (
                 <DiskSizeSelector
-                  idPrefix='detachable'
+                  {...{ disabled }}
+                  idPrefix='standard'
                   diskSize={diskConfig.size}
-                  disabled={disabled}
+                  style={{ marginTop: '11px' }}
                   onChange={(size: number) =>
                     onChange(
                       maybeWithExistingDiskName(
@@ -177,11 +176,11 @@ export const DiskSelector = ({
                     )
                   }
                 />
-              </FlexRow>
-            )}
-          </FlexColumn>
-        </FlexRow>
-      </TooltipTrigger>
+              )}
+            </FlexColumn>
+          </FlexRow>
+        </TooltipTrigger>
+      )}
     </FlexColumn>
   );
 };


### PR DESCRIPTION
Long ago, we provided an option to choose Standard disk vs. Detachable/Persistent disks for GCE VMs.  We have never offered the Persistent option for Dataproc clusters.

Since we started requiring Persistent Disks for GCE VMs, there is no longer any situation where we allow the user to make the choice between these disk types.

This PR removes the appearance of providing that option.

**I don't know why the fonts are wrong in these screenshots.**  I think something is wrong with my local browser.  There's no reason to expect that this change would have any effect on fonts, and I also see it for the version I didn't change.

Before (GCE)
<img width="649" alt="Before GCE" src="https://github.com/all-of-us/workbench/assets/2701406/1c54be33-6fe3-4979-a62b-cfd5fe464f6d">


After (GCE)
<img width="679" alt="After GCE" src="https://github.com/all-of-us/workbench/assets/2701406/089cc5cc-28f9-44ed-8c63-09fbd5296efd">


Before (Dataproc)
<img width="568" alt="Before Dataproc" src="https://github.com/all-of-us/workbench/assets/2701406/12ba3405-9ea0-426a-8674-e21dcac66d23">


After (Dataproc)
<img width="507" alt="After Dataproc" src="https://github.com/all-of-us/workbench/assets/2701406/2354e5c5-57a6-4400-a9e6-77b8fcffa0c2">




---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
