### PR TITLE
[no ticket][risk=no] bumping index for variant search in cohort builder

### DIFF
--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -185,7 +185,7 @@
       "creationTime": "2022-11-15 00:00:00Z",
       "releaseNumber": 10,
       "numParticipants": 413457,
-      "cdrDbName": "c_2022q4_13",
+      "cdrDbName": "c_2022q4_15",
       "hasFitbitData": true,
       "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,


### PR DESCRIPTION
bumping index for variant search in cohort builder.

@tarekmamdouh Appears you are the release eng next week. Please run the following commands from api directory before deploying the release to prod:

Variant search in cohort builder
Publish C2022Q4R11
db-cdr/generate-cdr/project.rb publish-cdr --project all-of-us-rw-prod --bq-dataset C2022Q4R11 --tier controlled --table-prefixes cb_