### PR TITLE
[risk=low][no ticket] Allow users to delete pausing/resuming runtimes

### DIFF
--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -23,6 +23,7 @@ import {
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
 import { GKE_APP_PROXY_PATH_SUFFIX } from 'app/utils/constants';
 import { currentWorkspaceStore } from 'app/utils/navigation';
+import { canDeleteStatuses } from 'app/utils/runtime-utils';
 import { runtimeStore, serverConfigStore } from 'app/utils/stores';
 import { appTypeToString } from 'app/utils/user-apps-utils';
 import {
@@ -173,13 +174,6 @@ describe('ExpandedApp', () => {
       }
     );
 
-    const canDeleteStatuses = [
-      RuntimeStatus.RUNNING,
-      RuntimeStatus.STOPPED,
-      RuntimeStatus.STOPPING,
-      RuntimeStatus.STARTING,
-      RuntimeStatus.ERROR,
-    ];
     test.each(canDeleteStatuses)(
       'should allow deletion when the Jupyter app status is %s',
       async (status) => {

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -176,6 +176,8 @@ describe('ExpandedApp', () => {
     const canDeleteStatuses = [
       RuntimeStatus.RUNNING,
       RuntimeStatus.STOPPED,
+      RuntimeStatus.STOPPING,
+      RuntimeStatus.STARTING,
       RuntimeStatus.ERROR,
     ];
     test.each(canDeleteStatuses)(

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.spec.tsx
@@ -2,11 +2,12 @@ import '@testing-library/jest-dom';
 
 import * as React from 'react';
 
-import { DiskType, RuntimeStatus } from 'generated/fetch';
+import { DiskType } from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { toAnalysisConfig } from 'app/utils/analysis-config';
+import { canDeleteStatuses } from 'app/utils/runtime-utils';
 import { serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
@@ -210,13 +211,6 @@ describe(CustomizePanelFooter.name, () => {
     });
   });
 
-  const canDeleteStatuses = [
-    RuntimeStatus.RUNNING,
-    RuntimeStatus.STOPPED,
-    RuntimeStatus.STOPPING,
-    RuntimeStatus.STARTING,
-    RuntimeStatus.ERROR,
-  ];
   test.each(canDeleteStatuses)(
     'it allows deleting the environment when a runtime is %s and no detached PD exists',
     async (status) => {

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.spec.tsx
@@ -28,7 +28,6 @@ const gcePersistentDisk = stubDisk();
 const analysisConfig = toAnalysisConfig(currentRuntime, gcePersistentDisk);
 const existingAnalysisConfig = analysisConfig;
 const defaultProps: CustomizePanelFooterProps = {
-  disableControls: false,
   runtimeCanBeCreated: false,
   runtimeCanBeUpdated: false,
   runtimeExists: false,
@@ -214,6 +213,8 @@ describe(CustomizePanelFooter.name, () => {
   const canDeleteStatuses = [
     RuntimeStatus.RUNNING,
     RuntimeStatus.STOPPED,
+    RuntimeStatus.STOPPING,
+    RuntimeStatus.STARTING,
     RuntimeStatus.ERROR,
   ];
   test.each(canDeleteStatuses)(
@@ -251,20 +252,6 @@ describe(CustomizePanelFooter.name, () => {
       await waitFor(() => expect(setPanelContent).not.toHaveBeenCalled());
     }
   );
-
-  it('does not allow deleting the environment when controls are disabled', async () => {
-    await component({
-      runtimeExists: true,
-      unattachedPdExists: false,
-      disableControls: true,
-    });
-    const deleteButton = screen.queryByRole('button', {
-      name: 'Delete Environment',
-    });
-    expect(deleteButton).toBeInTheDocument();
-    deleteButton.click();
-    await waitFor(() => expect(setPanelContent).not.toHaveBeenCalled());
-  });
 
   it.each([
     [

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
@@ -15,7 +15,6 @@ import { canDeleteRuntime } from 'app/utils/runtime-utils';
 import { PanelContent } from './utils';
 
 export interface CustomizePanelFooterProps {
-  disableControls: boolean;
   runtimeCanBeCreated: boolean;
   runtimeCannotBeCreatedExplanation?: string;
   runtimeCanBeUpdated: boolean;
@@ -31,7 +30,6 @@ export interface CustomizePanelFooterProps {
   setPanelContent: (pc: PanelContent) => void;
 }
 export const CustomizePanelFooter = ({
-  disableControls,
   runtimeCanBeCreated,
   runtimeCannotBeCreatedExplanation,
   runtimeCanBeUpdated,
@@ -95,12 +93,12 @@ export const CustomizePanelFooter = ({
       <LinkButton
         style={{
           ...styles.deleteLink,
-          ...(disableControls || !canDeleteRuntime(currentRuntime?.status)
+          ...(!canDeleteRuntime(currentRuntime?.status)
             ? { color: colorWithWhiteness(colors.dark, 0.4) }
             : {}),
         }}
         aria-label='Delete Environment'
-        disabled={disableControls || !canDeleteRuntime(currentRuntime?.status)}
+        disabled={!canDeleteRuntime(currentRuntime?.status)}
         onClick={() => setPanelContent(PanelContent.DeleteRuntime)}
       >
         Delete Environment

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -335,7 +335,6 @@ export const CustomizePanel = ({
         {...{
           analysisConfig,
           currentRuntime,
-          disableControls,
           existingAnalysisConfig,
           onClose,
           requestAnalysisConfig,

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -157,6 +157,7 @@ export const isVisible = (status: RuntimeStatus) =>
   ).includes(status);
 
 // can the user delete the runtime?
+// matches Leonardo code - ClusterStatus.deletableStatuses
 export const canDeleteRuntime = (status: RuntimeStatus) =>
   (
     [
@@ -165,6 +166,8 @@ export const canDeleteRuntime = (status: RuntimeStatus) =>
       RuntimeStatus.ERROR,
       RuntimeStatus.STARTING,
       RuntimeStatus.STOPPING,
+      RuntimeStatus.UNKNOWN,
+      RuntimeStatus.ERROR,
     ] as Array<RuntimeStatus>
   ).includes(status);
 

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -163,6 +163,8 @@ export const canDeleteRuntime = (status: RuntimeStatus) =>
       RuntimeStatus.RUNNING,
       RuntimeStatus.STOPPED,
       RuntimeStatus.ERROR,
+      RuntimeStatus.STARTING,
+      RuntimeStatus.STOPPING,
     ] as Array<RuntimeStatus>
   ).includes(status);
 

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -157,19 +157,18 @@ export const isVisible = (status: RuntimeStatus) =>
   ).includes(status);
 
 // can the user delete the runtime?
-// matches Leonardo code - ClusterStatus.deletableStatuses
+// matches deletableStatuses in https://github.com/DataBiosphere/leonardo/blob/7bb268a685bf90f5a2dcbb0f751e5bb786525abe/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala
+export const canDeleteStatuses: RuntimeStatus[] = [
+  RuntimeStatus.RUNNING,
+  RuntimeStatus.STOPPED,
+  RuntimeStatus.ERROR,
+  RuntimeStatus.STARTING,
+  RuntimeStatus.STOPPING,
+  RuntimeStatus.UNKNOWN,
+  RuntimeStatus.ERROR,
+];
 export const canDeleteRuntime = (status: RuntimeStatus) =>
-  (
-    [
-      RuntimeStatus.RUNNING,
-      RuntimeStatus.STOPPED,
-      RuntimeStatus.ERROR,
-      RuntimeStatus.STARTING,
-      RuntimeStatus.STOPPING,
-      RuntimeStatus.UNKNOWN,
-      RuntimeStatus.ERROR,
-    ] as Array<RuntimeStatus>
-  ).includes(status);
+  canDeleteStatuses.includes(status);
 
 // can the user update the runtime?
 export const canUpdateRuntime = (status: RuntimeStatus) =>


### PR DESCRIPTION
Support asked for this change, and it seems to work.  Tested locally.

Confirmed with the Leonardo team that this was appropriate: https://broadinstitute.slack.com/archives/C046XJD9MPW/p1706736760281869

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
