### PR TITLE
[risk=low][no ticket] Make the last-modified-time sortable in the apps list (analysis tab)

### DIFF
--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -146,7 +146,7 @@ export const AppFilesList = withCurrentWorkspace()(
       }
     }, [workspace, isTransferComplete]);
 
-    const displayMenu = (row) => {
+    const displayMenu = (row: FileDetail) => {
       return (
         <NotebookActionMenu
           resource={convertToResources([row], props.workspace)[0]}
@@ -159,14 +159,14 @@ export const AppFilesList = withCurrentWorkspace()(
       );
     };
 
-    const displayAppLogo = (row) => {
+    const displayAppLogo = (row: FileDetail) => {
       // Find App Type on the basis of file name extension
       const { name } = row;
       const appType = getAppInfoFromFileName(name).appType;
       return <AppBanner appType={appType} style={{ marginRight: '1em' }} />;
     };
 
-    const displayName = (row) => {
+    const displayName = (row: FileDetail) => {
       const {
         workspace: { namespace, id },
       } = props;
@@ -189,7 +189,7 @@ export const AppFilesList = withCurrentWorkspace()(
       );
     };
 
-    const displayLastModifiedTime = (row) => {
+    const displayLastModifiedTime = (row: FileDetail) => {
       const time = displayDateWithoutHours(row.lastModifiedTime);
       return <div>{time}</div>;
     };
@@ -242,7 +242,7 @@ export const AppFilesList = withCurrentWorkspace()(
                   style={styles.columns}
                   headerStyle={styles.tableHeader}
                   header='Name'
-                  field={'name'}
+                  field='name'
                   body={displayName}
                   bodyStyle={styles.rows}
                   filter
@@ -255,6 +255,8 @@ export const AppFilesList = withCurrentWorkspace()(
                   style={styles.columns}
                   bodyStyle={styles.rows}
                   header='Last Modified Time'
+                  field='lastModifiedTime'
+                  sortable
                   body={displayLastModifiedTime}
                 />
                 <Column


### PR DESCRIPTION
When we updated the analysis tab UX to the new apps-list, we accidentally removed the ability to sort by last modified time.  This PR restores it.

![lastmod](https://github.com/all-of-us/workbench/assets/2701406/f117875f-7db5-41e7-91fb-426454e0c8f3)



---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
