### PR TITLE
[no ticket][risk=no] Fix disk deletion language.

### DIFF
--- a/ui/src/app/components/common-env-conf-panels/confirm-delete-environment-with-pd.tsx
+++ b/ui/src/app/components/common-env-conf-panels/confirm-delete-environment-with-pd.tsx
@@ -81,7 +81,8 @@ export const ConfirmDeleteEnvironmentWithPD = ({
         <p style={{ ...styles.confirmWarningText, gridColumn: 1, gridRow: 4 }}>
           You will continue to incur persistent disk cost at{' '}
           <b>{formatUsd(detachableDiskPricePerMonth(disk))}</b> per month. You
-          can delete your disk at any time via the runtime panel.
+          can delete your disk at any time via the {appType} configuration
+          panel.
         </p>
       </div>
       <div style={styles.confirmWarning}>


### PR DESCRIPTION
Changed language for delete environment panel to reflect the type of environment being deleted.

Currently all environments say:

> You will continue to incur persistent disk cost at $x.yz per month. You can delete your disk at any time via the SAS configuration panel.

Current Design (same for all apps and Jupyter):
![image](https://github.com/all-of-us/workbench/assets/24514630/1c6151db-1e20-491e-b97c-8c9d29636671)

Updated Design:
Jupyter:
![image](https://github.com/all-of-us/workbench/assets/24514630/338b46bc-25e9-4872-9b74-ac1237bd34c4)

Cromwell:
![image](https://github.com/all-of-us/workbench/assets/24514630/a63e3b4a-29eb-46f9-89b2-148902c81004)

RStudio:
![image](https://github.com/all-of-us/workbench/assets/24514630/e589b9d4-99e6-4225-9b25-f202ce8eb9dc)

SAS:
![image](https://github.com/all-of-us/workbench/assets/24514630/db17ac54-dc22-45c1-a172-526186abd6c6)

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
