### PR TITLE
[RW-10627][risk=no] [P1] Free tier billing usage cron job starts failing recently due to timeout - Improve log messages

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -111,7 +111,7 @@ public class FreeTierBillingService {
 
     logger.info(
         String.format(
-            "Workspaces that require updates: %s",
+            "FreeTierBillingUsage: Workspace ids that require updates: %s",
             workspaceByProject.values().stream()
                 .map(workspaceId -> Long.toString(workspaceId))
                 .collect(Collectors.joining(","))));
@@ -438,10 +438,6 @@ public class FreeTierBillingService {
                                                     .numberOfDaysToConsiderForFreeTierUsageUpdate)
                                             .toMillis()))))
             .collect(Collectors.toList());
-
-    logger.info(
-        String.format("Workspaces that require update %d", workspacesThatRequireUpdate.size()));
-
     return workspacesThatRequireUpdate;
   }
 


### PR DESCRIPTION
The log messages are making more sense now however i feel there were some messages that were redundant and creating noise. 
<img width="1446" alt="Screenshot 2024-02-05 at 10 02 05 AM" src="https://github.com/all-of-us/workbench/assets/34481816/ce38e48b-1cc4-460d-82e1-1df63ae30788">

This PR:

- Removes the log message which shows the number of workspace that requires update
- Update the workspace that shows the id that requires update


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
