### PR TITLE
[risk=low][RW-10249] Break out inactivity config and add accessors

### DIFF
--- a/ui/src/app/pages/signed-in/inactivity-monitor.spec.tsx
+++ b/ui/src/app/pages/signed-in/inactivity-monitor.spec.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 
 import { environment } from 'environments/environment';
-import {
-  INACTIVITY_CONFIG,
-  InactivityMonitor,
-} from 'app/pages/signed-in/inactivity-monitor';
+import { InactivityMonitor } from 'app/pages/signed-in/inactivity-monitor';
 import * as Authentication from 'app/utils/authentication';
+import { setLastActive } from 'app/utils/inactivity';
 import { authStore, notificationStore } from 'app/utils/stores';
 
 import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
@@ -22,10 +20,7 @@ describe(InactivityMonitor.name, () => {
       isSignedIn: true,
     });
 
-    window.localStorage.setItem(
-      INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE,
-      String(Date.now() - environment.inactivityTimeoutSeconds * 1000 - 1)
-    );
+    setLastActive(Date.now() - environment.inactivityTimeoutSeconds * 1000 - 1);
 
     expect(notificationStore.get()).toBeNull();
     const wrapper = mount(<InactivityMonitor />);

--- a/ui/src/app/pages/signed-in/inactivity-monitor.tsx
+++ b/ui/src/app/pages/signed-in/inactivity-monitor.tsx
@@ -9,7 +9,7 @@ import {
   clearLastActive,
   getLastActiveEpochMillis,
   INACTIVITY_CONFIG,
-  setLastActive,
+  setLastActiveNow,
 } from 'app/utils/inactivity';
 import { authStore, useStore } from 'app/utils/stores';
 
@@ -136,7 +136,7 @@ export const InactivityMonitor = () => {
         startInactivityTimers();
       };
 
-      setLastActive(Date.now());
+      setLastActiveNow();
       resetTimers();
 
       // setTimeout does not necessary track real wall-time. Periodically
@@ -159,7 +159,7 @@ export const InactivityMonitor = () => {
           // elapsed before updating our inactivity time tracker.
           signOutIfLocalStorageInactivityElapsed();
 
-          setLastActive(Date.now());
+          setLastActiveNow();
           resetTimers();
         },
         false

--- a/ui/src/app/pages/signed-in/inactivity-monitor.tsx
+++ b/ui/src/app/pages/signed-in/inactivity-monitor.tsx
@@ -44,11 +44,9 @@ const getInactivityElapsedMs = () => {
   return lastActive && Date.now() - lastActive;
 };
 
