### PR TITLE
[RW-10362][risk=no]  Users who used Absorb can take annual renewal training using Absorb --banner text

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -76,5 +76,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "enableSasGKEApp", source = "config.featureFlags.enableSasGKEApp")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")
   @Mapping(target = "enableGKEAppPausing", source = "config.featureFlags.enableGKEAppPausing")
+  @Mapping(target = "redirectMoodleToAbsorb", source = "config.absorb.redirectMoodleUser")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6868,6 +6868,10 @@ components:
           type: boolean
           default: false
           description: Whether users are allowed to pause GKE applications.
+        redirectMoodleToAbsorb:
+          type: boolean
+          description: Start redirecting Moodle User to Absorb
+          default: false
     RuntimeImage:
       type: object
       properties:

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -72,7 +72,7 @@ export const AccessRenewalNotificationMaybe = (
     boxStyle = {
       backgroundColor: boxColor,
       height: '5.5rem',
-      width: '690px',
+      width: '630px',
     };
   }
 
@@ -80,13 +80,13 @@ export const AccessRenewalNotificationMaybe = (
   const getText = () => {
     if (!redirectMoodleToAbsorb) {
       return (
-        <div>
+        <div style={{ paddingTop: '5px' }}>
           Time for {accessType} renewal. {timeLeft} <br />
           <div style={{ fontWeight: 800 }}>
-            Note: Training will be unavailable from Jan 26 to Feb 5. If you are
-            unable to complete the training by Jan 26, you will need to wait
-            until Feb 5 to begin.
+            Note: Training will be unavailable from Jan 26 to Feb 5.
           </div>
+          If you are unable to complete the training by Jan 26, you will need to
+          wait until Feb 5 to begin.
         </div>
       );
     }

--- a/ui/src/app/pages/signed-in/access-renewal-notification.tsx
+++ b/ui/src/app/pages/signed-in/access-renewal-notification.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { CSSProperties } from 'react';
 
 import { cond } from '@terra-ui-packages/core-utils';
 import { NotificationBanner } from 'app/components/notification-banner';
@@ -8,7 +9,7 @@ import {
   ACCESS_RENEWAL_PATH,
   maybeDaysRemaining,
 } from 'app/utils/access-utils';
-import { profileStore, useStore } from 'app/utils/stores';
+import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
 
 export interface AccessRenewalNotificationProps {
   accessTier: AccessTierShortNames;
@@ -61,22 +62,52 @@ export const AccessRenewalNotificationMaybe = (
   );
 
   const iconStyle = { color: iconColor };
-  const boxStyle = { backgroundColor: boxColor };
   // Must use pathname and search because ACCESS_RENEWAL_PATH includes a path with a search parameter.
   const { pathname, search } = window.location;
   const fullPagePath = pathname + search;
 
+  const { redirectMoodleToAbsorb } = serverConfigStore.get().config;
+  let boxStyle: CSSProperties = { backgroundColor: boxColor };
+  if (!redirectMoodleToAbsorb) {
+    boxStyle = {
+      backgroundColor: boxColor,
+      height: '5.5rem',
+      width: '690px',
+    };
+  }
+
+  // This is temporary, on Feb 05 we will be reverting to the original text
+  const getText = () => {
+    if (!redirectMoodleToAbsorb) {
+      return (
+        <div>
+          Time for {accessType} renewal. {timeLeft} <br />
+          <div style={{ fontWeight: 800 }}>
+            Note: Training will be unavailable from Jan 26 to Feb 5. If you are
+            unable to complete the training by Jan 26, you will need to wait
+            until Feb 5 to begin.
+          </div>
+        </div>
+      );
+    }
+    return `Time for ${accessType} renewal. ${timeLeft}`;
+  };
   // returning null is a way to tell React not to render this component.  `undefined` won't work here.
   return daysRemaining !== undefined ? (
     <NotificationBanner
       dataTestId='access-renewal-notification'
-      text={`Time for ${accessType} renewal. ${timeLeft}`}
+      text={getText()}
       buttonText='Get Started'
       buttonPath={ACCESS_RENEWAL_PATH}
       buttonDisabled={fullPagePath === ACCESS_RENEWAL_PATH}
       bannerTextWidth={
-        props.accessTier === AccessTierShortNames.Registered ? '177px' : '250px'
+        !redirectMoodleToAbsorb
+          ? '410px'
+          : props.accessTier === AccessTierShortNames.Registered
+          ? '177px'
+          : '250px'
       }
+      textStyle={!redirectMoodleToAbsorb ? { paddingBottom: '5.5rem' } : {}}
       {...{ boxStyle, iconStyle }}
     />
   ) : null;

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -78,6 +78,7 @@ const defaultServerConfig: ConfigResponse = {
   enableSasGKEApp: true,
   tanagraBaseUrl: 'https://test.fake-research-aou.org',
   enableGKEAppPausing: false,
+  redirectMoodleToAbsorb: true,
 };
 
 export default defaultServerConfig;


### PR DESCRIPTION
With the next release all the users who are eligible for access module update will start seeing the following banner:
<img width="1493" alt="Screenshot 2024-01-12 at 11 49 48 AM" src="https://github.com/all-of-us/workbench/assets/34481816/5ed41b50-c8e2-49b2-9a62-727b3351476d">


As soon as the FF redirectMoodleToAbsorb is turned ON i.e all users will start using Absorb the banner text will revert to the original text

How to test:
1) With feature flag redirectMoodleToAbsorb true (default in local/test) there should be no change in access module banner

2) With feature flag redirectMoodleToAbsorb false there should be a change in text as in screenshot

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
