### PR TITLE
[risk=low][no ticket] 404 is better than 500/NPE when not found

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudStorageClientImpl.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.google;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.CopyRequest;
@@ -59,17 +60,24 @@ public class CloudStorageClientImpl implements CloudStorageClient {
 
   @Override
   public List<Blob> getBlobPage(String bucketName) {
-    return storageProvider.get().get(bucketName).list().streamValues().collect(Collectors.toList());
+    return getBucketOrThrow(bucketName).list().streamValues().toList();
   }
 
   @Override
   public List<Blob> getBlobPageForPrefix(String bucketName, String directory) {
-    return storageProvider
-        .get()
-        .get(bucketName)
+    return getBucketOrThrow(bucketName)
         .list(Storage.BlobListOption.prefix(directory))
         .streamValues()
-        .collect(Collectors.toList());
+        .toList();
+  }
+
+  private Bucket getBucketOrThrow(String bucketName) {
+    Bucket b = storageProvider.get().get(bucketName);
+    if (b == null) {
+      // better than NullPointerException
+      throw new NotFoundException("Bucket " + bucketName);
+    }
+    return b;
   }
 
   private String getCredentialsBucketName() {


### PR DESCRIPTION
This shouldn't ever happen, because any bucket we reference should exist, but I found a weird edge case today - a partially deleted workspace which I am looking into.

Anyway, we should return a better error message when this happens. 

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
