### PR TITLE
[risk=low][no ticket] Show both usernames and contact emails in mail server logs

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -334,9 +334,8 @@ public class ProfileController implements ProfileApiDelegate {
               && eraRequiredForTier(userInstitution, AccessTierService.CONTROLLED_TIER_SHORT_NAME);
 
       mail.sendWelcomeEmail(
-          user.getContactEmail(),
+          user,
           googleUser.getPassword(),
-          user.getUsername(),
           userInstitution.getDisplayName(),
           showEraStepInRT,
           showEraStepInCT);

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -13,9 +13,8 @@ import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 public interface MailService {
 
   void sendWelcomeEmail(
-      final String contactEmail,
+      final DbUser user,
       final String password,
-      final String username,
       final String institutionName,
       final Boolean showEraStepInRt,
       final Boolean showEraStepInCt)

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -151,7 +151,7 @@ public class MailServiceImpl implements MailService {
         Collections.singletonList(user.getContactEmail()),
         Collections.emptyList(),
         "Your new All of Us Researcher Workbench Account",
-        "Welcome for " + userForLogging(user),
+        String.format("Welcome for %s", userForLogging(user)),
         htmlMessage);
   }
 
@@ -172,7 +172,8 @@ public class MailServiceImpl implements MailService {
         Collections.singletonList(contactEmail),
         Collections.emptyList(),
         "Instructions from your institution on using the Researcher Workbench",
-        "Institution user instructions for " + userForLogging(username, contactEmail),
+        String.format(
+            "Institution user instructions for %s", userForLogging(username, contactEmail)),
         htmlMessage);
   }
 
@@ -276,7 +277,8 @@ public class MailServiceImpl implements MailService {
     sendWithRetries(
         Collections.singletonList(user.getContactEmail()),
         Collections.emptyList(),
-        "Your access to All of Us " + capitalizedAccessTierShortName + " Tier Data has expired",
+        String.format(
+            "Your access to All of Us %s Tier Data has expired", capitalizedAccessTierShortName),
         logMsg,
         htmlMessage);
   }
@@ -385,7 +387,7 @@ public class MailServiceImpl implements MailService {
         List.of(dbUser.getContactEmail()),
         Collections.emptyList(),
         "Researcher satisfaction survey for the All of Us Researcher Workbench",
-        "New user satisfaction survey email for " + userForLogging(dbUser),
+        String.format("New user satisfaction survey email for %s", userForLogging(dbUser)),
         htmlMessage);
   }
 
@@ -436,7 +438,7 @@ public class MailServiceImpl implements MailService {
         Optional.ofNullable(egressPolicy.notifyCcEmails).orElse(Collections.emptyList()),
         Collections.emptyList(),
         "[Response Required] AoU Researcher Workbench High Data Egress Alert",
-        "Egress remediation email for " + userForLogging(dbUser),
+        String.format("Egress remediation email for %s", userForLogging(dbUser)),
         htmlMessage);
   }
 
@@ -612,7 +614,7 @@ public class MailServiceImpl implements MailService {
       final InternetAddress contactInternetAddress = new InternetAddress(contactEmail);
       contactInternetAddress.validate();
     } catch (AddressException e) {
-      throw new ServerErrorException("Email: " + contactEmail + " is invalid.");
+      throw new ServerErrorException(String.format("Email: %s is invalid.", contactEmail));
     }
 
     final RecipientAddress toAddress = new RecipientAddress();
