### PR TITLE
[DT-699][risk=no] Add number inputs for variant filter sliders

### DIFF
--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
 import { Dropdown } from 'primereact/dropdown';
+import { Slider } from 'primereact/slider';
 import Nouislider from 'nouislider-react';
 
 import {
@@ -148,6 +149,10 @@ const VariantFilters = ({
   clearFn: Function;
   submitFn: Function;
 }) => {
+  let slider: {
+    get: () => Array<string>;
+    set: (values: Array<number>) => void;
+  };
   const [expanded, setExpanded] = useState([]);
 
   const toggleExpanded = (section: string) =>
@@ -294,32 +299,45 @@ const VariantFilters = ({
             />
           </Clickable>
           {expanded.includes('alleleCount') && (
-            <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
-              <Nouislider
-                style={{ marginTop: '3rem' }}
-                behaviour='drag'
-                onEnd={(value) =>
-                  sliderFn(
-                    ['countMin', 'countMax'],
-                    value.map((val) => +val)
-                  )
-                }
-                range={{
-                  min: filters.countMin,
-                  max:
-                    // Prevent Nouislider slider error if min/max are the same
-                    filters.countMax === filters.countMin
-                      ? filters.countMax + 1
-                      : filters.countMax,
-                }}
-                start={[
-                  formState.countMin ?? filters.countMin,
-                  formState.countMax ?? filters.countMax,
-                ]}
-                tooltips
-                connect
-              />
-            </div>
+            <>
+              <div style={{ marginBottom: '1rem' }}>
+                <input
+                  style={{ width: '4rem' }}
+                  type='number'
+                  value={formState.countMin ?? filters.countMin}
+                  onChange={(e) =>
+                    sliderFn(
+                      ['countMin', 'countMax'],
+                      [e.target.value, formState.countMax ?? filters.countMax]
+                    )
+                  }
+                />
+                <input
+                  style={{ float: 'right', width: '4rem' }}
+                  type='number'
+                  value={formState.countMax ?? filters.countMax}
+                  onChange={(e) =>
+                    sliderFn(
+                      ['countMin', 'countMax'],
+                      [formState.countMin ?? filters.countMin, e.target.value]
+                    )
+                  }
+                />
+              </div>
+              <div style={{ height: '2rem', margin: 'auto', width: '90%' }}>
+                <Slider
+                  style={{ maxWidth: '100%' }}
+                  value={[
+                    formState.countMin ?? filters.countMin,
+                    formState.countMax ?? filters.countMax,
+                  ]}
+                  min={filters.countMin}
+                  max={filters.countMax}
+                  onChange={(e) => sliderFn(['countMin', 'countMax'], e.value)}
+                  range
+                />
+              </div>
+            </>
           )}
         </div>
         <div style={{ color: colors.primary, fontSize: '12px' }}>
@@ -334,32 +352,64 @@ const VariantFilters = ({
             />
           </Clickable>
           {expanded.includes('alleleNumber') && (
-            <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
-              <Nouislider
-                style={{ marginTop: '3rem' }}
-                behaviour='drag'
-                onEnd={(value) =>
-                  sliderFn(
-                    ['numberMin', 'numberMax'],
-                    value.map((val) => +val)
-                  )
-                }
-                range={{
-                  min: filters.numberMin,
-                  max:
-                    // Prevent Nouislider slider error if min/max are the same
-                    filters.numberMax === filters.numberMin
-                      ? filters.numberMax + 1
-                      : filters.numberMax,
-                }}
-                start={[
-                  formState.numberMin ?? filters.numberMin,
-                  formState.numberMax ?? filters.numberMax,
-                ]}
-                tooltips
-                connect
-              />
-            </div>
+            <>
+              <div style={{ marginBottom: '1rem' }}>
+                <input
+                  style={{ width: '4rem' }}
+                  type='number'
+                  value={formState.numberMin ?? filters.numberMin}
+                  onChange={(e) => {
+                    console.log(e.target.value);
+                    console.log(+e.target.value >= filters.numberMin);
+                    console.log(+e.target.value <= filters.numberMax);
+                    console.log(+e.target.value >= filters.numberMin &&
+                      +e.target.value <= filters.numberMax);
+                    if (
+                      +e.target.value >= filters.numberMin &&
+                      +e.target.value <= filters.numberMax
+                    ) {
+                      sliderFn(
+                        ['numberMin', 'numberMax'],
+                        [
+                          e.target.value,
+                          formState.numberMax ?? filters.numberMax,
+                        ]
+                      );
+                    }
+                  }}
+                  min={filters.numberMin}
+                  max={filters.numberMax}
+                />
+                <input
+                  style={{ float: 'right', width: '4rem' }}
+                  type='number'
+                  value={formState.numberMax ?? filters.numberMax}
+                  onChange={(e) =>
+                    sliderFn(
+                      ['numberMin', 'numberMax'],
+                      [formState.numberMin ?? filters.numberMin, e.target.value]
+                    )
+                  }
+                  min={filters.numberMin}
+                  max={filters.numberMax}
+                />
+              </div>
+              <div style={{ height: '2rem', margin: 'auto', width: '90%' }}>
+                <Slider
+                  style={{ maxWidth: '100%' }}
+                  value={[
+                    formState.numberMin ?? filters.numberMin,
+                    formState.numberMax ?? filters.numberMax,
+                  ]}
+                  min={filters.numberMin}
+                  max={filters.numberMax}
+                  onChange={(e) =>
+                    sliderFn(['numberMin', 'numberMax'], e.value)
+                  }
+                  range
+                />
+              </div>
+            </>
           )}
         </div>
         <div style={{ color: colors.primary, fontSize: '12px' }}>
@@ -374,32 +424,53 @@ const VariantFilters = ({
             />
           </Clickable>
           {expanded.includes('alleleFrequency') && (
-            <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
-              <Nouislider
-                style={{ marginTop: '3rem' }}
-                behaviour='drag'
-                onEnd={(value) =>
-                  sliderFn(
-                    ['frequencyMin', 'frequencyMax'],
-                    value.map((val) => +val)
-                  )
-                }
-                range={{
-                  min: filters.frequencyMin,
-                  max:
-                    // Prevent Nouislider slider error if min/max are the same
-                    filters.frequencyMax === filters.frequencyMin
-                      ? filters.frequencyMax + 1
-                      : filters.frequencyMax,
-                }}
-                start={[
-                  formState.frequencyMin ?? filters.frequencyMin,
-                  formState.frequencyMax ?? filters.frequencyMax,
-                ]}
-                tooltips
-                connect
-              />
-            </div>
+            <>
+              <div style={{ marginBottom: '1rem' }}>
+                <input
+                  style={{ width: '4rem' }}
+                  type='number'
+                  value={formState.frequencyMin ?? filters.frequencyMin}
+                  onChange={(e) =>
+                    sliderFn(
+                      ['frequencyMin', 'frequencyMax'],
+                      [
+                        e.target.value,
+                        formState.frequencyMax ?? filters.frequencyMax,
+                      ]
+                    )
+                  }
+                />
+                <input
+                  style={{ float: 'right', width: '4rem' }}
+                  type='number'
+                  value={formState.frequencyMax ?? filters.frequencyMax}
+                  onChange={(e) =>
+                    sliderFn(
+                      ['frequencyMin', 'frequencyMax'],
+                      [
+                        formState.frequencyMin ?? filters.frequencyMin,
+                        e.target.value,
+                      ]
+                    )
+                  }
+                />
+              </div>
+              <div style={{ height: '2rem', margin: 'auto', width: '90%' }}>
+                <Slider
+                  style={{ maxWidth: '100%' }}
+                  value={[
+                    formState.frequencyMin ?? filters.frequencyMin,
+                    formState.frequencyMax ?? filters.frequencyMax,
+                  ]}
+                  min={filters.frequencyMin}
+                  max={filters.frequencyMax}
+                  onChange={(e) =>
+                    sliderFn(['frequencyMin', 'frequencyMax'], e.value)
+                  }
+                  range
+                />
+              </div>
+            </>
           )}
         </div>
         <div style={{ color: colors.primary, fontSize: '12px' }}>

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -131,21 +131,6 @@ const searchTooltip = (
   </div>
 );
 
-interface SliderRef {
-  get: () => Array<string>;
-  set: (values: Array<number>) => void;
-}
-let countSlider: SliderRef;
-const sliderRefs: {
-  count: SliderRef,
-  number: SliderRef,
-  frequency: SliderRef,
-} = {
-  count: null,
-  number: null,
-  frequency: null,
-};
-
 const VariantFilters = ({
   filters,
   formState,
@@ -214,9 +199,7 @@ const VariantFilters = ({
       ...prevState,
       [`${sliderName}Min`]: blur ? newValue : value,
     }));
-    sliderFn([`${sliderName}Min`, `${sliderName}Max`], [newValue, range[1]]);
-    console.log(sliderRefs[sliderName]);
-    sliderRefs[sliderName].set([newValue, null]);
+    sliderFn(sliderName, [newValue, range[1]]);
   };
 
   const handleMaxInputChange = (
@@ -235,13 +218,8 @@ const VariantFilters = ({
       ...prevState,
       [`${sliderName}Max`]: blur ? newValue : value,
     }));
-    sliderFn([`${sliderName}Min`, `${sliderName}Max`], [range[0], newValue]);
-    sliderRefs[sliderName].set([null, newValue]);
+    sliderFn(sliderName, [range[0], newValue]);
   };
-
-  const handleMinInputBlur = () => {};
-
-  const handleMaxInputBlur = () => {};
 
   return (
     <div
@@ -383,7 +361,7 @@ const VariantFilters = ({
             <>
               <div style={{ marginBottom: '1rem' }}>
                 <input
-                  style={{ width: '4rem' }}
+                  style={{ width: '5rem' }}
                   type='number'
                   value={sliderInputState.countMin}
                   min={filters.countMin}
@@ -405,7 +383,7 @@ const VariantFilters = ({
                   }
                 />
                 <input
-                  style={{ float: 'right', width: '4rem' }}
+                  style={{ float: 'right', width: '5rem' }}
                   type='number'
                   value={sliderInputState.countMax}
                   min={sliderInputState.countMin}
@@ -427,22 +405,15 @@ const VariantFilters = ({
                   }
                 />
               </div>
-              <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
+              <div style={{ height: '2rem', margin: 'auto', width: '85%' }}>
                 <Nouislider
-                  style={{ marginTop: '3rem' }}
                   behaviour='drag'
-                  instanceRef={(ref) => {
-                    console.dir(ref);
-                    console.log(ref['noUiSlider']);
-                    sliderRefs.count = ref['noUiSlider'];
-                  }}
                   onSlide={(value) =>
                     sliderFn(
-                      ['countMin', 'countMax'],
+                      'count',
                       value.map((val) => +val)
                     )
                   }
-                  tooltips
                   range={{
                     min: filters.countMin,
                     max:
@@ -452,8 +423,8 @@ const VariantFilters = ({
                         : filters.countMax,
                   }}
                   start={[
-                    filters.countMin,
-                    filters.countMax,
+                    formState.countMin ?? filters.countMin,
+                    formState.countMax ?? filters.countMax,
                   ]}
                   connect
                 />
@@ -476,54 +447,56 @@ const VariantFilters = ({
             <>
               <div style={{ marginBottom: '1rem' }}>
                 <input
-                  style={{ width: '4rem' }}
+                  style={{ width: '5rem' }}
                   type='number'
-                  value={formState.numberMin ?? filters.numberMin}
-                  onChange={(e) => {
-                    console.log(e.target.value);
-                    console.log(+e.target.value >= filters.numberMin);
-                    console.log(+e.target.value <= filters.numberMax);
-                    console.log(
-                      +e.target.value >= filters.numberMin &&
-                        +e.target.value <= filters.numberMax
-                    );
-                    if (
-                      +e.target.value >= filters.numberMin &&
-                      +e.target.value <= filters.numberMax
-                    ) {
-                      sliderFn(
-                        ['numberMin', 'numberMax'],
-                        [
-                          e.target.value,
-                          formState.numberMax ?? filters.numberMax,
-                        ]
-                      );
-                    }
-                  }}
+                  value={sliderInputState.numberMin}
                   min={filters.numberMin}
-                  max={filters.numberMax}
-                />
-                <input
-                  style={{ float: 'right', width: '4rem' }}
-                  type='number'
-                  value={formState.numberMax ?? filters.numberMax}
+                  max={sliderInputState.numberMax}
                   onChange={(e) =>
-                    sliderFn(
-                      ['numberMin', 'numberMax'],
-                      [formState.numberMin ?? filters.numberMin, e.target.value]
+                    handleMinInputChange(
+                      'number',
+                      [filters.numberMin, sliderInputState.numberMax],
+                      e.target.value
                     )
                   }
-                  min={filters.numberMin}
+                  onBlur={(e) =>
+                    handleMinInputChange(
+                      'number',
+                      [filters.numberMin, sliderInputState.numberMax],
+                      e.target.value,
+                      true
+                    )
+                  }
+                />
+                <input
+                  style={{ float: 'right', width: '5rem' }}
+                  type='number'
+                  value={sliderInputState.numberMax}
+                  min={sliderInputState.numberMin}
                   max={filters.numberMax}
+                  onChange={(e) =>
+                    handleMaxInputChange(
+                      'number',
+                      [sliderInputState.numberMin, filters.numberMax],
+                      e.target.value
+                    )
+                  }
+                  onBlur={(e) =>
+                    handleMaxInputChange(
+                      'number',
+                      [sliderInputState.numberMin, filters.numberMax],
+                      e.target.value,
+                      true
+                    )
+                  }
                 />
               </div>
-              <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
+              <div style={{ height: '2rem', margin: 'auto', width: '85%' }}>
                 <Nouislider
-                  style={{ marginTop: '3rem' }}
                   behaviour='drag'
-                  onEnd={(value) =>
+                  onSlide={(value) =>
                     sliderFn(
-                      ['numberMin', 'numberMax'],
+                      'number',
                       value.map((val) => +val)
                     )
                   }
@@ -539,7 +512,6 @@ const VariantFilters = ({
                     formState.numberMin ?? filters.numberMin,
                     formState.numberMax ?? filters.numberMax,
                   ]}
-                  tooltips
                   connect
                 />
               </div>
@@ -561,41 +533,56 @@ const VariantFilters = ({
             <>
               <div style={{ marginBottom: '1rem' }}>
                 <input
-                  style={{ width: '4rem' }}
+                  style={{ width: '5rem' }}
                   type='number'
-                  value={formState.frequencyMin ?? filters.frequencyMin}
+                  value={sliderInputState.frequencyMin}
+                  min={filters.frequencyMin}
+                  max={sliderInputState.frequencyMax}
                   onChange={(e) =>
-                    sliderFn(
-                      ['frequencyMin', 'frequencyMax'],
-                      [
-                        e.target.value,
-                        formState.frequencyMax ?? filters.frequencyMax,
-                      ]
+                    handleMinInputChange(
+                      'frequency',
+                      [filters.frequencyMin, sliderInputState.frequencyMax],
+                      e.target.value
+                    )
+                  }
+                  onBlur={(e) =>
+                    handleMinInputChange(
+                      'frequency',
+                      [filters.frequencyMin, sliderInputState.frequencyMax],
+                      e.target.value,
+                      true
                     )
                   }
                 />
                 <input
-                  style={{ float: 'right', width: '4rem' }}
+                  style={{ float: 'right', width: '5rem' }}
                   type='number'
-                  value={formState.frequencyMax ?? filters.frequencyMax}
+                  value={sliderInputState.frequencyMax}
+                  min={sliderInputState.frequencyMin}
+                  max={filters.frequencyMax}
                   onChange={(e) =>
-                    sliderFn(
-                      ['frequencyMin', 'frequencyMax'],
-                      [
-                        formState.frequencyMin ?? filters.frequencyMin,
-                        e.target.value,
-                      ]
+                    handleMaxInputChange(
+                      'frequency',
+                      [sliderInputState.frequencyMin, filters.frequencyMax],
+                      e.target.value
+                    )
+                  }
+                  onBlur={(e) =>
+                    handleMaxInputChange(
+                      'frequency',
+                      [sliderInputState.frequencyMin, filters.frequencyMax],
+                      e.target.value,
+                      true
                     )
                   }
                 />
               </div>
-              <div style={{ height: '2rem', margin: 'auto', width: '80%' }}>
+              <div style={{ height: '2rem', margin: 'auto', width: '85%' }}>
                 <Nouislider
-                  style={{ marginTop: '3rem' }}
                   behaviour='drag'
-                  onEnd={(value) =>
+                  onSlide={(value) =>
                     sliderFn(
-                      ['frequencyMin', 'frequencyMax'],
+                      'frequency',
                       value.map((val) => +val)
                     )
                   }
@@ -611,7 +598,6 @@ const VariantFilters = ({
                     formState.frequencyMin ?? filters.frequencyMin,
                     formState.frequencyMax ?? filters.frequencyMax,
                   ]}
-                  tooltips
                   connect
                 />
               </div>
@@ -820,11 +806,11 @@ export const VariantSearch = withCurrentWorkspace()(
           : prevState[filter].filter((val) => val !== name),
       }));
 
-    const handleSliderChange = (filters: string[], range: number[]) =>
+    const handleSliderChange = (filterName: string, range: number[]) =>
       setSelectedFilters((prevState) => ({
         ...prevState,
-        [filters[0]]: range[0],
-        [filters[1]]: range[1],
+        [`${filterName}Min`]: range[0],
+        [`${filterName}Max`]: range[1],
       }));
 
     const handleSortByChange = (value: string) =>


### PR DESCRIPTION
Add number inputs for min and max for each slider in the variant filters
<img width="712" alt="Screenshot 2024-01-19 at 12 25 47 PM" src="https://github.com/all-of-us/workbench/assets/40036095/0f30a667-a9f5-4966-bebc-645b7d040491">

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
