### PR TITLE
[risk=low][no ticket] Open RStudio/SAS from config panels

### DIFF
--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -3,18 +3,11 @@ import { useEffect, useState } from 'react';
 
 import { BillingStatus, Workspace } from 'generated/fetch';
 
-import { switchCase } from '@terra-ui-packages/core-utils';
 import { Clickable, CloseButton } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
-import {
-  cromwellConfigIconId,
-  rstudioConfigIconId,
-  sasConfigIconId,
-  SidebarIconId,
-} from 'app/components/help-sidebar-icons';
+import { SidebarIconId } from 'app/components/help-sidebar-icons';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import {
   runtimeStore,
   serverConfigStore,
@@ -26,7 +19,12 @@ import { maybeStartPollingForUserApps } from 'app/utils/user-apps-utils';
 
 import { AppBanner } from './apps-panel/app-banner';
 import { ExpandedApp } from './apps-panel/expanded-app';
-import { findApp, getAppsByDisplayGroup, UIAppType } from './apps-panel/utils';
+import {
+  findApp,
+  getAppsByDisplayGroup,
+  openConfigPanelForUIApp,
+  UIAppType,
+} from './apps-panel/utils';
 import { TooltipTrigger } from './popups';
 
 const styles = reactStyles({
@@ -169,26 +167,9 @@ export const AppsPanel = (props: {
                       workspace.billingStatus === BillingStatus.INACTIVE
                     }
                     onClick={() =>
-                      switchCase(
-                        availableApp.appType,
-                        [
-                          UIAppType.CROMWELL,
-                          () =>
-                            setSidebarActiveIconStore.next(
-                              cromwellConfigIconId
-                            ),
-                        ],
-                        [
-                          UIAppType.RSTUDIO,
-                          () =>
-                            setSidebarActiveIconStore.next(rstudioConfigIconId),
-                        ],
-                        [
-                          UIAppType.SAS,
-                          () => setSidebarActiveIconStore.next(sasConfigIconId),
-                        ],
-                        () => addToExpandedApps(availableApp.appType)
-                      )
+                      availableApp.appType === UIAppType.JUPYTER
+                        ? addToExpandedApps(availableApp.appType)
+                        : openConfigPanelForUIApp(availableApp.appType)
                     }
                   />
                 </div>

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -31,7 +31,7 @@ import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import {
   currentWorkspaceStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
   useNavigation,
 } from 'app/utils/navigation';
 import { useRuntimeStatus } from 'app/utils/runtime-hooks';
@@ -179,7 +179,7 @@ const RStudioButtonRow = (props: {
   const { namespace, id } = currentWorkspaceStore.getValue();
   const onClickLaunch = async () => {
     openAppInIframe(namespace, id, userApp, navigate);
-    setSidebarActiveIconStore.next(null);
+    sidebarActiveIconStore.next(null);
   };
   const launchButtonDisabled =
     billingAccountDisabled || userApp?.status !== AppStatus.RUNNING;
@@ -221,7 +221,7 @@ const SASButtonRow = (props: {
 
   const onClickLaunch = async () => {
     openAppInIframe(namespace, id, userApp, navigate);
-    setSidebarActiveIconStore.next(null);
+    sidebarActiveIconStore.next(null);
   };
 
   const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -14,8 +14,7 @@ import {
   Workspace,
 } from 'generated/fetch';
 
-import { cond } from '@terra-ui-packages/core-utils';
-import { switchCase } from '@terra-ui-packages/core-utils';
+import { cond, switchCase } from '@terra-ui-packages/core-utils';
 import { AppStatusIndicator } from 'app/components/app-status-indicator';
 import { DeleteCromwellConfirmationModal } from 'app/components/apps-panel/delete-cromwell-modal';
 import { Clickable } from 'app/components/buttons';
@@ -30,11 +29,7 @@ import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import {
-  currentWorkspaceStore,
-  setSidebarActiveIconStore,
-  useNavigation,
-} from 'app/utils/navigation';
+import { currentWorkspaceStore, useNavigation } from 'app/utils/navigation';
 import { useRuntimeStatus } from 'app/utils/runtime-hooks';
 import {
   canDeleteRuntime,
@@ -58,6 +53,7 @@ import {
   fromRuntimeStatus,
   fromUserAppStatus,
   fromUserAppStatusWithFallback,
+  openConfigPanelForUIApp,
   UIAppType,
 } from './utils';
 
@@ -162,7 +158,7 @@ const CromwellButtonRow = (props: {
   return (
     <FlexRow>
       <SettingsButton
-        onClick={() => setSidebarActiveIconStore.next(cromwellConfigIconId)}
+        onClick={() => openConfigPanelForUIApp(UIAppType.CROMWELL)}
         data-test-id='Cromwell-settings-button'
       />
       <PauseUserAppButton {...{ userApp, workspaceNamespace }} />
@@ -191,9 +187,7 @@ const RStudioButtonRow = (props: {
   return (
     <FlexRow>
       <SettingsButton
-        onClick={() => {
-          setSidebarActiveIconStore.next(rstudioConfigIconId);
-        }}
+        onClick={() => openConfigPanelForUIApp(UIAppType.RSTUDIO)}
       />
       <PauseUserAppButton userApp={userApp} workspaceNamespace={namespace} />
       <TooltipTrigger disabled={!launchButtonDisabled} content={tooltip}>
@@ -228,11 +222,7 @@ const SASButtonRow = (props: {
 
   return (
     <FlexRow>
-      <SettingsButton
-        onClick={() => {
-          setSidebarActiveIconStore.next(sasConfigIconId);
-        }}
-      />
+      <SettingsButton onClick={() => openConfigPanelForUIApp(UIAppType.SAS)} />
       <PauseUserAppButton userApp={userApp} workspaceNamespace={namespace} />
       <TooltipTrigger
         disabled={!launchButtonDisabled}

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -29,7 +29,11 @@ import { TooltipTrigger } from 'app/components/popups';
 import { RuntimeStatusIndicator } from 'app/components/runtime-status-indicator';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import { currentWorkspaceStore, useNavigation } from 'app/utils/navigation';
+import {
+  currentWorkspaceStore,
+  setSidebarActiveIconStore,
+  useNavigation,
+} from 'app/utils/navigation';
 import { useRuntimeStatus } from 'app/utils/runtime-hooks';
 import {
   canDeleteRuntime,

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -270,17 +270,13 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
       ? canDeleteRuntime(runtime?.status)
       : canDeleteApp(initialUserAppInfo);
 
-  const displayCromwellDeleteModal = () => {
-    setShowCromwellDeleteModal(true);
-  };
-
   const billingAccountDisabled =
     workspace.billingStatus === BillingStatus.INACTIVE;
 
   const onClickDelete = switchCase(
     appType,
     [UIAppType.JUPYTER, () => onClickDeleteRuntime],
-    [UIAppType.CROMWELL, () => displayCromwellDeleteModal],
+    [UIAppType.CROMWELL, () => () => setShowCromwellDeleteModal(true)],
     [UIAppType.RSTUDIO, () => () => onClickDeleteGkeApp(rstudioConfigIconId)],
     [UIAppType.SAS, () => () => onClickDeleteGkeApp(sasConfigIconId)]
   );
@@ -309,7 +305,7 @@ export const ExpandedApp = (props: ExpandedAppProps) => {
         }
         <TooltipTrigger
           disabled={trashEnabled}
-          content='Your application must be running in order to be deleted.'
+          content='Your application is not in a deleteable state.'
         >
           <Clickable
             aria-label={`Delete ${appType} Environment`}

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -175,6 +175,7 @@ const RStudioButtonRow = (props: {
   const { namespace, id } = currentWorkspaceStore.getValue();
   const onClickLaunch = async () => {
     openAppInIframe(namespace, id, userApp, navigate);
+    setSidebarActiveIconStore.next(null);
   };
   const launchButtonDisabled =
     billingAccountDisabled || userApp?.status !== AppStatus.RUNNING;
@@ -216,6 +217,7 @@ const SASButtonRow = (props: {
 
   const onClickLaunch = async () => {
     openAppInIframe(namespace, id, userApp, navigate);
+    setSidebarActiveIconStore.next(null);
   };
 
   const launchButtonDisabled = userApp?.status !== AppStatus.RUNNING;

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -18,7 +18,7 @@ import {
   SidebarIconId,
 } from 'app/components/help-sidebar-icons';
 import { DEFAULT_MACHINE_NAME } from 'app/utils/machines';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { sidebarActiveIconStore } from 'app/utils/navigation';
 import * as runtimeUtils from 'app/utils/runtime-utils';
 import cromwellBanner from 'assets/user-apps/Cromwell-banner.png';
 import cromwellIcon from 'assets/user-apps/Cromwell-icon.png';
@@ -152,7 +152,7 @@ export const helpSidebarConfigIdForUIApp: Record<
 };
 
 export const openConfigPanelForUIApp = (appType: UIAppType) =>
-  setSidebarActiveIconStore.next(helpSidebarConfigIdForUIApp[appType]);
+  sidebarActiveIconStore.next(helpSidebarConfigIdForUIApp[appType]);
 
 export const findApp = (
   apps: UserAppEnvironment[] | null | undefined,

--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -12,10 +12,13 @@ import {
 
 import { cond } from '@terra-ui-packages/core-utils';
 import {
+  cromwellConfigIconId,
   rstudioConfigIconId,
   sasConfigIconId,
+  SidebarIconId,
 } from 'app/components/help-sidebar-icons';
 import { DEFAULT_MACHINE_NAME } from 'app/utils/machines';
+import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import * as runtimeUtils from 'app/utils/runtime-utils';
 import cromwellBanner from 'assets/user-apps/Cromwell-banner.png';
 import cromwellIcon from 'assets/user-apps/Cromwell-icon.png';
@@ -140,12 +143,17 @@ export const toUIAppType: Record<AppType, UIAppType> = {
 };
 
 export const helpSidebarConfigIdForUIApp: Record<
-  Exclude<UIAppType, UIAppType.CROMWELL | UIAppType.JUPYTER>,
-  string
+  Exclude<UIAppType, UIAppType.JUPYTER>,
+  SidebarIconId
 > = {
   [UIAppType.SAS]: sasConfigIconId,
   [UIAppType.RSTUDIO]: rstudioConfigIconId,
+  [UIAppType.CROMWELL]: cromwellConfigIconId,
 };
+
+export const openConfigPanelForUIApp = (appType: UIAppType) =>
+  setSidebarActiveIconStore.next(helpSidebarConfigIdForUIApp[appType]);
+
 export const findApp = (
   apps: UserAppEnvironment[] | null | undefined,
   appType: UIAppType

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -29,7 +29,7 @@ import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import {
   appTypeToString,
-  canOpenApp,
+  isInteractiveUserApp,
   unattachedDiskExists,
 } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -174,7 +174,8 @@ export const CreateGkeApp = ({
           </LinkButton>
         )}
         <CreateAppText />
-        {app?.status === AppStatus.RUNNING && canOpenApp(app?.appType) ? (
+        {app?.status === AppStatus.RUNNING &&
+        isInteractiveUserApp(app?.appType) ? (
           <OpenGkeAppButton
             {...{ billingStatus, workspace, onClose }}
             userApp={app}

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {
+  AppStatus,
   AppType,
   CreateAppRequest,
   Disk,
@@ -28,12 +29,14 @@ import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import {
   appTypeToString,
+  canOpenApp,
   unattachedDiskExists,
 } from 'app/utils/user-apps-utils';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { CreateGkeAppButton } from './create-gke-app-button';
 import { DisabledCloudComputeProfile } from './disabled-cloud-compute-profile';
+import { OpenGkeAppButton } from './open-gke-app-button';
 
 const defaultIntroText =
   'Your analysis environment consists of an application and compute resources. ' +
@@ -171,12 +174,16 @@ export const CreateGkeApp = ({
           </LinkButton>
         )}
         <CreateAppText />
-        <CreateGkeAppButton
-          {...{ billingStatus, createAppRequest, onDismiss }}
-          existingApp={app}
-          workspaceNamespace={workspace.namespace}
-          username={profile.username}
-        />
+        {app?.status === AppStatus.RUNNING && canOpenApp(app?.appType) ? (
+          <OpenGkeAppButton {...{ billingStatus, workspace }} userApp={app} />
+        ) : (
+          <CreateGkeAppButton
+            {...{ billingStatus, createAppRequest, onDismiss }}
+            existingApp={app}
+            workspaceNamespace={workspace.namespace}
+            username={profile.username}
+          />
+        )}
       </FlexRow>
     </FlexColumn>
   );

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -25,7 +25,7 @@ import { FlexColumn, FlexRow } from 'app/components/flex';
 import { SidebarIconId } from 'app/components/help-sidebar-icons';
 import { AnalysisConfig } from 'app/utils/analysis-config';
 import { ComputeType, findMachineByName, Machine } from 'app/utils/machines';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { sidebarActiveIconStore } from 'app/utils/navigation';
 import { ProfileStore } from 'app/utils/stores';
 import {
   appTypeToString,
@@ -88,7 +88,7 @@ export const CreateGkeApp = ({
 
   const onDismiss = () => {
     onClose();
-    setTimeout(() => setSidebarActiveIconStore.next('apps'), 3000);
+    setTimeout(() => sidebarActiveIconStore.next('apps'), 3000);
   };
 
   const defaultConfig = switchCase(

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -175,7 +175,10 @@ export const CreateGkeApp = ({
         )}
         <CreateAppText />
         {app?.status === AppStatus.RUNNING && canOpenApp(app?.appType) ? (
-          <OpenGkeAppButton {...{ billingStatus, workspace }} userApp={app} />
+          <OpenGkeAppButton
+            {...{ billingStatus, workspace, onClose }}
+            userApp={app}
+          />
         ) : (
           <CreateGkeAppButton
             {...{ billingStatus, createAppRequest, onDismiss }}

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -174,8 +174,8 @@ export const CreateGkeApp = ({
           </LinkButton>
         )}
         <CreateAppText />
-        {app?.status === AppStatus.RUNNING &&
-        isInteractiveUserApp(app?.appType) ? (
+        {isInteractiveUserApp(app?.appType) &&
+        app?.status === AppStatus.RUNNING ? (
           <OpenGkeAppButton
             {...{ billingStatus, workspace, onClose }}
             userApp={app}

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
@@ -8,9 +8,9 @@ import {
   UserAppEnvironment,
 } from 'generated/fetch';
 
-import { UIAppType } from '../apps-panel/utils';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { UIAppType } from 'app/components/apps-panel/utils';
 import { appDisplayPath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { mockNavigate } from 'setupTests';
+
+import { AppsApi, AppStatus, BillingStatus } from 'generated/fetch';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UIAppType } from 'app/components/apps-panel/utils';
+import { appDisplayPath } from 'app/routing/utils';
+import { registerApiClient } from 'app/services/swagger-fetch-clients';
+
+import {
+  expectButtonElementDisabled,
+  expectButtonElementEnabled,
+} from 'testing/react-test-helpers';
+import {
+  AppsApiStub,
+  createListAppsCromwellResponse,
+} from 'testing/stubs/apps-api-stub';
+import {
+  workspaceStubs,
+  WorkspaceStubVariables,
+} from 'testing/stubs/workspaces';
+
+import { OpenGkeAppButton, OpenGkeAppButtonProps } from './open-gke-app-button';
+
+describe(OpenGkeAppButton.name, () => {
+  const defaultProps: OpenGkeAppButtonProps = {
+    userApp: null,
+    billingStatus: BillingStatus.ACTIVE,
+    workspace: workspaceStubs[0],
+    onClose: () => {},
+  };
+
+  let user;
+
+  const component = async (propOverrides?: Partial<OpenGkeAppButtonProps>) => {
+    const allProps = { ...defaultProps, ...propOverrides };
+    return render(<OpenGkeAppButton {...allProps} />);
+  };
+
+  const findOpenButton = () =>
+    screen.getByRole('button', {
+      name: 'Cromwell cloud environment open button',
+    });
+
+  beforeEach(() => {
+    registerApiClient(AppsApi, new AppsApiStub());
+    user = userEvent.setup();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should allow opening a running GKE app', async () => {
+    const onClose = jest.fn();
+    await component({
+      userApp: createListAppsCromwellResponse({ status: AppStatus.RUNNING }),
+      onClose,
+    });
+
+    const button = await waitFor(() => {
+      const openButton = findOpenButton();
+      expectButtonElementEnabled(openButton);
+      return openButton;
+    });
+
+    button.click();
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith([
+        appDisplayPath(
+          WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+          WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+          UIAppType.CROMWELL
+        ),
+      ]);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should not allow creating a GKE app when billing status is not active.', async () => {
+    await component({
+      userApp: createListAppsCromwellResponse({ status: AppStatus.RUNNING }),
+      billingStatus: BillingStatus.INACTIVE,
+    });
+    const button = await waitFor(() => {
+      const openButton = findOpenButton();
+      expectButtonElementDisabled(openButton);
+      return openButton;
+    });
+
+    await user.pointer([{ pointerName: 'mouse', target: button }]);
+
+    await screen.findByText(
+      'You have either run out of initial credits or have an inactive billing account.'
+    );
+  });
+});

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
@@ -74,8 +74,9 @@ describe(OpenGkeAppButton.name, () => {
           UIAppType.CROMWELL
         ),
       ]);
-      expect(onClose).toHaveBeenCalled();
     });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   it('should not allow creating a GKE app when billing status is not active.', async () => {

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import { BillingStatus, UserAppEnvironment, Workspace } from 'generated/fetch';
+
+import { Button } from 'app/components/buttons';
+import { TooltipTrigger } from 'app/components/popups';
+import { useNavigation } from 'app/utils/navigation';
+import { appTypeToString, openAppInIframe } from 'app/utils/user-apps-utils';
+
+export interface OpenGkeAppButtonProps {
+  userApp: UserAppEnvironment;
+  billingStatus: BillingStatus;
+  workspace: Workspace;
+}
+export function OpenGkeAppButton({
+  userApp,
+  billingStatus,
+  workspace: { namespace, id },
+}: OpenGkeAppButtonProps) {
+  const [navigate] = useNavigation();
+
+  const openEnabled = billingStatus === BillingStatus.ACTIVE;
+  const appTypeString = appTypeToString[userApp.appType];
+
+  const tooltip =
+    !openEnabled &&
+    'You have either run out of initial credits or have an inactive billing account.';
+
+  return (
+    <TooltipTrigger disabled={openEnabled} content={tooltip}>
+      {/* tooltip trigger needs a div for some reason */}
+      <div>
+        <Button
+          id={`${appTypeString}-cloud-environment-open-button`}
+          aria-label={`${appTypeString} cloud environment open button`}
+          onClick={() => openAppInIframe(namespace, id, userApp, navigate)}
+          disabled={!openEnabled}
+        >
+          Open {appTypeString}
+        </Button>
+      </div>
+    </TooltipTrigger>
+  );
+}

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
@@ -11,11 +11,13 @@ export interface OpenGkeAppButtonProps {
   userApp: UserAppEnvironment;
   billingStatus: BillingStatus;
   workspace: Workspace;
+  onClose: () => void;
 }
 export function OpenGkeAppButton({
   userApp,
   billingStatus,
   workspace: { namespace, id },
+  onClose,
 }: OpenGkeAppButtonProps) {
   const [navigate] = useNavigation();
 
@@ -33,7 +35,10 @@ export function OpenGkeAppButton({
         <Button
           id={`${appTypeString}-cloud-environment-open-button`}
           aria-label={`${appTypeString} cloud environment open button`}
-          onClick={() => openAppInIframe(namespace, id, userApp, navigate)}
+          onClick={() => {
+            openAppInIframe(namespace, id, userApp, navigate);
+            onClose();
+          }}
           disabled={!openEnabled}
         >
           Open {appTypeString}

--- a/ui/src/app/components/help-sidebar.spec.tsx
+++ b/ui/src/app/components/help-sidebar.spec.tsx
@@ -31,7 +31,7 @@ import {
   currentCohortCriteriaStore,
   currentCohortReviewStore,
   currentWorkspaceStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import {
   cdrVersionStore,
@@ -186,7 +186,7 @@ describe('HelpSidebar', () => {
   };
 
   const setActiveIcon = async (wrapper, activeIconKey) => {
-    setSidebarActiveIconStore.next(activeIconKey);
+    sidebarActiveIconStore.next(activeIconKey);
     await waitForFakeTimersAndUpdate(wrapper);
   };
 

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -173,6 +173,7 @@ const SIDEBAR_ICONS_DISABLED_WHEN_USER_SUSPENDED = [
   'runtimeConfig',
   cromwellConfigIconId,
   rstudioConfigIconId,
+  sasConfigIconId,
   'terminal',
 ] as SidebarIconId[];
 

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -59,7 +59,7 @@ import { AnalyticsTracker } from 'app/utils/analytics';
 import {
   currentConceptStore,
   NavigationProps,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import {
   ComputeSecuritySuspendedError,
@@ -319,7 +319,7 @@ export const HelpSidebar = fp.flow(
     );
 
     setActiveIcon(activeIcon: SidebarIconId) {
-      setSidebarActiveIconStore.next(activeIcon);
+      sidebarActiveIconStore.next(activeIcon);
       // let the Config Panels use their own logic
       this.setState({
         runtimeConfPanelInitialState: null,
@@ -328,7 +328,7 @@ export const HelpSidebar = fp.flow(
     }
 
     openRuntimeConfigWithState(runtimeConfPanelInitialState: PanelContent) {
-      setSidebarActiveIconStore.next('runtimeConfig');
+      sidebarActiveIconStore.next('runtimeConfig');
       this.setState({ runtimeConfPanelInitialState });
     }
 
@@ -336,7 +336,7 @@ export const HelpSidebar = fp.flow(
       icon: SidebarIconId,
       gkeAppConfPanelInitialState: GKEAppPanelContent
     ) {
-      setSidebarActiveIconStore.next(icon);
+      sidebarActiveIconStore.next(icon);
       this.setState({ gkeAppConfPanelInitialState });
     }
 
@@ -359,7 +359,7 @@ export const HelpSidebar = fp.flow(
         )
       );
       this.subscriptions.push(
-        setSidebarActiveIconStore.subscribe((activeIcon) => {
+        sidebarActiveIconStore.subscribe((activeIcon) => {
           this.setState({ activeIcon });
           if (activeIcon) {
             localStorage.setItem(LOCAL_STORAGE_KEY_SIDEBAR_STATE, activeIcon);

--- a/ui/src/app/components/runtime-initializer-modal.tsx
+++ b/ui/src/app/components/runtime-initializer-modal.tsx
@@ -6,7 +6,7 @@ import { Runtime, RuntimeConfigurationType } from 'generated/fetch';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { toAnalysisConfig } from 'app/utils/analysis-config';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { sidebarActiveIconStore } from 'app/utils/navigation';
 import { runtimeDiskStore, useStore } from 'app/utils/stores';
 
 import { Button, Clickable } from './buttons';
@@ -96,7 +96,7 @@ export const RuntimeInitializerModal = ({
           data-test-id='runtime-initializer-configure'
           type='secondary'
           onClick={() => {
-            setSidebarActiveIconStore.next('runtimeConfig');
+            sidebarActiveIconStore.next('runtimeConfig');
             cancel();
           }}
         >

--- a/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
+++ b/ui/src/app/pages/analysis/interactive-notebook.spec.tsx
@@ -28,7 +28,7 @@ import {
 import * as swaggerClients from 'app/services/swagger-fetch-clients';
 import {
   currentWorkspaceStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { MatchParams, userAppsStore } from 'app/utils/stores';
 
@@ -156,9 +156,9 @@ test.each([
     await user.click(editButton);
     expect(spyWindowOpen).toHaveBeenCalledTimes(0);
     if (appType === AppType.RSTUDIO) {
-      expect(setSidebarActiveIconStore.value).toEqual(rstudioConfigIconId);
+      expect(sidebarActiveIconStore.value).toEqual(rstudioConfigIconId);
     } else if (appType === AppType.SAS) {
-      expect(setSidebarActiveIconStore.value).toEqual(sasConfigIconId);
+      expect(sidebarActiveIconStore.value).toEqual(sasConfigIconId);
     } else {
       fail(`Unknown app type ${appType}`);
     }

--- a/ui/src/app/pages/data/cohort/cohort-search.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-search.tsx
@@ -41,7 +41,7 @@ import {
   currentCohortCriteriaStore,
   currentCohortSearchContextStore,
   currentCohortStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import arrowIcon from 'assets/icons/arrow-left-regular.svg';
@@ -571,7 +571,7 @@ export const CohortSearch = fp.flow(
                   type='primary'
                   style={styles.finishButton}
                   disabled={!!selectedIds && selectedIds.length === 0}
-                  onClick={() => setSidebarActiveIconStore.next('criteria')}
+                  onClick={() => sidebarActiveIconStore.next('criteria')}
                 >
                   Finish & Review
                 </Button>

--- a/ui/src/app/pages/data/cohort/list-search.tsx
+++ b/ui/src/app/pages/data/cohort/list-search.tsx
@@ -43,7 +43,7 @@ import {
   attributesSelectionStore,
   currentCohortCriteriaStore,
   currentCohortSearchContextStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
@@ -568,7 +568,7 @@ export const ListSearch = fp.flow(
 
     setAttributes(node: any) {
       attributesSelectionStore.next(node);
-      setSidebarActiveIconStore.next('criteria');
+      sidebarActiveIconStore.next('criteria');
     }
 
     showHierarchy = (row: any) => {

--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -23,7 +23,7 @@ import {
 import {
   attributesSelectionStore,
   currentCohortCriteriaStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import arrowLeft from 'assets/icons/arrow-left-regular.svg';
 import times from 'assets/icons/times-light.svg';
@@ -277,7 +277,7 @@ export const SelectionList = fp.flow(
         (attributesSelection) => {
           this.setState({ attributesSelection });
           if (!!attributesSelection) {
-            setSidebarActiveIconStore.next('criteria');
+            sidebarActiveIconStore.next('criteria');
           }
         }
       );
@@ -347,7 +347,7 @@ export const SelectionList = fp.flow(
 
     closeSidebar() {
       attributesSelectionStore.next(undefined);
-      setSidebarActiveIconStore.next(null);
+      sidebarActiveIconStore.next(null);
     }
 
     get showModifierButton() {

--- a/ui/src/app/pages/data/cohort/tree-node.tsx
+++ b/ui/src/app/pages/data/cohort/tree-node.tsx
@@ -24,7 +24,7 @@ import {
   currentCohortCriteriaStore,
   currentConceptStore,
   currentWorkspaceStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 
 export const COPE_SURVEY_GROUP_NAME =
@@ -392,7 +392,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     event.stopPropagation();
     delete node.children;
     attributesSelectionStore.next(node);
-    setSidebarActiveIconStore.next('criteria');
+    sidebarActiveIconStore.next('criteria');
   }
 
   get showCode() {

--- a/ui/src/app/pages/data/concept/concept-list.tsx
+++ b/ui/src/app/pages/data/concept/concept-list.tsx
@@ -34,7 +34,7 @@ import {
   currentConceptSetStore,
   currentConceptStore,
   NavigationProps,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
@@ -235,7 +235,7 @@ export const ConceptListPage = fp.flow(
 
     closeConceptAddModal() {
       this.setState({ conceptAddModalOpen: false });
-      setSidebarActiveIconStore.next(null);
+      sidebarActiveIconStore.next(null);
     }
 
     renderSelection(selection: any, index: number) {
@@ -317,7 +317,7 @@ export const ConceptListPage = fp.flow(
             <Button
               type='link'
               style={{ color: colors.primary, left: 0 }}
-              onClick={() => setSidebarActiveIconStore.next(null)}
+              onClick={() => sidebarActiveIconStore.next(null)}
             >
               Close
             </Button>

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -51,7 +51,7 @@ import {
   currentConceptSetStore,
   currentConceptStore,
   NavigationProps,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { nameValidationFormat } from 'app/utils/resources';
 import { MatchParams } from 'app/utils/stores';
@@ -629,7 +629,7 @@ export const ConceptSearch = fp.flow(
                 <Button
                   style={{ float: 'right', marginBottom: '3rem' }}
                   disabled={this.disableFinishButton}
-                  onClick={() => setSidebarActiveIconStore.next('concept')}
+                  onClick={() => sidebarActiveIconStore.next('concept')}
                 >
                   Finish & Review
                 </Button>

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -22,7 +22,7 @@ import {
   currentCohortCriteriaStore,
   currentCohortStore,
   currentConceptStore,
-  setSidebarActiveIconStore,
+  sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
 import arrowIcon from 'assets/icons/arrow-left-regular.svg';
@@ -270,7 +270,7 @@ export const CriteriaSearch = fp.flow(
 
     closeSidebar() {
       attributesSelectionStore.next(undefined);
-      setSidebarActiveIconStore.next(null);
+      sidebarActiveIconStore.next(null);
     }
 
     addSelection = (selectCriteria) => {

--- a/ui/src/app/utils/navigation.tsx
+++ b/ui/src/app/utils/navigation.tsx
@@ -57,9 +57,7 @@ export const attributesSelectionStore = new BehaviorSubject<Criteria>(
 export const currentCohortSearchContextStore = new BehaviorSubject<any>(
   undefined
 );
-export const setSidebarActiveIconStore = new BehaviorSubject<SidebarIconId>(
-  null
-);
+export const sidebarActiveIconStore = new BehaviorSubject<SidebarIconId>(null);
 export const conceptSetUpdating = new BehaviorSubject<boolean>(false);
 
 export const useNavigation = () => {

--- a/ui/src/app/utils/user-apps-utils.spec.tsx
+++ b/ui/src/app/utils/user-apps-utils.spec.tsx
@@ -12,7 +12,7 @@ import { UIAppType } from 'app/components/apps-panel/utils';
 import { rstudioConfigIconId } from 'app/components/help-sidebar-icons';
 import { appDisplayPath } from 'app/routing/utils';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
+import { sidebarActiveIconStore } from 'app/utils/navigation';
 
 import { AppsApiStub } from 'testing/stubs/apps-api-stub';
 
@@ -41,7 +41,7 @@ describe('User Apps Helper functions', () => {
     appsApiStub = new AppsApiStub();
     registerApiClient(AppsApi, appsApiStub);
     userAppsStore.set({ updating: false });
-    setSidebarActiveIconStore.next(null);
+    sidebarActiveIconStore.next(null);
   });
 
   afterEach(async () => {
@@ -124,7 +124,7 @@ describe('User Apps Helper functions', () => {
 
   it('Opens Config panel if RStudio App is not running', async () => {
     const navigate = mockNavigate;
-    expect(setSidebarActiveIconStore.value).toBeNull();
+    expect(sidebarActiveIconStore.value).toBeNull();
 
     userAppsUtils.openAppOrConfigPanel(
       'ws',
@@ -137,12 +137,12 @@ describe('User Apps Helper functions', () => {
     // Since RStudio is NOT in running state this will open the RStudio config side panel and
     // There will be no navigation to any other page
     expect(mockNavigate).not.toBeCalled();
-    expect(setSidebarActiveIconStore.value).toBe(rstudioConfigIconId);
+    expect(sidebarActiveIconStore.value).toBe(rstudioConfigIconId);
   });
 
   it('Will open RStudio App in iframe if app is running', async () => {
     const navigate = mockNavigate;
-    expect(setSidebarActiveIconStore.value).toBeNull();
+    expect(sidebarActiveIconStore.value).toBeNull();
 
     userAppsUtils.openAppOrConfigPanel(
       'ws',
@@ -155,7 +155,7 @@ describe('User Apps Helper functions', () => {
     expect(mockNavigate).toHaveBeenCalledWith([
       appDisplayPath('ws', 'wsid', UIAppType.RSTUDIO),
     ]);
-    expect(setSidebarActiveIconStore.value).toBeNull();
+    expect(sidebarActiveIconStore.value).toBeNull();
   });
 });
 

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -134,8 +134,14 @@ const localizeUserApp = (
     appType,
   });
 
-export const canOpenApp = (appType: AppType) =>
-  ([AppType.RSTUDIO, AppType.SAS] as AppType[]).includes(appType);
+// does this app have a UI that the user can interact with?
+export const isInteractiveUIApp = (appType: UIAppType) =>
+  (
+    [UIAppType.JUPYTER, UIAppType.RSTUDIO, UIAppType.SAS] as UIAppType[]
+  ).includes(appType);
+
+export const isInteractiveUserApp = (appType: AppType) =>
+  isInteractiveUIApp(toUIAppType[appType]);
 
 export const openAppInIframe = (
   workspaceNamespace: string,

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -9,14 +9,13 @@ import {
 
 import {
   findApp,
-  helpSidebarConfigIdForUIApp,
+  openConfigPanelForUIApp,
   toUIAppType,
   UIAppType,
 } from 'app/components/apps-panel/utils';
 import { appDisplayPath } from 'app/routing/utils';
 import { leoAppsApi } from 'app/services/notebooks-swagger-fetch-clients';
 import { appsApi } from 'app/services/swagger-fetch-clients';
-import { setSidebarActiveIconStore } from 'app/utils/navigation';
 import { userAppsStore } from 'app/utils/stores';
 
 import { fetchWithErrorModal } from './errors';
@@ -170,6 +169,6 @@ export const openAppOrConfigPanel = (
   if (userApp?.status === AppStatus.RUNNING) {
     openAppInIframe(workspaceNamespace, workspaceId, userApp, navigate);
   } else {
-    setSidebarActiveIconStore.next(helpSidebarConfigIdForUIApp[requestedApp]);
+    openConfigPanelForUIApp(requestedApp);
   }
 };

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -134,6 +134,9 @@ const localizeUserApp = (
     appType,
   });
 
+export const canOpenApp = (appType: AppType) =>
+  ([AppType.RSTUDIO, AppType.SAS] as AppType[]).includes(appType);
+
 export const openAppInIframe = (
   workspaceNamespace: string,
   workspaceId: string,


### PR DESCRIPTION
Changes the "Start" button in the SAS and RStudio config panels to "Open <app>" when the app is running.  Works similarly to the lightning-bolt panel.

Also updated the lightning-bolt panel "open" to close the panel.

Tested by creating SAS and RStudio apps and opening them both ways.

![open2](https://github.com/all-of-us/workbench/assets/2701406/3d0d251f-b08e-43ea-a58c-d71658292671)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
