### PR TITLE
[RW-11375][risk=none] Switch users using Moodle to Absorb <-Turn on for all env

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -97,7 +97,7 @@
     "redirectMoodleUser": true
   },
   "moodle": {
-    "trainingMigrationPauseActive": true,
+    "trainingMigrationPauseActive": false,
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -97,7 +97,7 @@
     "redirectMoodleUser": true
   },
   "moodle": {
-    "trainingMigrationPauseActive": true,
+    "trainingMigrationPauseActive": false,
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -94,7 +94,7 @@
     "externalDepartmentId": "Researchers",
     "samlIdentityProviderId": "C02celxus",
     "samlServiceProviderId": "638082479253",
-    "redirectMoodleUser": false
+    "redirectMoodleUser": true
   },
   "moodle": {
     "trainingMigrationPauseActive": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -97,7 +97,7 @@
     "redirectMoodleUser": true
   },
   "moodle": {
-    "trainingMigrationPauseActive": true,
+    "trainingMigrationPauseActive": false,
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -94,7 +94,7 @@
     "externalDepartmentId": "Researchers",
     "samlIdentityProviderId": "C02celxus",
     "samlServiceProviderId": "638082479253",
-    "redirectMoodleUser": false
+    "redirectMoodleUser": true
   },
   "moodle": {
     "trainingMigrationPauseActive": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -94,7 +94,7 @@
     "externalDepartmentId": "Development",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028",
-    "redirectMoodleUser": false
+    "redirectMoodleUser": true
   },
   "moodle": {
     "trainingMigrationPauseActive": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -97,7 +97,7 @@
     "redirectMoodleUser": true
   },
   "moodle": {
-    "trainingMigrationPauseActive": true,
+    "trainingMigrationPauseActive": false,
     "host": "aou.nnlm.gov",
     "credentialsKeyV2": "moodle-prod-key-v2.txt"
   },

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -94,7 +94,7 @@
     "externalDepartmentId": "Development",
     "samlIdentityProviderId": "C03q5hexf",
     "samlServiceProviderId": "133137951028",
-    "redirectMoodleUser": false
+    "redirectMoodleUser": true
   },
   "moodle": {
     "trainingMigrationPauseActive": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -97,7 +97,7 @@
     "redirectMoodleUser": true
   },
   "moodle": {
-    "trainingMigrationPauseActive": true,
+    "trainingMigrationPauseActive": false,
     "host": "aoudev.nnlm.gov",
     "credentialsKeyV2": "moodle-key-v2.txt"
   },


### PR DESCRIPTION
Absorb team has migrated all users from moodle to absorb,
 this PR will do the following

- Turn **on** flag to redirect ALL users to absorb
- Turn **off** Flag to disable training card for Moddle Users

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
