### PR TITLE
[no ticket][risk=no] Added identity bypass time to AdminTableUser.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -249,6 +249,6 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  FROM user_access_module uam "
               + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
               + "  WHERE am.name = 'IDENTITY' "
-              + ") as uami ON u.user_id = uami.user_id " )
+              + ") as uami ON u.user_id = uami.user_id ")
   List<DbAdminTableUser> getAdminTableUsers();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -141,6 +141,8 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
     Timestamp getRasLinkLoginGovBypassTime();
 
+    Timestamp getIdentityBypassTime();
+
     String getAccessTierShortNames();
   }
 
@@ -171,6 +173,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "uampublication.publication_confirmation_bypass_time AS publicationConfirmationBypassTime, "
               + "uamt.two_factor_auth_bypass_time AS twoFactorAuthBypassTime, "
               + "uamr.ras_link_login_gov_bypass_time AS rasLinkLoginGovBypassTime, "
+              + "uami.identity_bypass_time AS identityBypassTime, "
               + "t.access_tier_short_names AS accessTierShortNames "
               + "FROM user u "
               + "LEFT JOIN user_verified_institutional_affiliation AS uvia ON u.user_id = uvia.user_id "
@@ -239,6 +242,13 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
               + "  FROM user_access_module uam "
               + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
               + "  WHERE am.name = 'RAS_LOGIN_GOV' "
-              + ") as uamr ON u.user_id = uamr.user_id ")
+              + ") as uamr ON u.user_id = uamr.user_id "
+              + "LEFT JOIN ( "
+              + "  SELECT uam.user_id, "
+              + "    uam.bypass_time AS identity_bypass_time "
+              + "  FROM user_access_module uam "
+              + "  JOIN access_module am ON am.access_module_id=uam.access_module_id "
+              + "  WHERE am.name = 'IDENTITY' "
+              + ") as uami ON u.user_id = uami.user_id " )
   List<DbAdminTableUser> getAdminTableUsers();
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8218,6 +8218,9 @@ components:
         rasLinkLoginGovBypassTime:
           type: integer
           format: int64
