### PR TITLE
[risk=low][RW-11756] Sort by numerical last-modified, not string

### DIFF
--- a/ui/src/app/components/resource-list.tsx
+++ b/ui/src/app/components/resource-list.tsx
@@ -26,7 +26,7 @@ import colors from 'app/styles/colors';
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
-import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
+import { displayDateWithoutHours } from 'app/utils/dates';
 import {
   getDisplayName,
   getType,
@@ -88,8 +88,8 @@ interface TableData {
   menu: JSX.Element;
   resourceType: string;
   resourceName: string;
+  lastModifiedForSorting: number;
   formattedLastModified: string;
-  lastModifiedDateAsString: string;
   lastModifiedBy: string;
   cdrVersionName: string;
   resource: WorkspaceResource;
@@ -174,10 +174,8 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
                   menu: renderResourceMenu(r, workspace),
                   resourceType: getTypeString(r),
                   resourceName: getDisplayName(r),
+                  lastModifiedForSorting: r.lastModifiedEpochMillis,
                   formattedLastModified: displayDateWithoutHours(
-                    r.lastModifiedEpochMillis
-                  ),
-                  lastModifiedDateAsString: displayDate(
                     r.lastModifiedEpochMillis
                   ),
                   cdrVersionName: getCdrVersionName(r),
@@ -265,7 +263,7 @@ export const ResourceList = fp.flow(withCdrVersions())((props: Props) => {
               field='formattedLastModified'
               header='Last Modified Date'
               style={styles.modifiedDateColumn}
-              sortField={'lastModifiedDateAsString'}
+              sortField='lastModifiedForSorting'
               sortable
             />
             {props.recentResourceSource && (

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -241,11 +241,11 @@ export const AppFilesList = withCurrentWorkspace()(
                   style={styles.columns}
                   headerStyle={styles.tableHeader}
                   header='Name'
-                  field={'name'}
+                  field='name'
                   body={displayName}
                   bodyStyle={styles.rows}
                   filter
-                  filterPlaceholder={'Search Name'}
+                  filterPlaceholder='Search Name'
                   filterHeaderStyle={{ paddingTop: '0rem' }}
                   sortable
                 />
@@ -255,6 +255,7 @@ export const AppFilesList = withCurrentWorkspace()(
                   bodyStyle={styles.rows}
                   header='Last Modified Time'
                   body={displayLastModifiedTime}
+                  sortField='lastModifiedTime'
                 />
                 <Column
                   headerStyle={styles.tableHeader}

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -241,11 +241,11 @@ export const AppFilesList = withCurrentWorkspace()(
                   style={styles.columns}
                   headerStyle={styles.tableHeader}
                   header='Name'
-                  field='name'
+                  field={'name'}
                   body={displayName}
                   bodyStyle={styles.rows}
                   filter
-                  filterPlaceholder='Search Name'
+                  filterPlaceholder={'Search Name'}
                   filterHeaderStyle={{ paddingTop: '0rem' }}
                   sortable
                 />
@@ -255,7 +255,6 @@ export const AppFilesList = withCurrentWorkspace()(
                   bodyStyle={styles.rows}
                   header='Last Modified Time'
                   body={displayLastModifiedTime}
-                  sortField='lastModifiedTime'
                 />
                 <Column
                   headerStyle={styles.tableHeader}

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -39,7 +39,7 @@ import {
 import { reactStyles, withCdrVersions } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { ROWS_PER_PAGE_RESOURCE_TABLE } from 'app/utils/constants';
-import { displayDate, displayDateWithoutHours } from 'app/utils/dates';
+import { displayDateWithoutHours } from 'app/utils/dates';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 const styles = reactStyles({

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -93,8 +93,8 @@ interface TableData {
   menu: JSX.Element;
   resourceType: string;
   resourceName: string;
+  lastModifiedForSorting: number;
   formattedLastModified: string;
-  lastModifiedDateAsString: string;
   createdBy: string;
   cdrVersionName: string;
   resource: WorkspaceResource;
@@ -184,10 +184,8 @@ export const TanagraResourceList = fp.flow(
                   menu: <ResourceActionsMenu actions={actions(r)} />,
                   resourceType: getTypeString(r),
                   resourceName: getDisplayName(r),
+                  lastModifiedForSorting: r.lastModifiedEpochMillis,
                   formattedLastModified: displayDateWithoutHours(
-                    r.lastModifiedEpochMillis
-                  ),
-                  lastModifiedDateAsString: displayDate(
                     r.lastModifiedEpochMillis
                   ),
                   cdrVersionName: getCdrVersionName(r),
@@ -301,7 +299,7 @@ export const TanagraResourceList = fp.flow(
               field='formattedLastModified'
               header='Last Modified Date'
               style={styles.modifiedDateColumn}
-              sortField={'lastModifiedDateAsString'}
+              sortField='lastModifiedForSorting'
               sortable
             />
             {props.recentResourceSource && (

--- a/ui/src/app/utils/dates.tsx
+++ b/ui/src/app/utils/dates.tsx
@@ -7,7 +7,8 @@ export const plusDays = (date: number, days: number): number =>
   date + MILLIS_PER_DAY * days;
 export const nowPlusDays = (days: number) => plusDays(Date.now(), days);
 
-// To convert datetime strings into human-readable dates
+// To convert datetime strings into human-readable dates in the format
+// 08/11/23, 11:26 AM
 export function displayDate(time: number): string {
   const date = new Date(time);
   // datetime formatting to slice off weekday from readable date string
@@ -21,6 +22,8 @@ export function displayDate(time: number): string {
   });
 }
 
+// To convert datetime strings into human-readable dates in the format
+// Feb 14, 2022
 export function displayDateWithoutHours(time: number): string {
   if (!time) {
     return null;


### PR DESCRIPTION
We had a silly bug: our date sorting was Month first
<img width="245" alt="bad-sort-data" src="https://github.com/all-of-us/workbench/assets/2701406/e54c1299-180e-422c-ad8e-44e352d39eee">

Now it is correctly Year first
<img width="240" alt="good-sort-data" src="https://github.com/all-of-us/workbench/assets/2701406/e4a60b17-8c03-420d-a442-480430d2d176">

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
