### PR TITLE
[risk=low][no ticket] User apps config panel reacts to app changes

### DIFF
--- a/ui/src/app/components/apps-panel.tsx
+++ b/ui/src/app/components/apps-panel.tsx
@@ -151,6 +151,7 @@ export const AppsPanel = (props: {
               />
             ) : (
               <TooltipTrigger
+                key={availableApp.appType}
                 disabled={workspace.billingStatus !== BillingStatus.INACTIVE}
                 content={BILLING_ACCOUNT_DISABLED_TOOLTIP}
               >

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -521,7 +521,6 @@ describe(GKEAppConfigurationPanel.name, () => {
   });
 
   it('should update the Create panel when the app changes status', async () => {
-    // Setup: an RStudio disk exists and the current app is RStudio
     const workspaceNamespace = 'aou-rw-1234';
     const runningApp = {
       ...createListAppsRStudioResponse(),

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -4,7 +4,6 @@ import {
   AppsApi,
   AppType,
   DisksApi,
-  ListAppsResponse,
   UserAppEnvironment,
 } from 'generated/fetch';
 

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -21,7 +21,10 @@ import {
 } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { expectButtonElementEnabled } from 'testing/react-test-helpers';
+import {
+  expectButtonElementDisabled,
+  expectButtonElementEnabled,
+} from 'testing/react-test-helpers';
 import {
   AppsApiStub,
   createListAppsCromwellResponse,
@@ -63,7 +66,7 @@ const findOpenButton = (appType: string): HTMLElement =>
 
 const findCreateButton = (appType: string): HTMLElement =>
   screen.queryByRole('button', {
-    name: `${appType}  cloud environment create button`,
+    name: `${appType} cloud environment create button`,
   });
 
 describe(GKEAppConfigurationPanel.name, () => {
@@ -521,6 +524,8 @@ describe(GKEAppConfigurationPanel.name, () => {
   });
 
   it('should update the Create panel when the app changes status', async () => {
+    jest.useFakeTimers();
+
     const workspaceNamespace = 'aou-rw-1234';
     const runningApp = {
       ...createListAppsRStudioResponse(),
@@ -537,14 +542,16 @@ describe(GKEAppConfigurationPanel.name, () => {
       workspaceNamespace,
     });
 
-    // expect to see the open button because the app is running
-    await waitFor(() => {
-      expect(findOpenButton(UIAppType.RSTUDIO)).not.toBeNull();
+    // expect to see the (enabled) open button because the app is running
+    const openButton = await waitFor(() => {
+      const button = findOpenButton(UIAppType.RSTUDIO);
+      expect(button).not.toBeNull();
+      return button;
     });
+    expectButtonElementEnabled(openButton);
+
     // expect NOT to see the create button because the app is running
-    await waitFor(() => {
-      expect(findCreateButton(UIAppType.RSTUDIO)).toBeNull();
-    });
+    await waitFor(() => expect(findCreateButton(UIAppType.RSTUDIO)).toBeNull());
 
     const deletingApp = {
       ...runningApp,
@@ -552,18 +559,22 @@ describe(GKEAppConfigurationPanel.name, () => {
     };
     jest
       .spyOn(appsApi(), 'listAppsInWorkspace')
-      .mockImplementationOnce(
-        (): Promise<any> => Promise.resolve([deletingApp])
-      );
+      .mockImplementation((): Promise<any> => Promise.resolve([deletingApp]));
 
-    // expect to see the create button because the app is deleting
-    await waitFor(() => {
-      expect(findCreateButton(UIAppType.RSTUDIO)).toBeNull();
+    // wait for additional 5 min to ensure the app status change is processed
+    jest.advanceTimersByTime(5 * 60e3);
+
+    // expect to see the (disabled) create button because the app is deleting
+    const createButton = await waitFor(() => {
+      const button = findCreateButton(UIAppType.RSTUDIO);
+      expect(button).not.toBeNull();
+      return button;
     });
+    expectButtonElementDisabled(createButton);
 
     // expect NOT to see the open button because the app is deleting
-    await waitFor(() => {
-      expect(findOpenButton(UIAppType.RSTUDIO)).not.toBeNull();
-    });
+    await waitFor(() => expect(findOpenButton(UIAppType.RSTUDIO)).toBeNull());
+
+    jest.useRealTimers();
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
+import { UIAppType } from 'app/components/apps-panel/utils';
 import {
   appsApi,
   disksApi,
@@ -32,7 +33,6 @@ import {
 } from 'testing/stubs/apps-api-stub';
 import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 
-import { UIAppType } from './apps-panel/utils';
 import {
   GKEAppConfigurationPanel,
   GkeAppConfigurationPanelProps,

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -4,6 +4,7 @@ import {
   AppsApi,
   AppType,
   DisksApi,
+  ListAppsResponse,
   UserAppEnvironment,
 } from 'generated/fetch';
 
@@ -13,7 +14,11 @@ import {
   disksApi,
   registerApiClient,
 } from 'app/services/swagger-fetch-clients';
-import { notificationStore, serverConfigStore } from 'app/utils/stores';
+import {
+  notificationStore,
+  serverConfigStore,
+  userAppsStore,
+} from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
 import { expectButtonElementEnabled } from 'testing/react-test-helpers';
@@ -51,8 +56,10 @@ const validateInitialLoadingSpinner = async () => {
 
 describe(GKEAppConfigurationPanel.name, () => {
   beforeEach(() => {
+    jest.clearAllTimers();
     registerApiClient(AppsApi, new AppsApiStub());
     registerApiClient(DisksApi, new DisksApiStub());
+    userAppsStore.set({ updating: false, userApps: [] });
     notificationStore.set(null);
     serverConfigStore.set({
       config: {
@@ -105,20 +112,6 @@ describe(GKEAppConfigurationPanel.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve([]));
     createWrapper();
     await validateInitialLoadingSpinner();
-  });
-
-  it('should show an error if the list apps API call fails', async () => {
-    jest
-      .spyOn(appsApi(), 'listAppsInWorkspace')
-      .mockImplementation((): Promise<any> => Promise.reject());
-
-    expect(notificationStore.get()).toBeNull();
-
-    createWrapper();
-    await waitFor(() => {
-      expect(notificationStore.get().title).toBeTruthy();
-      expect(notificationStore.get().message).toBeTruthy();
-    });
   });
 
   it('should show an error if the list disks API call fails', async () => {

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -91,7 +91,7 @@ export const GKEAppConfigurationPanel = ({
   const onClickDeleteGkeApp = () =>
     setPanelContent(GKEAppPanelContent.DELETE_GKE_APP);
 
-  const onConfirmDeleteGKEApp = async (deletePDSelected) => {
+  const onConfirmDeleteGKEApp = async (deletePDSelected: boolean) => {
     await deleteUserApp(workspaceNamespace, app.appName, deletePDSelected);
     onClose();
   };

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -157,7 +157,7 @@ export const GKEAppConfigurationPanel = ({
           <ConfirmDeleteEnvironmentWithPD
             onConfirm={onConfirmDeleteGKEApp}
             onCancel={onClose}
-            appType={toUIAppType[app.appType]}
+            appType={toUIAppType[app?.appType]}
             usingDataproc={false}
             disk={disk}
           />

--- a/ui/src/app/components/gke-app-configuration-panel.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { AppType, Disk } from 'generated/fetch';
 
 import { switchCase } from '@terra-ui-packages/core-utils';
+import { findApp, toUIAppType } from 'app/components/apps-panel/utils';
 import { Spinner } from 'app/components/spinners';
 import { disksApi } from 'app/services/swagger-fetch-clients';
 import { notificationStore, userAppsStore, useStore } from 'app/utils/stores';
@@ -13,7 +14,6 @@ import {
   maybeStartPollingForUserApps,
 } from 'app/utils/user-apps-utils';
 
-import { findApp, toUIAppType } from './apps-panel/utils';
 import { ConfirmDelete } from './common-env-conf-panels/confirm-delete';
 import { ConfirmDeleteEnvironmentWithPD } from './common-env-conf-panels/confirm-delete-environment-with-pd';
 import { ConfirmDeleteUnattachedPD } from './common-env-conf-panels/confirm-delete-unattached-pd';

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -89,24 +89,36 @@ export const maybeStartPollingForUserApps = (namespace: string) => {
     });
 };
 
-export const createUserApp = (namespace, config: CreateAppRequest) =>
+export const createUserApp = (namespace: string, config: CreateAppRequest) =>
   appsApi()
     .createApp(namespace, config)
     .then(() => {
       maybeStartPollingForUserApps(namespace);
     });
 
-export const deleteUserApp = (namespace, appName, deleteDiskWithUserApp) =>
+export const deleteUserApp = (
+  namespace: string,
+  appName: string,
+  deleteDiskWithUserApp: boolean
+) =>
   appsApi()
     .deleteApp(namespace, appName, deleteDiskWithUserApp)
     .then(() => maybeStartPollingForUserApps(namespace));
 
-export const pauseUserApp = (googleProject, appName, namespace) =>
+export const pauseUserApp = (
+  googleProject: string,
+  appName: string,
+  namespace: string
+) =>
   leoAppsApi()
     .stopApp(googleProject, appName)
     .then(() => maybeStartPollingForUserApps(namespace));
 
-export const resumeUserApp = (googleProject, appName, namespace) =>
+export const resumeUserApp = (
+  googleProject: string,
+  appName: string,
+  namespace: string
+) =>
   leoAppsApi()
     .startApp(googleProject, appName)
     .then(() => maybeStartPollingForUserApps(namespace));

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -52,7 +52,7 @@ export const updateLastActive = (userApps: ListAppsResponse) => {
       app.dateAccessed ? new Date(app.dateAccessed).valueOf() : 0
     )
   );
-  if (userAppLastActive > getLastActiveEpochMillis() ?? 0) {
+  if (userAppLastActive > (getLastActiveEpochMillis() ?? 0)) {
     setLastActive(userAppLastActive);
   }
 };


### PR DESCRIPTION
The user apps config panel was checking for apps only **once** on load, instead of receiving updates by polling and checking the store.

Tested locally by opening the app config panel after creating and deleting apps, and observing that the button changed from "start" to "open" or vice-versa as appropriate **without any user interaction**

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
