### PR TITLE
Revert "[risk=no][no ticket] Add the libyear gradle plugin (#8290)"

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -54,7 +54,6 @@ plugins {
     id 'org.owasp.dependencycheck' version '8.4.2'
     id 'org.springframework.boot' version '2.7.4'
     id 'jacoco'
-    id 'com.libyear.libyear-gradle-plugin' version "0.1.7"
 }
 
 // keep in sync with:
@@ -724,13 +723,6 @@ task listProjectAPIs(type: GenerateAPIListingTask)
 // XML file under src/main/webapp/WEB-INF/appengine-web.xml
 def db_host = System.getenv("DB_HOST")
 def db_port = System.getenv("DB_PORT")
-
-// run with "./gradlew reportLibyears"
-libyear {
-    configurations = ['compileClasspath']
-    failOnError = false // necessary for sam-client
-    validator = singleArtifactMustNotBeOlderThan(years(15))
-}
 
 // See project.rb command: fetch-firecloud-user-profiles
 task fetchFireCloudUserProfile(type: JavaExec) {


### PR DESCRIPTION
`libyear` seems to be causing `dev-up` slowdowns.  Not sure if it provides enough value to justify this - let's discuss.

This reverts commit f735d6432dba57124c470fbd2afb362759f8dce8.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
