### PR TITLE
[noTicket][risk=none] Create colima directory  only if it does'nt exist

### DIFF
--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -104,8 +104,9 @@ def setup_and_enter_docker(cmd_name, opts)
 
   # By default Tempfile on OS X does not use a docker-friendly location/
   # use /tmp/colima to make it work with colima, see https://github.com/abiosoft/colima/issues/844 for more details
-  Dir.mkdir("/tmp/colima");
-  key_file = Tempfile.new(["#{opts.account}-key", ".json"], "/tmp/colima")
+  colima_path = "/tmp/colima"
+  Dir.mkdir(colima_path) unless File.exists?(colima_path)
+  key_file = Tempfile.new(["#{opts.account}-key", ".json"], colima_path)
   ServiceAccountContext.new(
     opts.project, opts.account, key_file.path).run do
     common.run_inline %W{docker-compose build deploy}


### PR DESCRIPTION
The existing script fails if the directory /tmp/colima exisit. Update the script to create the directory ONLY if it doesnt exist.

Tested by trying create the script twice 
 ./project.rb deploy --project all-of-us-rw-stable --account deploy@all-of-us-rw-stable.iam.gserviceaccount.com --no-promote --dry-run

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
