### PR TITLE
[DT-773][risk=no] adding ability to use variantFilter to select variants. 

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -2498,7 +2498,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @ParameterizedTest
   @ValueSource(strings = {"1-101504524-G-A", "gene", "chr20:955-1000", "rs23346"})
   public void findVariants(String searchTerm) {
-    VariantFilterRequest request = new VariantFilterRequest().searchTerm(searchTerm);
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm(searchTerm);
     Variant expectedVariant =
         new Variant()
             .vid("1-101504524-G-A")
@@ -2515,11 +2516,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByConsequence() {
-    VariantFilterRequest request =
-        new VariantFilterRequest()
-            .searchTerm("gene")
-            .addConsequenceListItem("intron_variant")
-            .addConsequenceListItem("non_coding_transcript_variant");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request
+        .searchTerm("gene")
+        .addConsequenceListItem("intron_variant")
+        .addConsequenceListItem("non_coding_transcript_variant");
     Variant expectedVariant =
         new Variant()
             .vid("1-101504524-G-A")
@@ -2536,11 +2537,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByConsequenceNA() {
-    VariantFilterRequest request =
-        new VariantFilterRequest()
-            .searchTerm("gene3")
-            .addConsequenceListItem("n/a")
-            .addConsequenceListItem("intron_variant");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request
+        .searchTerm("gene3")
+        .addConsequenceListItem("n/a")
+        .addConsequenceListItem("intron_variant");
     Variant expectedVariant =
         new Variant()
             .vid("1-100550658-T-AA")
@@ -2557,11 +2558,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByClinicalSignificance() {
-    VariantFilterRequest request =
-        new VariantFilterRequest()
-            .searchTerm("gene")
-            .addClinicalSignificanceListItem("likely pathogenic")
-            .addClinicalSignificanceListItem("pathogenic");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request
+        .searchTerm("gene")
+        .addClinicalSignificanceListItem("likely pathogenic")
+        .addClinicalSignificanceListItem("pathogenic");
     Variant expectedVariant =
         new Variant()
             .vid("1-101504524-G-A")
@@ -2578,11 +2579,11 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByClinicalSignificanceNA() {
-    VariantFilterRequest request =
-        new VariantFilterRequest()
-            .searchTerm("gene3")
-            .addClinicalSignificanceListItem("n/a")
-            .addClinicalSignificanceListItem("pathogenic");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request
+        .searchTerm("gene3")
+        .addClinicalSignificanceListItem("n/a")
+        .addClinicalSignificanceListItem("pathogenic");
     Variant expectedVariant =
         new Variant()
             .vid("1-100550658-T-AA")
@@ -2599,8 +2600,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByGeneList() {
-    VariantFilterRequest request =
-        new VariantFilterRequest().searchTerm("gene").addGeneListItem("gene, gene2");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm("gene").addGeneListItem("gene, gene2");
     Variant expectedVariant =
         new Variant()
             .vid("1-101504524-G-A")
@@ -2617,8 +2618,8 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByGenesListNA() {
-    VariantFilterRequest request =
-        new VariantFilterRequest().searchTerm("rs23347").addGeneListItem("n/a");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm("rs23347").addGeneListItem("n/a");
     Variant expectedVariant =
         new Variant()
             .vid("1-100550658-T-AH")
@@ -2634,15 +2635,15 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsFilterByMinAndMax() {
-    VariantFilterRequest request =
-        new VariantFilterRequest()
-            .searchTerm("gene")
-            .countMin(4L)
-            .countMax(5L)
-            .numberMin(18242L)
-            .numberMax(18245L)
-            .frequencyMin(new BigDecimal("0.000277").setScale(6, RoundingMode.HALF_UP))
-            .frequencyMax(new BigDecimal(1).setScale(6, RoundingMode.HALF_UP));
+    VariantFilterRequest request = new VariantFilterRequest();
+    request
+        .searchTerm("gene")
+        .countMin(4L)
+        .countMax(5L)
+        .numberMin(18242L)
+        .numberMax(18245L)
+        .frequencyMin(new BigDecimal("0.000277").setScale(6, RoundingMode.HALF_UP))
+        .frequencyMax(new BigDecimal(1).setScale(6, RoundingMode.HALF_UP));
     Variant expectedVariant =
         new Variant()
             .vid("1-101504524-G-A")
@@ -2659,8 +2660,9 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantsSortByAlleleCount() {
-    VariantFilterRequest request =
-        new VariantFilterRequest().searchTerm("gene1").pageSize(1).sortBy("Allele Count");
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm("gene1");
+    request.pageSize(1).sortBy("Allele Count");
     Variant expectedVariant =
         new Variant()
             .vid("1-100550658-T-H")
@@ -2692,7 +2694,9 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariants_Pagination() {
-    VariantFilterRequest request = new VariantFilterRequest().searchTerm("gene1").pageSize(1);
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm("gene1");
+    request.pageSize(1);
     VariantListResponse response =
         controller.findVariants(WORKSPACE_NAMESPACE, WORKSPACE_ID, request).getBody();
     List<Variant> items = Objects.requireNonNull(response).getItems();
@@ -2739,20 +2743,20 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
 
   @Test
   public void findVariantFilters() {
-    VariantFilterRequest request = new VariantFilterRequest().searchTerm("chr20:1000-5000");
-    VariantFilterResponse expectedVariantFilter =
-        new VariantFilterResponse()
-            .geneList(Arrays.asList("gene, gene2", "gene3"))
-            .consequenceList(
-                Arrays.asList("intron_variant", "n/a", "non_coding_transcript_variant"))
-            .clinicalSignificanceList(Arrays.asList("likely pathogenic", "n/a", "pathogenic"))
-            .countMin(5L)
-            .countMax(7L)
-            .numberMin(18226L)
-            .numberMax(18242L)
-            .frequencyMin(new BigDecimal(0))
-            .frequencyMax(new BigDecimal(1))
-            .sortByList(VariantQueryBuilder.VatColumns.getDisplayNameList());
+    VariantFilterRequest request = new VariantFilterRequest();
+    request.searchTerm("chr20:1000-5000");
+    VariantFilterResponse expectedVariantFilter = new VariantFilterResponse();
+    expectedVariantFilter
+        .geneList(Arrays.asList("gene, gene2", "gene3"))
+        .consequenceList(Arrays.asList("intron_variant", "n/a", "non_coding_transcript_variant"))
+        .clinicalSignificanceList(Arrays.asList("likely pathogenic", "n/a", "pathogenic"))
+        .countMin(5L)
+        .countMax(7L)
+        .numberMin(18226L)
+        .numberMax(18242L)
+        .frequencyMin(new BigDecimal(0))
+        .frequencyMax(new BigDecimal(1));
+    expectedVariantFilter.sortByList(VariantQueryBuilder.VatColumns.getDisplayNameList());
     assertFindVariantFiltersResponse(request, expectedVariantFilter);
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -10953,6 +10953,8 @@ components:
         variantId:
           type: string
           description: The variant id of SNP Indel Variants.
+        variantFilter:
+          $ref: '#/components/schemas/VariantFilter'
         attributes:
           type: array
           description: |
@@ -11237,105 +11239,94 @@ components:
           format: int64
         conceptName:
           type: string
+    BaseVariantFilter:
+      type: object
+      properties:
+        geneList:
+          type: array
+          description: List of string gene names
+          items:
+            type: string
+        consequenceList:
+          type: array
+          description: List of string consequence names
+          items:
+            type: string
+        clinicalSignificanceList:
+          type: array
+          description: List of string clinical significance names
+          items:
+            type: string
+        countMin:
+          type: integer
+          format: int64
+          description: Allele count min
+        countMax:
+          type: integer
+          format: int64
+          description: Allele count max
+        numberMin:
+          type: integer
+          format: int64
+          description: Allele number min
+        numberMax:
+          type: integer
+          format: int64
+          description: Allele number max
+        frequencyMin:
+          type: number
+          description: Allele frequency min(floating point)
+        frequencyMax:
+          type: number
+          description: Allele number max(floating point)
+        participantCountRange:
+          $ref: '#/components/schemas/ParticipantCountFilter'
+    VariantFilter:
+      allOf:
+        - $ref: '#/components/schemas/BaseVariantFilter'
+        - type: object
+          required: 
+            - searchTerm
+          properties:
+            searchTerm:
+              type: string
+              description: The term used to search variants.
     VariantFilterRequest:
-      type: object
+      allOf:
+        - $ref: '#/components/schemas/VariantFilter'
+        - type: object
+          properties:
+            pageToken:
+              type: string
+              description: Used for retrieving additional pages of results.
+            pageSize:
+              type: integer
+              description: page size of results (default is 25)
+            sortBy:
+              type: string
+              description: sort column by
+    ParticipantCountFilter:
       required:
-      - searchTerm
-      properties:
-        searchTerm:
-          type: string
-          description: The term used to search variants.
-        pageToken:
-          type: string
-          description: Used for retrieving additional pages of results.
-        pageSize:
-          type: integer
-          description: page size of results (default is 25)
-        geneList:
-          type: array
-          description: List of string gene names
-          items:
-            type: string
-        consequenceList:
-          type: array
-          description: List of string consequence names
-          items:
-            type: string
-        clinicalSignificanceList:
-          type: array
-          description: List of string clinical significance names
-          items:
-            type: string
-        countMin:
-          type: integer
-          format: int64
-          description: Allele count min
-        countMax:
-          type: integer
-          format: int64
-          description: Allele count max
-        numberMin:
-          type: integer
-          format: int64
-          description: Allele number min
-        numberMax:
-          type: integer
-          format: int64
-          description: Allele number max
-        frequencyMin:
-          type: number
-          description: Allele frequency min(floating point)
-        frequencyMax:
-          type: number
-          description: Allele number max(floating point)
-        sortBy:
-          type: string
-          description: sort column by
-    VariantFilterResponse:
+        - operator
+        - operands
       type: object
       properties:
-        geneList:
+        operator:
+          $ref: '#/components/schemas/Operator'
+        operands:
           type: array
-          description: List of string gene names
           items:
             type: string
-        consequenceList:
-          type: array
-          description: List of string consequence names
-          items:
-            type: string
-        clinicalSignificanceList:
-          type: array
-          description: List of string clinical significance names
-          items:
-            type: string
-        countMin:
-          type: integer
-          format: int64
-          description: Allele count min
-        countMax:
-          type: integer
-          format: int64
-          description: Allele count max
-        numberMin:
-          type: integer
-          format: int64
-          description: Allele number min
-        numberMax:
-          type: integer
-          format: int64
-          description: Allele number max
-        frequencyMin:
-          type: number
-          description: Allele frequency min(floating point)
-        frequencyMax:
-          type: number
-          description: Allele number max(floating point)
-        sortByList:
-          type: array
-          description: List of string column names
-          items:
-            type: string
+    VariantFilterResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseVariantFilter'
+        - type: object
+          properties:
+            sortByList:
+              type: array
+              description: List of string column names
+              items:
+                type: string
     VariantListResponse:
       required:
       - items


### PR DESCRIPTION
adding ability to use variantFilter to select variants. Now the `SearchParameter` model object allows for 2 different ways to add variants:

1. VariantId - can add variants one at a time
2. VaraintFilter - can add variants using a variantFilter

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