@@ -669,6 +671,7 @@ public class MailServiceImpl implements MailService {
       retries--;
       Pair<Status, String> attempt = trySend(keyAndMessage);
       Status status = Status.valueOf(attempt.getLeft().toString());
+      String defaultFailureMessage = String.format("Sending email failed: %s", attempt.getRight());
       switch (status) {
         case API_ERROR:
           log.log(
@@ -681,7 +684,7 @@ public class MailServiceImpl implements MailService {
                 String.format(
                     "ApiException: On Last Attempt! Email '%s' not sent: %s",
                     descriptionForLog, attempt.getRight()));
-            throw new MessagingException("Sending email failed: " + attempt.getRight());
+            throw new MessagingException(defaultFailureMessage);
           }
           break;
 
@@ -690,8 +693,8 @@ public class MailServiceImpl implements MailService {
               Level.SEVERE,
               String.format(
                   "Messaging Exception: Email '%s' not sent: %s",
-                  descriptionForLog, attempt.getRight().toString()));
-          throw new MessagingException("Sending email failed: " + attempt.getRight());
+                  descriptionForLog, attempt.getRight()));
+          throw new MessagingException(defaultFailureMessage);
 
         case SUCCESSFUL:
           log.log(Level.INFO, String.format("Email '%s' was sent.", descriptionForLog));
@@ -702,7 +705,7 @@ public class MailServiceImpl implements MailService {
             log.log(
                 Level.SEVERE,
                 String.format("Email '%s' was not sent. Default case.", descriptionForLog));
-            throw new MessagingException("Sending email failed: " + attempt.getRight());
+            throw new MessagingException(defaultFailureMessage);
           }
       }
     } while (retries > 0);

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -5,7 +5,6 @@ import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHOR
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import com.google.common.html.HtmlEscapers;
@@ -59,8 +58,8 @@ import org.springframework.util.StringUtils;
 @Service
 public class MailServiceImpl implements MailService {
 
-  public static final ImmutableMap<EgressRemediationAction, String> EGRESS_REMEDIATION_ACTION_MAP =
-      ImmutableMap.of(
+  public static final Map<EgressRemediationAction, String> EGRESS_REMEDIATION_ACTION_MAP =
+      Map.of(
           EgressRemediationAction.DISABLE_USER,
           "Your account has been disabled pending manual review by the <i>All of Us</i> "
               + "security team.",
@@ -136,9 +135,8 @@ public class MailServiceImpl implements MailService {
 
   @Override
   public void sendWelcomeEmail(
-      final String contactEmail,
+      final DbUser user,
       final String password,
-      final String username,
       final String institutionName,
       final Boolean showEraStepInRt,
       final Boolean showEraStepInCt)
@@ -147,13 +145,13 @@ public class MailServiceImpl implements MailService {
         buildHtml(
             WELCOME_RESOURCE,
             welcomeMessageSubstitutionMap(
-                password, username, institutionName, showEraStepInRt, showEraStepInCt));
+                password, user.getUsername(), institutionName, showEraStepInRt, showEraStepInCt));
 
     sendWithRetries(
-        Collections.singletonList(contactEmail),
+        Collections.singletonList(user.getContactEmail()),
         Collections.emptyList(),
         "Your new All of Us Researcher Workbench Account",
-        String.format("Welcome for %s", username),
+        "Welcome for " + userForLogging(user),
         htmlMessage);
   }
 
@@ -174,7 +172,7 @@ public class MailServiceImpl implements MailService {
         Collections.singletonList(contactEmail),
         Collections.emptyList(),
         "Instructions from your institution on using the Researcher Workbench",
-        String.format("Institution user instructions for %s", contactEmail),
+        "Institution user instructions for " + userForLogging(username, contactEmail),
         htmlMessage);
   }
 
@@ -186,7 +184,7 @@ public class MailServiceImpl implements MailService {
     final String logMsg =
         String.format(
             "User %s has passed the %.2f initial credits dollar threshold.  Current total usage is $%.2f with remaining balance $%.2f",
-            user.getUsername(), threshold, currentUsage, remainingBalance);
+            userForLogging(user), threshold, currentUsage, remainingBalance);
     log.info(logMsg);
 
     final String htmlMessage =
@@ -200,7 +198,7 @@ public class MailServiceImpl implements MailService {
         String.format(
             "Reminder - %s Initial credit usage in All of Us Researcher Workbench",
             formatPercentage(threshold)),
-        String.format("User %s passed an initial credits dollar threshold", user.getUsername()),
+        String.format("User %s passed an initial credits dollar threshold", userForLogging(user)),
         htmlMessage);
   }
 
