### PR TITLE
[risk=low][RW-6159] Reload Recent Resources on home page after deleting a workspace

### DIFF
--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -108,10 +108,6 @@ interface Props {
 export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
   const [tableData, setTableData] = useState<TableData[]>();
 
-  const reloadResources = async () => {
-    await props.onUpdate();
-  };
-
   const getResourceMap = () => {
     const resourceTypeNameListMap = new Map<ResourceType, string[]>();
     props.workspaceResources.map((resource) => {
@@ -136,7 +132,7 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
       workspace,
       menuOnly: true,
       existingNameList: resourceTypeNameMap.get(getType(resource)),
-      onUpdate: reloadResources,
+      onUpdate: () => props.onUpdate(),
     });
   };
 

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -111,7 +111,7 @@ const WelcomeHeader = () => {
   );
 };
 
-const Workspaces = () => {
+const Workspaces = ({ onChange }: { onChange: () => void }) => {
   const [navigate] = useNavigation();
 
   return (
@@ -150,7 +150,7 @@ const Workspaces = () => {
           See all workspaces
         </span>
       </FlexRow>
-      <RecentWorkspaces />
+      <RecentWorkspaces {...{ onChange }} />
     </FlexColumn>
   );
 };
@@ -306,7 +306,7 @@ export const Homepage = fp.flow(
             <FadeBox style={styles.fadeBox}>
               {/* The elements inside this fadeBox will be changed as part of ongoing homepage redesign work */}
               <FlexColumn style={{ justifyContent: 'flex-start' }}>
-                <Workspaces />
+                <Workspaces onChange={() => this.checkWorkspaces()} />
                 {userWorkspacesResponse &&
                   (this.userHasWorkspaces() ? (
                     <RecentResources

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -239,7 +239,7 @@ export const Homepage = fp.flow(
 
     componentDidMount() {
       this.props.hideSpinner();
-      this.checkWorkspaces();
+      this.loadWorkspaces();
       this.callProfile();
     }
 
@@ -285,7 +285,7 @@ export const Homepage = fp.flow(
       }
     }
 
-    async checkWorkspaces() {
+    async loadWorkspaces() {
       return fetchWithSystemErrorHandler(() =>
         workspacesApi().getWorkspaces()
       ).then((response) => this.setState({ userWorkspacesResponse: response }));
@@ -293,7 +293,7 @@ export const Homepage = fp.flow(
 
     userHasWorkspaces(): boolean {
       const { userWorkspacesResponse } = this.state;
-      return userWorkspacesResponse && userWorkspacesResponse.items.length > 0;
+      return userWorkspacesResponse?.items?.length > 0;
     }
 
     render() {
@@ -306,7 +306,7 @@ export const Homepage = fp.flow(
             <FadeBox style={styles.fadeBox}>
               {/* The elements inside this fadeBox will be changed as part of ongoing homepage redesign work */}
               <FlexColumn style={{ justifyContent: 'flex-start' }}>
-                <Workspaces onChange={() => this.checkWorkspaces()} />
+                <Workspaces onChange={() => this.loadWorkspaces()} />
                 {userWorkspacesResponse &&
                   (this.userHasWorkspaces() ? (
                     <RecentResources

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -239,7 +239,7 @@ export const Homepage = fp.flow(
 
     componentDidMount() {
       this.props.hideSpinner();
-      this.loadWorkspaces();
+      this.fetchWorkspaces();
       this.callProfile();
     }
 
@@ -285,7 +285,7 @@ export const Homepage = fp.flow(
       }
     }
 
-    async loadWorkspaces() {
+    async fetchWorkspaces() {
       return fetchWithSystemErrorHandler(() =>
         workspacesApi().getWorkspaces()
       ).then((response) => this.setState({ userWorkspacesResponse: response }));
@@ -306,7 +306,7 @@ export const Homepage = fp.flow(
             <FadeBox style={styles.fadeBox}>
               {/* The elements inside this fadeBox will be changed as part of ongoing homepage redesign work */}
               <FlexColumn style={{ justifyContent: 'flex-start' }}>
-                <Workspaces onChange={() => this.loadWorkspaces()} />
+                <Workspaces onChange={() => this.fetchWorkspaces()} />
                 {userWorkspacesResponse &&
                   (this.userHasWorkspaces() ? (
                     <RecentResources

--- a/ui/src/app/pages/homepage/recent-workspaces.tsx
+++ b/ui/src/app/pages/homepage/recent-workspaces.tsx
@@ -8,12 +8,15 @@ import { WorkspaceCard } from 'app/pages/workspace/workspace-card';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 
+interface Props {
+  onChange: () => void;
+}
 interface State {
   loading: boolean;
   recentWorkspaces: RecentWorkspace[];
 }
 
-export const RecentWorkspaces = class extends React.Component<{}, State> {
+export const RecentWorkspaces = class extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
@@ -73,7 +76,10 @@ export const RecentWorkspaces = class extends React.Component<{}, State> {
                     key={recentWorkspace.workspace.namespace}
                     workspace={recentWorkspace.workspace}
                     accessLevel={recentWorkspace.accessLevel}
-                    reload={() => this.loadWorkspaces()}
+                    reload={() => {
+                      this.loadWorkspaces();
+                      this.props.onChange();
+                    }}
                   />
                 );
               })}


### PR DESCRIPTION
If you delete a Workspace on the homepage, using the Workspace Card context menu, the Recent Resources list doesn't update, so it's possible to have resource entries that refer to a deleted workspace or resource.  Attempting to access these leads to bad UX: the app just appears to hang.

This PR causes the Recent Resources list to refresh after deleting a workspace, ensuring that these links do not appear.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
