### PR TITLE
[risk=low][RW-11847] Easy prerequisites for the spring-boot upgrade

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         OKHTTP_VERSION = '2.7.5'
         OPENCENSUS_VERSION = '0.31.1'
         SPRINGFOX_VERSION = '3.0.0'
-        SPRING_BOOT_VERSION = '2.7.4'
+        SPRING_BOOT_VERSION = '2.7.18'
         SPRING_FRAMEWORK_VERSION = '5.3.23'
         SWAGGER_3_CODEGEN_VERSION = '3.0.34'
     }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         GSON_VERSION = '2.9.0'
         HIBERNATE_VERSION = '5.6.9.Final'
         JACKSON_DATABIND_VERSION = '2.13.4'
-        JACKSON_VERSION = '2.13.4'
+        JACKSON_VERSION = '2.16.1'
         KOTLIN_VERSION = '1.8.20'
         LIQUIBASE_VERSION = '4.16.1'
         LOGBACK_VERSION = '1.2.13'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         SPRINGFOX_VERSION = '3.0.0'
         SPRING_BOOT_VERSION = '2.7.18'
         SPRING_FRAMEWORK_VERSION = '5.3.23'
+        SPRING_SECURITY_VERSION = '5.8.9'
         SWAGGER_3_CODEGEN_VERSION = '3.0.34'
     }
 
@@ -483,8 +484,9 @@ dependencies {
     }
 
     implementation "org.springframework.retry:spring-retry"
-    implementation "org.springframework.security:spring-security-core"
-    implementation "org.springframework.security:spring-security-web"
+    implementation "org.springframework.security:spring-security-core:$project.ext.SPRING_SECURITY_VERSION"
+    implementation "org.springframework.security:spring-security-crypto:$project.ext.SPRING_SECURITY_VERSION"
+    implementation "org.springframework.security:spring-security-web:$project.ext.SPRING_SECURITY_VERSION"
 
     // updated versions of transitive dependencies to resolve vulnerabilities
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -425,7 +425,7 @@ dependencies {
     implementation 'io.swagger:swagger-annotations:1.6.7'
     implementation "javax.inject:javax.inject:1"
     implementation "org.liquibase:liquibase-core:$project.ext.LIQUIBASE_VERSION"
-    implementation 'mysql:mysql-connector-java:8.0.30'
+    implementation 'com.mysql:mysql-connector-j:8.3.0'
     implementation "org.apache.commons:commons-collections4:4.4"
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-text:1.10.0'

--- a/api/db-cdr/build.gradle
+++ b/api/db-cdr/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     liquibaseRuntime 'org.liquibase:liquibase-core:4.16.1'
     liquibaseRuntime 'org.liquibase:liquibase-groovy-dsl:3.0.2'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'mysql:mysql-connector-java:5.1.37'
+    liquibaseRuntime 'com.mysql:mysql-connector-j:8.3.0'
     liquibaseRuntime group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 }
 

--- a/api/db/build.gradle
+++ b/api/db/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     liquibaseRuntime 'org.liquibase:liquibase-core:4.16.1'
     liquibaseRuntime 'org.liquibase:liquibase-groovy-dsl:3.0.2'
     liquibaseRuntime 'info.picocli:picocli:4.6.1'
-    liquibaseRuntime 'mysql:mysql-connector-java:5.1.34'
+    liquibaseRuntime 'com.mysql:mysql-connector-j:8.3.0'
     liquibaseRuntime group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 }
 


### PR DESCRIPTION
First, bump spring-boot to the latest 2.x (this is not the major upgrade - that will be to 3.x)

Then made these prerequisite upgrades:
* mysql-connector
* spring-security
* jackson

Tested locally with no obvious issues.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
