### PR TITLE
[no ticket][risk=no] Update devstart.rb to use different temp dir to make colima working

### DIFF
--- a/api/db-cdr/generate-cdr/libproject/devstart.rb
+++ b/api/db-cdr/generate-cdr/libproject/devstart.rb
@@ -40,7 +40,7 @@ def service_account_context_for_bq(project, account)
 
   original_account = get_active_gcloud_account()
   # TODO(RW-3208): Investigate using a temporary / impersonated SA credential instead of a key.
-  key_file = Tempfile.new(["#{account}-key", ".json"], "/tmp")
+  key_file = Tempfile.new(["#{account}-key", ".json"], "/tmp/colima")
   ServiceAccountContext.new(
     project, account, key_file.path).run do
     common.run_inline %W{gcloud auth activate-service-account -q --key-file #{key_file.path}}


### PR DESCRIPTION
Same as https://github.com/all-of-us/workbench/pull/8234

We will mount a volumn in docker and put SA credential in that path.
The current approach does not work with [colima](https://github.com/abiosoft/colima) (Verily bans docker, verily eng can only use colima).
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