@@ -208,7 +206,7 @@ public class MailServiceImpl implements MailService {
   public void alertUserInitialCreditsExpiration(final DbUser user) throws MessagingException {
 
     final String expirationMsg =
-        String.format("Initial credits have expired for User %s", user.getUsername());
+        String.format("Initial credits have expired for User %s", userForLogging(user));
     log.info(expirationMsg);
 
     final String htmlMessage =
@@ -232,10 +230,9 @@ public class MailServiceImpl implements MailService {
 
     final String logMsg =
         String.format(
-            "%s Tier access expiration will occur for user %s (%s) in %d days (on %s).",
+            "%s Tier access expiration will occur for user %s in %d days (on %s).",
             capitalizedAccessTierShortName,
-            user.getUsername(),
-            user.getContactEmail(),
+            userForLogging(user),
             daysRemaining,
             formatCentralTime(expirationTime));
     log.info(logMsg);
@@ -253,10 +250,8 @@ public class MailServiceImpl implements MailService {
             + " Tier Data will expire "
             + (daysRemaining == 1 ? "tomorrow" : String.format("in %d days", daysRemaining)),
         String.format(
-            "User %s (%s) will lose " + tierShortName + " tier access in %d days",
-            user.getUsername(),
-            user.getContactEmail(),
-            daysRemaining),
+            "User %s will lose %s tier access in %d days",
+            userForLogging(user), tierShortName, daysRemaining),
         htmlMessage);
   }
 
@@ -267,9 +262,9 @@ public class MailServiceImpl implements MailService {
 
     final String logMsg =
         String.format(
-            capitalizedAccessTierShortName + " Tier access expired for user %s (%s) on %s.",
-            user.getUsername(),
-            user.getContactEmail(),
+            "%s Tier access expired for user %s on %s.",
+            capitalizedAccessTierShortName,
+            userForLogging(user),
             formatCentralTime(expirationTime));
     log.info(logMsg);
 
@@ -282,10 +277,7 @@ public class MailServiceImpl implements MailService {
         Collections.singletonList(user.getContactEmail()),
         Collections.emptyList(),
         "Your access to All of Us " + capitalizedAccessTierShortName + " Tier Data has expired",
-        String.format(
-            capitalizedAccessTierShortName + " Tier access expired for user %s (%s)",
-            user.getUsername(),
-            user.getContactEmail()),
+        logMsg,
         htmlMessage);
   }
 
@@ -335,9 +327,9 @@ public class MailServiceImpl implements MailService {
                 .build());
     sendWithRetries(
         workbenchConfigProvider.get().mandrill.fromEmail,
-        ImmutableList.of(),
-        ImmutableList.of(),
-        users.stream().map(DbUser::getContactEmail).collect(Collectors.toList()),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        users.stream().map(DbUser::getContactEmail).toList(),
         "Reminder - Unused Disk in your Workspace",
         "Unused disk notification",
         htmlMessage);
@@ -361,9 +353,7 @@ public class MailServiceImpl implements MailService {
         receiptEmails,
         Collections.singletonList(workbenchConfigProvider.get().mandrill.fromEmail),
         "Request to set up Google Cloud Billing Account for All of Us Workbench",
-        String.format(
-            " User %s (%s) requests billing setup from Carasoft.",
-            dbUser.getUsername(), dbUser.getContactEmail()),
+        String.format(" User %s requests billing setup from Carasoft.", userForLogging(dbUser)),
         htmlMessage);
   }
 