-const invalidateInactivityCookie = (): void => clearLastActive();
-
 const invalidateInactivityCookieAndSignOut = (continuePath?: string): void => {
   AnalyticsTracker.User.InactivitySignOut();
-  invalidateInactivityCookie();
+  clearLastActive();
   withErrorModal(
     {
       title: 'Sign Out Error',
@@ -92,7 +90,7 @@ export const InactivityMonitor = () => {
     }
 
     if (!isSignedIn) {
-      invalidateInactivityCookie();
+      clearLastActive();
       return;
     }
 

--- a/ui/src/app/utils/inactivity.spec.tsx
+++ b/ui/src/app/utils/inactivity.spec.tsx
@@ -18,16 +18,30 @@ describe('inactivity last-active accessors', () => {
     expect(getLastActiveEpochMillis()).toBeNull();
   });
 
-  it('should store values as epoch milli strings', () => {
+  // implementation detail useful for debugging
+  it('should use the LOCAL_STORAGE_KEY_LAST_ACTIVE location in local storage', () => {
+    expect(
+      window.localStorage.getItem(
+        INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
+      )
+    ).toBeNull();
+
     setLastActive(123);
     expect(
       window.localStorage.getItem(
         INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
       )
-    ).toEqual('123');
+    ).toEqual('123'); // epoch millis as a string
+
+    clearLastActive();
+    expect(
+      window.localStorage.getItem(
+        INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
+      )
+    ).toBeNull();
   });
 
-  it('should use the current time as the value', () => {
+  it('should use the current time as the value for setLastActiveNow()', () => {
     jest.useFakeTimers();
     setLastActiveNow();
     expect(getLastActiveEpochMillis()).toEqual(Date.now());

--- a/ui/src/app/utils/inactivity.spec.tsx
+++ b/ui/src/app/utils/inactivity.spec.tsx
@@ -27,7 +27,7 @@ describe('inactivity last-active accessors', () => {
     ).toEqual('123');
   });
 
-  it('should set the current value', () => {
+  it('should use the current time as the value', () => {
     jest.useFakeTimers();
     setLastActiveNow();
     expect(getLastActiveEpochMillis()).toEqual(Date.now());

--- a/ui/src/app/utils/inactivity.spec.tsx
+++ b/ui/src/app/utils/inactivity.spec.tsx
@@ -15,7 +15,7 @@ describe('inactivity last-active accessors', () => {
   it('should clear', () => {
     setLastActive(123);
     clearLastActive();
-    expect(getLastActiveEpochMillis()).toBeUndefined();
+    expect(getLastActiveEpochMillis()).toBeNull();
   });
 
   it('should store values as epoch milli strings', () => {
@@ -24,11 +24,15 @@ describe('inactivity last-active accessors', () => {
       window.localStorage.getItem(
         INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
       )
-    ).toEqual('12345');
+    ).toEqual('123');
   });
 
   it('should set the current value', () => {
     setLastActiveNow();
-    expect(getLastActiveEpochMillis()).toEqual(Date.now());
+
+    // assumption: this test takes less than one second to run
+    const oneSecondInMillis = 1e3;
+    const sinceLastActive = Date.now() - getLastActiveEpochMillis();
+    expect(sinceLastActive).toBeLessThan(oneSecondInMillis);
   });
 });

--- a/ui/src/app/utils/inactivity.spec.tsx
+++ b/ui/src/app/utils/inactivity.spec.tsx
@@ -1,0 +1,34 @@
+import {
+  clearLastActive,
+  getLastActiveEpochMillis,
+  INACTIVITY_CONFIG,
+  setLastActive,
+  setLastActiveNow,
+} from './inactivity';
+
+describe('inactivity last-active accessors', () => {
+  it('should round-trip', () => {
+    setLastActive(123);
+    expect(getLastActiveEpochMillis()).toEqual(123);
+  });
+
+  it('should clear', () => {
+    setLastActive(123);
+    clearLastActive();
+    expect(getLastActiveEpochMillis()).toBeUndefined();
+  });
+
+  it('should store values as epoch milli strings', () => {
+    setLastActive(123);
+    expect(
+      window.localStorage.getItem(
+        INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
+      )
+    ).toEqual('12345');
+  });
+
+  it('should set the current value', () => {
+    setLastActiveNow();
+    expect(getLastActiveEpochMillis()).toEqual(Date.now());
+  });
+});

--- a/ui/src/app/utils/inactivity.spec.tsx
+++ b/ui/src/app/utils/inactivity.spec.tsx
@@ -28,11 +28,9 @@ describe('inactivity last-active accessors', () => {
   });
 
   it('should set the current value', () => {
+    jest.useFakeTimers();
     setLastActiveNow();
-
-    // assumption: this test takes less than one second to run
-    const oneSecondInMillis = 1e3;
-    const sinceLastActive = Date.now() - getLastActiveEpochMillis();
-    expect(sinceLastActive).toBeLessThan(oneSecondInMillis);
+    expect(getLastActiveEpochMillis()).toEqual(Date.now());
+    jest.useRealTimers();
   });
 });

--- a/ui/src/app/utils/inactivity.tsx
+++ b/ui/src/app/utils/inactivity.tsx
@@ -29,6 +29,8 @@ export const setLastActive = (epochMillis: number): void => {
   );
 };
 
+export const setLastActiveNow = () => setLastActive(Date.now());
+
 export const clearLastActive = (): void => {
   window.localStorage.removeItem(
     INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE

--- a/ui/src/app/utils/inactivity.tsx
+++ b/ui/src/app/utils/inactivity.tsx
@@ -1,0 +1,36 @@
+/*
+ * The user's last known active timestamp is stored in localStorage with the key of
+ * INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE. This value is checked whenever
+ * the application is reloaded. If the difference between the time at reload and the
+ * value in local storage is greater than the inactivity timeout period, the user will
+ * be signed out of all Google accounts.
+ *
+ * If the localStorage value is null for whatever reason, we defer to the more secure
+ * solution of logging out the user. This should not affect new users since the logout
+ * flow is ignored if there is no user session.
+ */
+export const INACTIVITY_CONFIG = {
+  TRACKED_EVENTS: ['mousedown', 'keypress', 'scroll', 'click'],
+  LOCAL_STORAGE_KEY_LAST_ACTIVE: 'LAST_ACTIVE_TIMESTAMP_EPOCH_MS',
+  MESSAGE_KEY: 'USER_ACTIVITY_DETECTED',
+};
+
+export const getLastActiveEpochMillis = (): number | undefined => {
+  const lastActive: string = window.localStorage.getItem(
+    INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
+  );
+  return lastActive && parseInt(lastActive, 10);
+};
+
+export const setLastActive = (epochMillis: number): void => {
+  window.localStorage.setItem(
+    INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE,
+    epochMillis.toString()
+  );
+};
+
+export const clearLastActive = (): void => {
+  window.localStorage.removeItem(
+    INACTIVITY_CONFIG.LOCAL_STORAGE_KEY_LAST_ACTIVE
+  );
+};


### PR DESCRIPTION
A small change to help me understand what I need to do for RW-10249 better.  Does not complete the story.

Tested locally by observing that clicking in the app continues to update `LAST_ACTIVE_TIMESTAMP_EPOCH_MS` in local storage

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
