### PR TITLE
[risk=low][RW-11453] Fix Notebook Preview and User App breadcrumb URLs

### DIFF
--- a/ui/src/app/components/breadcrumb-type.tsx
+++ b/ui/src/app/components/breadcrumb-type.tsx
@@ -5,7 +5,7 @@ export enum BreadcrumbType {
   WorkspaceDuplicate = 'WorkspaceDuplicate',
   Analysis = 'Analysis',
   AnalysisPreview = 'AnalysisPreview',
-  App = 'App',
+  UserApp = 'UserApp',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',
   CohortReview = 'CohortReview',

--- a/ui/src/app/components/breadcrumb-type.tsx
+++ b/ui/src/app/components/breadcrumb-type.tsx
@@ -4,6 +4,7 @@ export enum BreadcrumbType {
   WorkspaceEdit = 'WorkspaceEdit',
   WorkspaceDuplicate = 'WorkspaceDuplicate',
   Analysis = 'Analysis',
+  AnalysisPreview = 'AnalysisPreview',
   App = 'App',
   ConceptSet = 'ConceptSet',
   Cohort = 'Cohort',

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -3,6 +3,7 @@ import { WorkspacesApi } from 'generated/fetch';
 import { getTrail } from 'app/components/breadcrumb';
 import {
   analysisTabName,
+  analysisTabPath,
   appDisplayPath,
   dataTabPath,
 } from 'app/routing/utils';
@@ -35,9 +36,9 @@ describe('getTrail', () => {
     );
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
-      'defaultWorkspace',
-      'Cohort Name',
-      'Participant 77',
+      workspaceDataStub.name,
+      exampleCohortStubs[0].name,
+      cohortReviewStubs[0].cohortName,
     ]);
     expect(trail[3].url).toEqual(
       dataTabPath('testns', 'testwsid') +
@@ -61,21 +62,18 @@ describe('getTrail', () => {
     }
   );
 
-  it('Should display correct trail for App display', () => {
+  it('Should display correct trail for Jupyter', () => {
+    const ns = 'testns';
+    const wsid = 'testwsid';
+    const nbName = 'myNotebook';
+
     const trail = getTrail(
-      BreadcrumbType.UserApp,
+      BreadcrumbType.Analysis,
       workspaceDataStub,
       undefined,
       undefined,
       undefined,
-      {
-        ns: 'testns',
-        wsid: 'testwsid',
-        cid: undefined,
-        crid: undefined,
-        pid: undefined,
-        appType: UIAppType.RSTUDIO,
-      }
+      { ns, wsid, nbName }
     );
 
     const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
@@ -84,12 +82,71 @@ describe('getTrail', () => {
 
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
-      'defaultWorkspace',
+      workspaceDataStub.name,
+      analysisTabDisplay,
+      nbName,
+    ]);
+    expect(trail[trail.length - 1].url).toEqual(
+      `${analysisTabPath(ns, wsid)}/${nbName}`
+    );
+  });
+
+  it('Should display correct trail for Jupyter preview', () => {
+    const ns = 'testns';
+    const wsid = 'testwsid';
+    const nbName = 'myNotebook';
+
+    const trail = getTrail(
+      BreadcrumbType.AnalysisPreview,
+      workspaceDataStub,
+      undefined,
+      undefined,
+      undefined,
+      { ns, wsid, nbName }
+    );
+
+    const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
+      .slice(1)
+      .toLowerCase()}`;
+
+    expect(trail.map((item) => item.label)).toEqual([
+      'Workspaces',
+      workspaceDataStub.name,
+      analysisTabDisplay,
+      nbName,
+    ]);
+    expect(trail[trail.length - 1].url).toEqual(
+      `${analysisTabPath(ns, wsid)}/preview/${nbName}`
+    );
+  });
+
+  it('Should display correct trail for User Apps', () => {
+    const ns = 'testns';
+    const wsid = 'testwsid';
+    const nbName = "don't display this!";
+    const appType = UIAppType.RSTUDIO;
+
+    const trail = getTrail(
+      BreadcrumbType.UserApp,
+      workspaceDataStub,
+      undefined,
+      undefined,
+      undefined,
+      { ns, wsid, nbName, appType }
+    );
+
+    const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
+      .slice(1)
+      .toLowerCase()}`;
+
+    expect(trail.map((item) => item.label)).toEqual([
+      'Workspaces',
+      workspaceDataStub.name,
       analysisTabDisplay,
       UIAppType.RSTUDIO,
     ]);
-    expect(trail[3].url).toEqual(
-      appDisplayPath('testns', 'testwsid', UIAppType.RSTUDIO)
+    expect(trail[trail.length - 1].url).toEqual(
+      appDisplayPath(ns, wsid, appType)
     );
   });
 });

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -63,7 +63,7 @@ describe('getTrail', () => {
 
   it('Should display correct trail for App display', () => {
     const trail = getTrail(
-      BreadcrumbType.App,
+      BreadcrumbType.UserApp,
       workspaceDataStub,
       undefined,
       undefined,

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -68,6 +68,10 @@ describe('getTrail', () => {
     }
   );
 
+  const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
+    .slice(1)
+    .toLowerCase()}`;
+
   it('Should display correct trail for Jupyter', () => {
     const ns = 'testns';
     const wsid = 'testwsid';
@@ -81,10 +85,6 @@ describe('getTrail', () => {
       undefined,
       { ns, wsid, nbName }
     );
-
-    const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
-      .slice(1)
-      .toLowerCase()}`;
 
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
@@ -111,10 +111,6 @@ describe('getTrail', () => {
       { ns, wsid, nbName }
     );
 
-    const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
-      .slice(1)
-      .toLowerCase()}`;
-
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
       workspaceDataStub.name,
@@ -140,10 +136,6 @@ describe('getTrail', () => {
       undefined,
       { ns, wsid, nbName, appType }
     );
-
-    const analysisTabDisplay = `${analysisTabName[0].toUpperCase()}${analysisTabName
-      .slice(1)
-      .toLowerCase()}`;
 
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -137,7 +137,9 @@ describe('getTrail', () => {
       { ns, wsid, nbName, appType }
     );
 
-    expect(trail.map((item) => item.label)).toEqual([
+    const trailLabels: string[] = trail.map((item) => item.label);
+    expect(trailLabels).not.toContain(nbName);
+    expect(trailLabels).toEqual([
       'Workspaces',
       workspaceDataStub.name,
       analysisTabDisplay,

--- a/ui/src/app/components/breadcrumb.spec.tsx
+++ b/ui/src/app/components/breadcrumb.spec.tsx
@@ -26,23 +26,29 @@ describe('getTrail', () => {
   });
 
   it('works', () => {
+    const ns = 'testns';
+    const wsid = 'testwsid';
+    const cid = '123';
+    const crid = '456';
+    const pid = '789';
+
     const trail = getTrail(
       BreadcrumbType.Participant,
       workspaceDataStub,
       exampleCohortStubs[0],
       cohortReviewStubs[0],
       ConceptSetsApiStub.stubConceptSets()[0],
-      { ns: 'testns', wsid: 'testwsid', cid: '88', crid: '99', pid: '77' }
+      { ns, wsid, cid, crid, pid }
     );
     expect(trail.map((item) => item.label)).toEqual([
       'Workspaces',
       workspaceDataStub.name,
-      exampleCohortStubs[0].name,
       cohortReviewStubs[0].cohortName,
+      `Participant ${pid}`,
     ]);
     expect(trail[3].url).toEqual(
       dataTabPath('testns', 'testwsid') +
-        '/cohorts/88/reviews/99/participants/77'
+        `/cohorts/${cid}/reviews/${crid}/participants/${pid}`
     );
   });
 

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -418,12 +418,6 @@ export const Breadcrumb = fp.flow(
         () => ({ breadcrumbType: this.props.routeData.breadcrumb })
       );
 
-      console.log('analysisPreviewMatch', !!analysisPreviewMatch);
-      console.log('userAppMatch', !!userAppMatch);
-      console.log('analysisMatch', !!analysisMatch);
-      console.log('nbName', nbName);
-      console.log('breadcrumbType', breadcrumbType);
-
       return getTrail(
         breadcrumbType,
         this.props.workspace,

--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -70,7 +70,7 @@ export const getTrail = (
 ): Array<BreadcrumbData> => {
   const { ns, wsid, cid, crid, csid, pid, nbName, appType } = params;
   switch (type) {
-    case BreadcrumbType.App:
+    case BreadcrumbType.UserApp:
       return [
         ...getTrail(
           BreadcrumbType.Workspace,
@@ -374,18 +374,18 @@ export const Breadcrumb = fp.flow(
       });
       const { pid = '' } = participantMatch ? participantMatch.params : {};
 
-      // must match before analysisMatch - otherwise the analysisMatch will incorrectly match a file named "preview"
+      // WARNING
+      // because this pattern *also* matches previews and user apps, it must be checked AFTER those in the cond()
+      const analysisMatch = matchPath<MatchParams>(location.pathname, {
+        path: `/workspaces/:ns/:wsid/${analysisTabName}/:nbName`,
+      });
+
       const analysisPreviewMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${analysisTabName}/preview/:nbName`,
       });
 
-      // must match before analysisMatch - otherwise the analysisMatch will incorrectly match a file named "userApp"
       const userAppMatch = matchPath<MatchParams>(location.pathname, {
         path: `/workspaces/:ns/:wsid/${analysisTabName}/userApp/:appType`,
-      });
-
-      const analysisMatch = matchPath<MatchParams>(location.pathname, {
-        path: `/workspaces/:ns/:wsid/${analysisTabName}/:nbName`,
       });
 
       const {
@@ -404,10 +404,11 @@ export const Breadcrumb = fp.flow(
           !!userAppMatch,
           () => ({
             ...userAppMatch.params,
-            breadcrumbType: BreadcrumbType.Analysis,
+            breadcrumbType: BreadcrumbType.UserApp,
           }),
         ],
         [
+          // this check must go after analysisPreviewMatch and userAppMatch
           !!analysisMatch,
           () => ({
             ...analysisMatch.params,

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -191,27 +191,6 @@ export const WorkspaceRoutes = () => {
       </AppRoute>
       <AppRoute
         exact
-        path={`${path}/${analysisTabName}/userApp/:appType`}
-        guards={[adminLockedGuard(ns, wsid), appIsValidGuard(ns, wsid)]}
-      >
-        <GKEAppRedirectPage
-          key='app'
-          routeData={{
-            pathElementForTitle: 'appType',
-            breadcrumb: BreadcrumbType.UserApp,
-            // The iframe we use to display the Gke App does something strange
-            // to the height calculation of the container, which is normally set to auto.
-            // Setting this flag sets the container to 100% so that no content is clipped.
-            // This is same as the configuration used for Jupyter iframe
-            contentFullHeightOverride: true,
-            pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: analysisTabName,
-            minimizeChrome: true,
-          }}
-        />
-      </AppRoute>
-      <AppRoute
-        exact
         path={`${path}/${analysisTabName}/:nbName`}
         guards={[adminLockedGuard(ns, wsid)]}
       >
@@ -229,6 +208,27 @@ export const WorkspaceRoutes = () => {
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.JupyterNotebook}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
+        path={`${path}/${analysisTabName}/userApp/:appType`}
+        guards={[adminLockedGuard(ns, wsid), appIsValidGuard(ns, wsid)]}
+      >
+        <GKEAppRedirectPage
+          key='app'
+          routeData={{
+            pathElementForTitle: 'appType',
+            breadcrumb: BreadcrumbType.UserApp,
+            // The iframe we use to display the Gke App does something strange
+            // to the height calculation of the container, which is normally set to auto.
+            // Setting this flag sets the container to 100% so that no content is clipped.
+            // This is same as the configuration used for Jupyter iframe
+            contentFullHeightOverride: true,
+            pageKey: LEONARDO_APP_PAGE_KEY,
+            workspaceNavBarTab: analysisTabName,
+            minimizeChrome: true,
+          }}
         />
       </AppRoute>
       <AppRoute

--- a/ui/src/app/routing/workspace-app-routing.tsx
+++ b/ui/src/app/routing/workspace-app-routing.tsx
@@ -182,7 +182,28 @@ export const WorkspaceRoutes = () => {
         <InteractiveNotebookPage
           routeData={{
             pathElementForTitle: 'nbName',
-            breadcrumb: BreadcrumbType.Analysis,
+            breadcrumb: BreadcrumbType.AnalysisPreview,
+            pageKey: LEONARDO_APP_PAGE_KEY,
+            workspaceNavBarTab: analysisTabName,
+            minimizeChrome: true,
+          }}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
+        path={`${path}/${analysisTabName}/userApp/:appType`}
+        guards={[adminLockedGuard(ns, wsid), appIsValidGuard(ns, wsid)]}
+      >
+        <GKEAppRedirectPage
+          key='app'
+          routeData={{
+            pathElementForTitle: 'appType',
+            breadcrumb: BreadcrumbType.UserApp,
+            // The iframe we use to display the Gke App does something strange
+            // to the height calculation of the container, which is normally set to auto.
+            // Setting this flag sets the container to 100% so that no content is clipped.
+            // This is same as the configuration used for Jupyter iframe
+            contentFullHeightOverride: true,
             pageKey: LEONARDO_APP_PAGE_KEY,
             workspaceNavBarTab: analysisTabName,
             minimizeChrome: true,
@@ -208,27 +229,6 @@ export const WorkspaceRoutes = () => {
             minimizeChrome: true,
           }}
           leoAppType={LeoApplicationType.JupyterNotebook}
-        />
-      </AppRoute>
-      <AppRoute
-        exact
-        path={`${path}/${analysisTabName}/userApp/:appType`}
-        guards={[adminLockedGuard(ns, wsid), appIsValidGuard(ns, wsid)]}
-      >
-        <GKEAppRedirectPage
-          key='app'
-          routeData={{
-            pathElementForTitle: 'appType',
-            breadcrumb: BreadcrumbType.App,
-            // The iframe we use to display the Gke App does something strange
-            // to the height calculation of the container, which is normally set to auto.
-            // Setting this flag sets the container to 100% so that no content is clipped.
-            // This is same as the configuration used for Jupyter iframe
-            contentFullHeightOverride: true,
-            pageKey: LEONARDO_APP_PAGE_KEY,
-            workspaceNavBarTab: analysisTabName,
-            minimizeChrome: true,
-          }}
         />
       </AppRoute>
       <AppRoute


### PR DESCRIPTION
We planned yesterday to disable clicking on these breadcrumbs, but I think I have a better understanding of their intention now, so I corrected it instead: now breadcrumbs for notebook/R/SAS/etc previews have appropriate URLs: they link to the preview page, not the live notebook page.

In the normal case (you are at the preview page and this breadcrumb comes last) clicking it does nothing, so you can interpret that as "disabled" if you like.

Tested locally with various file types in preview and non-preview modes.
 
---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
