### PR TITLE
[risk=low][no ticket] Replace deprecated CircleCI images for e2ev2 and playground

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,7 @@ jobs:
   # Playground job. Re-run with ssh enabled to play with Circle's machine image.
   playground:
     machine:
-      image: ubuntu-2204:2022.04.1
+      image: default # latest stable version
     steps:
       - run:
           name: Echo
@@ -597,7 +597,7 @@ jobs:
 
   e2etests-deploy-ui:
     machine:
-      image: ubuntu-2204:2022.04.1
+      image: default # latest stable version
     environment:
       PR_SITE_COUNT: 10
     steps:
@@ -628,7 +628,7 @@ jobs:
             ./src/circle-deploy.sh
   e2etests-run:
     machine:
-      image: ubuntu-2204:2022.04.1
+      image: default # latest stable version
     environment:
       PR_SITE_COUNT: 10
     steps:

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -74,7 +74,6 @@ export interface Environment extends EnvironmentBase {
   // Indicates that the current server is a local server where client-side
   // debugging should be enabled (e.g. console.log, or devtools APIs).
   debug: boolean;
-
   // A prefix to add to the site title (shown in the tab title).
   // Example value: 'Test' would cause the following full title:
   // "Homepage | [Test] All of Us Researcher Workbench"


### PR DESCRIPTION
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

No expected changes.  If e2ev2 tests run and pass, we can merge this.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
