### PR TITLE
[DT-736][risk=no] Fix dates for Tanagra resources

### DIFF
--- a/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
@@ -105,11 +105,13 @@ const mapTanagraWorkspaceResource = ({
   cohort,
   conceptSet,
   review,
+  lastModified,
   workspace,
 }: {
   cohort?: Cohort;
   conceptSet?: ConceptSet;
   review?: Review;
+  lastModified: Date;
   workspace: WorkspaceData;
 }): TanagraWorkspaceResource => ({
   workspaceNamespace: workspace.namespace,
@@ -121,7 +123,7 @@ const mapTanagraWorkspaceResource = ({
   cohortTanagra: cohort,
   conceptSetTanagra: conceptSet,
   reviewTanagra: review,
-  lastModifiedEpochMillis: workspace.lastModifiedTime,
+  lastModifiedEpochMillis: lastModified.getTime(),
   adminLocked: workspace.adminLocked,
 });
 
@@ -178,13 +180,25 @@ export const DataComponentTanagra = fp.flow(
       }
       setResourceList([
         ...cohorts.map((cohort) =>
-          mapTanagraWorkspaceResource({ cohort, workspace })
+          mapTanagraWorkspaceResource({
+            cohort,
+            lastModified: cohort.lastModified,
+            workspace,
+          })
         ),
         ...conceptSets.map((conceptSet) =>
-          mapTanagraWorkspaceResource({ conceptSet, workspace })
+          mapTanagraWorkspaceResource({
+            conceptSet,
+            lastModified: conceptSet.lastModified,
+            workspace,
+          })
         ),
         ...reviews.map((review) =>
-          mapTanagraWorkspaceResource({ review, workspace })
+          mapTanagraWorkspaceResource({
+            review,
+            lastModified: review.lastModified,
+            workspace,
+          })
         ),
       ]);
     } catch (error) {


### PR DESCRIPTION
Fix 'Last Modified Date' column in the resources list for Tanagra workspaces, which was using the `lastModifiedTime` of the workspace instead of the resource.

Before:
![Screenshot 2024-02-14 at 5 07 38 PM](https://github.com/all-of-us/workbench/assets/40036095/6a485028-d743-4abf-804f-fa660c925acd)

After:
![Screenshot 2024-02-14 at 5 06 43 PM](https://github.com/all-of-us/workbench/assets/40036095/ea95f446-c213-4545-8842-f841f6b0976a)


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