+        identityBypassTime:
+          type: integer
+          format: int64
         complianceTrainingBypassTime:
           type: integer
           format: int64

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -212,6 +212,7 @@ public class UserDaoTest {
     Timestamp duccBypassTime = Timestamp.from(now.minusSeconds(70));
     Timestamp duccCompleteTime = Timestamp.from(now.minusSeconds(80));
     Timestamp rasBypassTime = Timestamp.from(now.minusSeconds(90));
+    Timestamp identityBypassTime = Timestamp.from(now.minusSeconds(95));
     Timestamp ctTrainingBypassTime = Timestamp.from(now.minusSeconds(100));
     Timestamp ctTrainingCompleteTime = Timestamp.from(now.minusSeconds(110));
     Timestamp profileConfirmationBypassTime = Timestamp.from(now.minusSeconds(120));
@@ -227,6 +228,11 @@ public class UserDaoTest {
     addUserAccessModule(user, profileConfirmationModule, profileConfirmationBypassTime, null);
     addUserAccessModule(
         user, publicationConfirmationModule, publicationConfirmationBypassTime, null);
+    addUserAccessModule(
+        user,
+        accessModuleDao.findOneByName(DbAccessModuleName.IDENTITY).get(),
+        identityBypassTime,
+        null);
     List<DbAdminTableUser> rows = userDao.getAdminTableUsers();
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).getEraCommonsBypassTime()).isEqualTo(eRABypassTime);
@@ -235,6 +241,7 @@ public class UserDaoTest {
     assertThat(rows.get(0).getDuccBypassTime()).isEqualTo(duccBypassTime);
     assertThat(rows.get(0).getTwoFactorAuthBypassTime()).isEqualTo(twoFactorAuthBypassTime);
     assertThat(rows.get(0).getRasLinkLoginGovBypassTime()).isEqualTo(rasBypassTime);
+    assertThat(rows.get(0).getIdentityBypassTime()).isEqualTo(identityBypassTime);
     assertThat(rows.get(0).getProfileConfirmationBypassTime())
         .isEqualTo(profileConfirmationBypassTime);
     assertThat(rows.get(0).getPublicationConfirmationBypassTime())

--- a/ui/src/app/pages/admin/user/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.tsx
@@ -87,7 +87,7 @@ const moduleToToggleProps: Record<
     'data-test-id': 'ras-link-login-gov-toggle',
   },
   [AccessModule.IDENTITY]: {
-    name: 'Identity Verification!!!',
+    name: 'Identity Verification',
     'data-test-id': 'identity-toggle',
   },
   [AccessModule.PROFILE_CONFIRMATION]: {

--- a/ui/src/app/pages/admin/user/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.tsx
@@ -48,6 +48,7 @@ const getBypassedModules = (user: AdminTableUser): Array<AccessModule> => {
     ...(user.rasLinkLoginGovBypassTime
       ? [AccessModule.RAS_LINK_LOGIN_GOV]
       : []),
+    ...(user.identityBypassTime ? [AccessModule.IDENTITY] : []),
     ...(user.profileConfirmationBypassTime
       ? [AccessModule.PROFILE_CONFIRMATION]
       : []),
@@ -86,7 +87,7 @@ const moduleToToggleProps: Record<
     'data-test-id': 'ras-link-login-gov-toggle',
   },
   [AccessModule.IDENTITY]: {
-    name: 'Identity Verification',
+    name: 'Identity Verification!!!',
     'data-test-id': 'identity-toggle',
   },
   [AccessModule.PROFILE_CONFIRMATION]: {
@@ -137,6 +138,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
       user,
       user: { username },
     } = this.props;
+    console.log('What are selected modules? ', selectedModules);
     const changedModules = fp.xor(getBypassedModules(user), selectedModules);
     this.setState({ isSaving: true });
     try {
@@ -184,6 +186,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
   }
 
   render() {
+    console.log('Hi');
     const { selectedModules, isPopupOpen, isSaving } = this.state;
 
     const bypassToggleProps = orderedAccessModules
@@ -194,6 +197,9 @@ export class AdminUserBypass extends React.Component<Props, State> {
           module: module,
         };
       });
+
+    console.log('What are selectedModules? ', selectedModules);
+    console.log('What are bypassToggleProps? ', bypassToggleProps);
 
     return (
       <PopupTrigger
@@ -232,7 +238,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
                 onClick={() => this.save()}
                 disabled={!this.hasEdited()}
               >
-                Save
+                Save!!!
               </Button>
             </div>
             {isSaving && <SpinnerOverlay />}

--- a/ui/src/app/pages/admin/user/admin-user-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.tsx
@@ -138,7 +138,6 @@ export class AdminUserBypass extends React.Component<Props, State> {
       user,
       user: { username },
     } = this.props;
-    console.log('What are selected modules? ', selectedModules);
     const changedModules = fp.xor(getBypassedModules(user), selectedModules);
     this.setState({ isSaving: true });
     try {
@@ -186,7 +185,6 @@ export class AdminUserBypass extends React.Component<Props, State> {
   }
 
   render() {
-    console.log('Hi');
     const { selectedModules, isPopupOpen, isSaving } = this.state;
 
     const bypassToggleProps = orderedAccessModules
@@ -197,9 +195,6 @@ export class AdminUserBypass extends React.Component<Props, State> {
           module: module,
         };
       });
-
-    console.log('What are selectedModules? ', selectedModules);
-    console.log('What are bypassToggleProps? ', bypassToggleProps);
 
     return (
       <PopupTrigger
@@ -238,7 +233,7 @@ export class AdminUserBypass extends React.Component<Props, State> {
                 onClick={() => this.save()}
                 disabled={!this.hasEdited()}
               >
-                Save!!!
+                Save
               </Button>
             </div>
             {isSaving && <SpinnerOverlay />}


### PR DESCRIPTION
Added missing code to read identity bypass status on Admin User page.

To test that this work appropriately, bypass a user's Identity requirement from UserAdmin table and then navigate to the User Admin page for the same user to see if that user was appropriately bypassed
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