@@ -392,10 +382,10 @@ public class MailServiceImpl implements MailService {
                 .build());
 
     sendWithRetries(
-        ImmutableList.of(dbUser.getContactEmail()),
-        ImmutableList.of(),
+        List.of(dbUser.getContactEmail()),
+        Collections.emptyList(),
         "Researcher satisfaction survey for the All of Us Researcher Workbench",
-        String.format("New user satisfaction survey email for %s", dbUser.getUsername()),
+        "New user satisfaction survey email for " + userForLogging(dbUser),
         htmlMessage);
   }
 
@@ -406,16 +396,14 @@ public class MailServiceImpl implements MailService {
     WorkbenchConfig config = workbenchConfigProvider.get();
     List<String> ccSupportMaybe =
         config.featureFlags.ccSupportWhenAdminLocking
-            ? ImmutableList.of(config.mandrill.fromEmail)
+            ? List.of(config.mandrill.fromEmail)
             : Collections.emptyList();
 
     final String ownersInfoStr =
-        owners.stream()
-            .map(o -> String.format("%s (%s)", o.getUsername(), o.getContactEmail()))
-            .collect(Collectors.joining(", "));
+        owners.stream().map(this::userForLogging).collect(Collectors.joining(", "));
 
     sendWithRetries(
-        owners.stream().map(DbUser::getContactEmail).collect(Collectors.toList()),
+        owners.stream().map(DbUser::getContactEmail).toList(),
         ccSupportMaybe,
         "[Response Required] AoU Researcher Workbench Workspace Admin Locked",
         String.format(
@@ -444,11 +432,11 @@ public class MailServiceImpl implements MailService {
         workbenchConfigProvider.get().egressAlertRemediationPolicy;
     sendWithRetries(
         egressPolicy.notifyFromEmail,
-        ImmutableList.of(dbUser.getContactEmail()),
-        Optional.ofNullable(egressPolicy.notifyCcEmails).orElse(ImmutableList.of()),
-        ImmutableList.of(),
+        List.of(dbUser.getContactEmail()),
+        Optional.ofNullable(egressPolicy.notifyCcEmails).orElse(Collections.emptyList()),
+        Collections.emptyList(),
         "[Response Required] AoU Researcher Workbench High Data Egress Alert",
-        String.format("Egress remediation email for %s", dbUser.getUsername()),
+        "Egress remediation email for " + userForLogging(dbUser),
         htmlMessage);
   }
 
@@ -474,8 +462,8 @@ public class MailServiceImpl implements MailService {
         .build();
   }
 
-  private String getRTSteps(Boolean showEraStepInRT) {
-    StringBuffer rtSteps = new StringBuffer();
+  private String getRTSteps(boolean showEraStepInRT) {
+    StringBuilder rtSteps = new StringBuilder();
     encloseInLiTag(rtSteps, TWO_STEP_VERIFICATION);
     encloseInLiTag(rtSteps, LOGIN_GOV);
     if (showEraStepInRT) {
@@ -485,8 +473,8 @@ public class MailServiceImpl implements MailService {
     return rtSteps.toString();
   }
 
-  private String getCTSteps(Boolean showEraStepInCT, String institutionName) {
-    StringBuffer ctSteps = new StringBuffer();
+  private String getCTSteps(boolean showEraStepInCT, String institutionName) {
+    StringBuilder ctSteps = new StringBuilder();
     encloseInLiTag(ctSteps, String.format(CT_INSTITUTION_CHECK, institutionName));
     if (showEraStepInCT) {
       encloseInLiTag(ctSteps, ERA_COMMON);
@@ -495,8 +483,8 @@ public class MailServiceImpl implements MailService {
     return ctSteps.toString();
   }
 
-  private StringBuffer encloseInLiTag(StringBuffer steps, String step) {
-    return steps.append(OPEN_LI_TAG).append(step).append(CLOSE_LI_TAG);
+  private void encloseInLiTag(StringBuilder steps, String step) {
+    steps.append(OPEN_LI_TAG).append(step).append(CLOSE_LI_TAG);
   }
 
   private Map<EmailSubstitutionField, String> instructionsSubstitutionMap(
@@ -636,16 +624,16 @@ public class MailServiceImpl implements MailService {
       List<String> toRecipientEmails,
       List<String> ccRecipientEmails,
       String subject,
-      String description,
+      String descriptionForLog,
       String htmlMessage)
       throws MessagingException {
     sendWithRetries(
         workbenchConfigProvider.get().mandrill.fromEmail,
         toRecipientEmails,
         ccRecipientEmails,
-        ImmutableList.of(),
+        Collections.emptyList(),
         subject,
-        description,
+        descriptionForLog,
         htmlMessage);
   }
 
@@ -655,7 +643,7 @@ public class MailServiceImpl implements MailService {
       List<String> ccRecipientEmails,
       List<String> bccRecipientEmails,
       String subject,
-      String description,
+      String descriptionForLog,
       String htmlMessage)
       throws MessagingException {
     List<RecipientAddress> toAddresses =
@@ -663,7 +651,7 @@ public class MailServiceImpl implements MailService {
                 toRecipientEmails.stream().map(e -> validatedRecipient(e, RecipientType.TO)),
                 ccRecipientEmails.stream().map(e -> validatedRecipient(e, RecipientType.CC)),
                 bccRecipientEmails.stream().map(e -> validatedRecipient(e, RecipientType.BCC)))
-            .collect(Collectors.toList());
+            .toList();
     final MandrillMessage msg =
         new MandrillMessage()
             .to(toAddresses)
@@ -686,14 +674,13 @@ public class MailServiceImpl implements MailService {
           log.log(
               Level.WARNING,
               String.format(
-                  "ApiException: Email '%s' not sent: %s",
-                  description, attempt.getRight().toString()));
+                  "ApiException: Email '%s' not sent: %s", descriptionForLog, attempt.getRight()));
           if (retries == 0) {
             log.log(
                 Level.SEVERE,
                 String.format(
                     "ApiException: On Last Attempt! Email '%s' not sent: %s",
-                    description, attempt.getRight().toString()));
+                    descriptionForLog, attempt.getRight()));
             throw new MessagingException("Sending email failed: " + attempt.getRight());
           }
           break;
@@ -703,17 +690,18 @@ public class MailServiceImpl implements MailService {
               Level.SEVERE,
               String.format(
                   "Messaging Exception: Email '%s' not sent: %s",
-                  description, attempt.getRight().toString()));
+                  descriptionForLog, attempt.getRight().toString()));
           throw new MessagingException("Sending email failed: " + attempt.getRight());
 
         case SUCCESSFUL:
-          log.log(Level.INFO, String.format("Email '%s' was sent.", description));
+          log.log(Level.INFO, String.format("Email '%s' was sent.", descriptionForLog));
           return;
 
         default:
           if (retries == 0) {
             log.log(
-                Level.SEVERE, String.format("Email '%s' was not sent. Default case.", description));
+                Level.SEVERE,
+                String.format("Email '%s' was not sent. Default case.", descriptionForLog));
             throw new MessagingException("Sending email failed: " + attempt.getRight());
           }
       }
@@ -747,17 +735,12 @@ public class MailServiceImpl implements MailService {
   }
 
   private String getBadgeImage(String tierShortName) {
-    String imageURL;
-    switch (tierShortName) {
-      case REGISTERED_TIER_SHORT_NAME:
-        imageURL = "registered-tier-badge.png";
-        break;
-      case CONTROLLED_TIER_SHORT_NAME:
-        imageURL = "controlled-tier-badge.png";
-        break;
-      default:
-        imageURL = null;
-    }
+    String imageURL =
+        switch (tierShortName) {
+          case REGISTERED_TIER_SHORT_NAME -> "registered-tier-badge.png";
+          case CONTROLLED_TIER_SHORT_NAME -> "controlled-tier-badge.png";
+          default -> null;
+        };
 
     return cloudStorageClientProvider.get().getImageUrl(imageURL);
   }
@@ -820,5 +803,13 @@ public class MailServiceImpl implements MailService {
 
   private String href(String url, String text) {
     return String.format("<a href=\"%s\">%s</a>", url, text);
+  }
+
+  private String userForLogging(String username, String contactEmail) {
+    return String.format("%s (%s)", username, contactEmail);
+  }
+
+  private String userForLogging(DbUser user) {
+    return userForLogging(user.getUsername(), user.getContactEmail());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -206,9 +206,9 @@ public class MailServiceImpl implements MailService {
   @Override
   public void alertUserInitialCreditsExpiration(final DbUser user) throws MessagingException {
 
-    final String expirationMsg =
+    final String logMsg =
         String.format("Initial credits have expired for User %s", userForLogging(user));
-    log.info(expirationMsg);
+    log.info(logMsg);
 
     final String htmlMessage =
         buildHtml(
@@ -218,7 +218,7 @@ public class MailServiceImpl implements MailService {
         Collections.singletonList(user.getContactEmail()),
         Collections.emptyList(),
         "Alert - Initial credit expiration in All of Us Researcher Workbench",
-        expirationMsg,
+        logMsg,
         htmlMessage);
   }
 
@@ -401,7 +401,7 @@ public class MailServiceImpl implements MailService {
             ? List.of(config.mandrill.fromEmail)
             : Collections.emptyList();
 
-    final String ownersInfoStr =
+    final String ownersForLogging =
         owners.stream().map(this::userForLogging).collect(Collectors.joining(", "));
 
     sendWithRetries(
@@ -410,7 +410,7 @@ public class MailServiceImpl implements MailService {
         "[Response Required] AoU Researcher Workbench Workspace Admin Locked",
         String.format(
             "Admin locking email for workspace '%s' (%s) sent to owners %s",
-            workspace.getName(), workspace.getWorkspaceNamespace(), ownersInfoStr),
+            workspace.getName(), workspace.getWorkspaceNamespace(), ownersForLogging),
         buildHtml(
             WORKSPACE_ADMIN_LOCKING_RESOURCE,
             workspaceAdminLockedSubstitutionMap(workspace, lockingReason)));
@@ -485,8 +485,8 @@ public class MailServiceImpl implements MailService {
     return ctSteps.toString();
   }
 
-  private void encloseInLiTag(StringBuilder steps, String step) {
-    steps.append(OPEN_LI_TAG).append(step).append(CLOSE_LI_TAG);
+  private StringBuilder encloseInLiTag(StringBuilder steps, String step) {
+    return steps.append(OPEN_LI_TAG).append(step).append(CLOSE_LI_TAG);
   }
 
   private Map<EmailSubstitutionField, String> instructionsSubstitutionMap(

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -1001,7 +1001,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     when(mockDirectoryService.resetUserPassword(anyString())).thenReturn(googleUser);
     doThrow(new MessagingException("exception"))
         .when(mockMailService)
-        .sendWelcomeEmail(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
 
     ResponseEntity<Void> response =
         profileController.resendWelcomeEmail(
@@ -1009,7 +1009,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     // called twice, once during account creation, once on resend
     verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 
@@ -1019,7 +1019,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     when(mockDirectoryService.resetUserPassword(anyString())).thenReturn(googleUser);
     doNothing()
         .when(mockMailService)
-        .sendWelcomeEmail(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
 
     ResponseEntity<Void> response =
         profileController.resendWelcomeEmail(
@@ -1027,7 +1027,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     // called twice, once during account creation, once on resend
     verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 
@@ -1035,7 +1035,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void sendUserInstructions_none() throws MessagingException {
     // default Institution in this test class has no instructions
     createAccountAndDbUserWithAffiliation();
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
 
     // don't send the user instructions email if there are no instructions
     verifyNoMoreInteractions(mockMailService);
@@ -1054,7 +1054,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     institutionService.setInstitutionUserInstructions(instructions);
 
     createAccountAndDbUserWithAffiliation(verifiedInstitutionalAffiliation);
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
     verify(mockMailService)
         .sendInstitutionUserInstructions(
             CONTACT_EMAIL, instructions.getInstructions(), FULL_USER_NAME);
@@ -1075,7 +1075,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         verifiedInstitutionalAffiliation.getInstitutionShortName());
 
     createAccountAndDbUserWithAffiliation(verifiedInstitutionalAffiliation);
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
 
     // don't send the user instructions email if the instructions have been deleted
     verifyNoMoreInteractions(mockMailService);

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
@@ -97,9 +97,7 @@ public class MailServiceImplTest {
     when(mockMandrillApi.send(any())).thenReturn(msgStatuses);
     assertThrows(
         MessagingException.class,
-        () ->
-            mailService.sendWelcomeEmail(
-                CONTACT_EMAIL, PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, true));
+        () -> mailService.sendWelcomeEmail(CONTACT_EMAIL, PASSWORD, INSTITUTION_NAME, true, true));
     verify(mockMandrillApi, times(1)).send(any());
   }
 
@@ -108,9 +106,7 @@ public class MailServiceImplTest {
     doThrow(ApiException.class).when(mockMandrillApi).send(any());
     assertThrows(
         MessagingException.class,
-        () ->
-            mailService.sendWelcomeEmail(
-                CONTACT_EMAIL, PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, true));
+        () -> mailService.sendWelcomeEmail(CONTACT_EMAIL, PASSWORD, INSTITUTION_NAME, true, true));
     verify(mockMandrillApi, times(3)).send(any());
   }
 
@@ -121,7 +117,7 @@ public class MailServiceImplTest {
             ServerErrorException.class,
             () ->
                 mailService.sendWelcomeEmail(
-                    "Nota valid email", PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, true));
+                    "Nota valid email", PASSWORD, INSTITUTION_NAME, true, true));
     assertThat(exception.getMessage()).isEqualTo("Email: Nota valid email is invalid.");
   }
 
@@ -131,7 +127,7 @@ public class MailServiceImplTest {
         ServerErrorException.class,
         () ->
             mailService.sendWelcomeEmail(
-                "Nota valid email", PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, false));
+                "Nota valid email", PASSWORD, INSTITUTION_NAME, true, false));
   }
 
   @Test
@@ -140,27 +136,24 @@ public class MailServiceImplTest {
         ServerErrorException.class,
         () ->
             mailService.sendWelcomeEmail(
-                "Nota valid email", PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, false, false));
+                "Nota valid email", PASSWORD, INSTITUTION_NAME, false, false));
   }
 
   @Test
   public void testSendWelcomeEmailRTAndCT() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(
-        CONTACT_EMAIL, PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, true);
+    mailService.sendWelcomeEmail(CONTACT_EMAIL, PASSWORD, INSTITUTION_NAME, true, true);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 
   @Test
   public void testSendWelcomeEmailOnlyRT() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(
-        CONTACT_EMAIL, PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, true, false);
+    mailService.sendWelcomeEmail(CONTACT_EMAIL, PASSWORD, INSTITUTION_NAME, true, false);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 
   @Test
   public void testSendWelcomeEmailNoRtAndCt() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(
-        CONTACT_EMAIL, PASSWORD, FULL_USER_NAME, INSTITUTION_NAME, false, false);
+    mailService.sendWelcomeEmail(CONTACT_EMAIL, PASSWORD, INSTITUTION_NAME, false, false);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 


### PR DESCRIPTION
Tested by creating a user and observing this in the logs:
```
[Mon Feb 12 14:54:51 EST 2024] INFO: org.pmiops.workbench.mail.MailServiceImpl sendWithRetries - Email 'Welcome for joel-feb12@fake-research-aou.org (thibault@broadinstitute.org)' was sent.
```


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
