### PR TITLE
[RW-11654][risk=no] Adding valid URL requirement

### DIFF
--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -60,8 +60,6 @@ class RuntimesApiTest {
     RuntimesApi api = new RuntimesApi(client);
 
     LeonardoCreateRuntimeRequest request = new LeonardoCreateRuntimeRequest();
-    request.setJupyterUserScriptUri("http://string.com");
-    request.setJupyterStartUserScriptUri("http://start.com");
     request.setAutopause(true);
     request.setAutopauseThreshold(57);
     request.setDefaultClientId("string");

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -33,12 +33,13 @@ class RuntimesApiTest {
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
-            //These string matchers are used to ensure these fields are present and have the
+            // These string matchers are used to ensure these fields are present and have the
             // correct format. The third argument is the value that is stored in the contract.
             // StringType will use a random string each time, but there is no way to ensure that
             // the string is a valid URL.
             body.stringMatcher("jupyterUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
-            body.stringMatcher("jupyterStartUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
+            body.stringMatcher(
+                "jupyterStartUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
             body.booleanType("autopause");
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
@@ -122,26 +123,26 @@ class RuntimesApiTest {
         .headers(contentTypeJsonHeader)
         .body(
             newJsonBody(
-                body -> {
-                  body.stringType("runtimeName");
-                  body.stringType("status");
-                  body.numberType("autopauseThreshold");
-                  body.stringType("proxyUrl");
-                  body.array("errors", errors -> {});
-                  body.object(
-                      "cloudContext",
-                      context -> {
-                        context.stringType("cloudProvider");
-                        context.stringType("cloudResource");
-                      });
-                  body.object(
-                      "auditInfo",
-                      context -> {
-                        context.stringType("creator");
-                        context.stringType("createdDate");
-                        context.stringType("dateAccessed");
-                      });
-                })
+                    body -> {
+                      body.stringType("runtimeName");
+                      body.stringType("status");
+                      body.numberType("autopauseThreshold");
+                      body.stringType("proxyUrl");
+                      body.array("errors", errors -> {});
+                      body.object(
+                          "cloudContext",
+                          context -> {
+                            context.stringType("cloudProvider");
+                            context.stringType("cloudResource");
+                          });
+                      body.object(
+                          "auditInfo",
+                          context -> {
+                            context.stringType("creator");
+                            context.stringType("createdDate");
+                            context.stringType("dateAccessed");
+                          });
+                    })
                 .build())
         .toPact();
   }
@@ -193,11 +194,11 @@ class RuntimesApiTest {
         .path("/api/google/v1/runtimes/googleProject/exampleruntimename")
         .body(
             newJsonBody(
-                body -> {
-                  body.booleanType("allowStop");
-                  body.booleanType("autopause");
-                  body.numberType("autopauseThreshold");
-                })
+                    body -> {
+                      body.booleanType("allowStop");
+                      body.booleanType("autopause");
+                      body.numberType("autopauseThreshold");
+                    })
                 .build())
         .willRespondWith()
         .status(202)
@@ -227,22 +228,22 @@ class RuntimesApiTest {
         .path("/api/google/v1/runtimes/googleProject/exampleruntimename")
         .body(
             newJsonBody(
-                body -> {
-                  body.booleanType("allowStop");
-                  body.booleanType("autopause");
-                  body.numberType("autopauseThreshold");
-                  body.object(
-                      "runtimeConfig",
-                      runtimeConfig -> {
-                        runtimeConfig.stringType("cloudService");
-                        runtimeConfig.stringType("machineType");
-                        runtimeConfig.numberType("diskSize");
-                      });
-                  body.array("labelsToDelete", arr -> arr.stringType("deletableLabel"));
-                  body.object(
-                      "labelsToUpsert",
-                      labels -> labels.stringValue("randomKey", "randomValue"));
-                })
+                    body -> {
+                      body.booleanType("allowStop");
+                      body.booleanType("autopause");
+                      body.numberType("autopauseThreshold");
+                      body.object(
+                          "runtimeConfig",
+                          runtimeConfig -> {
+                            runtimeConfig.stringType("cloudService");
+                            runtimeConfig.stringType("machineType");
+                            runtimeConfig.numberType("diskSize");
+                          });
+                      body.array("labelsToDelete", arr -> arr.stringType("deletableLabel"));
+                      body.object(
+                          "labelsToUpsert",
+                          labels -> labels.stringValue("randomKey", "randomValue"));
+                    })
                 .build())
         .willRespondWith()
         .status(404)

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -39,6 +39,7 @@ class RuntimesApiTest {
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
             body.stringType("toolDockerImage");
+            body.stringType("welderRegistry");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -33,8 +33,6 @@ class RuntimesApiTest {
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
-            body.stringType("jupyterUserScriptUri");
-            body.stringType("jupyterStartUserScriptUri");
             body.booleanType("autopause");
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -39,7 +39,6 @@ class RuntimesApiTest {
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
             body.stringType("toolDockerImage");
-            body.stringType("welderRegistry");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -237,7 +237,6 @@ class RuntimesApiTest {
                           runtimeConfig -> {
                             runtimeConfig.stringMatcher(
                                 "cloudService", "(DATAPROC|GCE)", CloudServiceEnum.GCE.name());
-                            runtimeConfig.stringType("cloudService");
                             runtimeConfig.stringType("machineType");
                             runtimeConfig.numberType("diskSize");
                           });

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -33,6 +33,8 @@ class RuntimesApiTest {
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
+            body.stringMatcher("jupyterUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
+            body.stringMatcher("jupyterStartUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
             body.booleanType("autopause");
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
@@ -60,6 +62,8 @@ class RuntimesApiTest {
     RuntimesApi api = new RuntimesApi(client);
 
     LeonardoCreateRuntimeRequest request = new LeonardoCreateRuntimeRequest();
+    request.setJupyterUserScriptUri("http://string.com");
+    request.setJupyterStartUserScriptUri("http://start.com");
     request.setAutopause(true);
     request.setAutopauseThreshold(57);
     request.setDefaultClientId("string");
@@ -91,6 +95,8 @@ class RuntimesApiTest {
     RuntimesApi api = new RuntimesApi(client);
 
     LeonardoCreateRuntimeRequest request = new LeonardoCreateRuntimeRequest();
+    request.setJupyterUserScriptUri("http://string.com");
+    request.setJupyterStartUserScriptUri("http://start.com");
     request.setAutopause(true);
     request.setAutopauseThreshold(57);
     request.setDefaultClientId("string");
@@ -112,26 +118,26 @@ class RuntimesApiTest {
         .headers(contentTypeJsonHeader)
         .body(
             newJsonBody(
-                    body -> {
-                      body.stringType("runtimeName");
-                      body.stringType("status");
-                      body.numberType("autopauseThreshold");
-                      body.stringType("proxyUrl");
-                      body.array("errors", errors -> {});
-                      body.object(
-                          "cloudContext",
-                          context -> {
-                            context.stringType("cloudProvider");
-                            context.stringType("cloudResource");
-                          });
-                      body.object(
-                          "auditInfo",
-                          context -> {
-                            context.stringType("creator");
-                            context.stringType("createdDate");
-                            context.stringType("dateAccessed");
-                          });
-                    })
+                body -> {
+                  body.stringType("runtimeName");
+                  body.stringType("status");
+                  body.numberType("autopauseThreshold");
+                  body.stringType("proxyUrl");
+                  body.array("errors", errors -> {});
+                  body.object(
+                      "cloudContext",
+                      context -> {
+                        context.stringType("cloudProvider");
+                        context.stringType("cloudResource");
+                      });
+                  body.object(
+                      "auditInfo",
+                      context -> {
+                        context.stringType("creator");
+                        context.stringType("createdDate");
+                        context.stringType("dateAccessed");
+                      });
+                })
                 .build())
         .toPact();
   }
@@ -183,11 +189,11 @@ class RuntimesApiTest {
         .path("/api/google/v1/runtimes/googleProject/exampleruntimename")
         .body(
             newJsonBody(
-                    body -> {
-                      body.booleanType("allowStop");
-                      body.booleanType("autopause");
-                      body.numberType("autopauseThreshold");
-                    })
+                body -> {
+                  body.booleanType("allowStop");
+                  body.booleanType("autopause");
+                  body.numberType("autopauseThreshold");
+                })
                 .build())
         .willRespondWith()
         .status(202)
@@ -217,22 +223,22 @@ class RuntimesApiTest {
         .path("/api/google/v1/runtimes/googleProject/exampleruntimename")
         .body(
             newJsonBody(
-                    body -> {
-                      body.booleanType("allowStop");
-                      body.booleanType("autopause");
-                      body.numberType("autopauseThreshold");
-                      body.object(
-                          "runtimeConfig",
-                          runtimeConfig -> {
-                            runtimeConfig.stringType("cloudService");
-                            runtimeConfig.stringType("machineType");
-                            runtimeConfig.numberType("diskSize");
-                          });
-                      body.array("labelsToDelete", arr -> arr.stringType("deletableLabel"));
-                      body.object(
-                          "labelsToUpsert",
-                          labels -> labels.stringValue("randomKey", "randomValue"));
-                    })
+                body -> {
+                  body.booleanType("allowStop");
+                  body.booleanType("autopause");
+                  body.numberType("autopauseThreshold");
+                  body.object(
+                      "runtimeConfig",
+                      runtimeConfig -> {
+                        runtimeConfig.stringType("cloudService");
+                        runtimeConfig.stringType("machineType");
+                        runtimeConfig.numberType("diskSize");
+                      });
+                  body.array("labelsToDelete", arr -> arr.stringType("deletableLabel"));
+                  body.object(
+                      "labelsToUpsert",
+                      labels -> labels.stringValue("randomKey", "randomValue"));
+                })
                 .build())
         .willRespondWith()
         .status(404)

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -33,6 +33,10 @@ class RuntimesApiTest {
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
+            //These string matchers are used to ensure these fields are present and have the
+            // correct format. The third argument is the value that is stored in the contract.
+            // StringType will use a random string each time, but there is no way to ensure that
+            // the string is a valid URL.
             body.stringMatcher("jupyterUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
             body.stringMatcher("jupyterStartUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
             body.booleanType("autopause");

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -235,6 +235,8 @@ class RuntimesApiTest {
                       body.object(
                           "runtimeConfig",
                           runtimeConfig -> {
+                            runtimeConfig.stringMatcher(
+                                "cloudService", "(DATAPROC|GCE)", CloudServiceEnum.GCE.name());
                             runtimeConfig.stringType("cloudService");
                             runtimeConfig.stringType("machineType");
                             runtimeConfig.numberType("diskSize");

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -91,8 +91,6 @@ class RuntimesApiTest {
     RuntimesApi api = new RuntimesApi(client);
 
     LeonardoCreateRuntimeRequest request = new LeonardoCreateRuntimeRequest();
-    request.setJupyterUserScriptUri("http://string.com");
-    request.setJupyterStartUserScriptUri("http://start.com");
     request.setAutopause(true);
     request.setAutopauseThreshold(57);
     request.setDefaultClientId("string");


### PR DESCRIPTION
~~Removing deprecated fields.~~

~~https://github.com/DataBiosphere/leonardo/blob/2430b89b14f95ab51e8886def70f571c8febb610/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/api/RuntimeRoutes.scala#L432~~

While these fields are still in use, that is not why the contract was failing. They were failing, because I had said they could be any string when they need to be a valid URL.
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
