### PR TITLE
[risk=low][RW-11801] Dataset export UI update for RStudio

### DIFF
--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -63,7 +63,7 @@ describe(ExportDatasetModal.name, () => {
   }
 
   function findNotebookNameInput() {
-    return screen.getByLabelText('Notebook Name');
+    return screen.getByLabelText('Jupyter Notebook Name');
   }
 
   const waitUntilDoneLoading = async () =>
@@ -260,14 +260,16 @@ describe(ExportDatasetModal.name, () => {
 
     await waitUntilDoneLoading();
 
-    const notebookDropdown = screen.getByText(/\(create a new notebook\)/i);
+    const notebookDropdown = screen.getByText(
+      /\(create a new jupyter notebook\)/i
+    );
     await user.click(notebookDropdown);
 
     const existingNotebookOption = screen.getByText(notebookName);
     await user.click(existingNotebookOption);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText('Notebook Name')).toBeNull();
+      expect(screen.queryByLabelText('Jupyter Notebook Name')).toBeNull();
     });
 
     await clickExportButton();

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -338,7 +338,9 @@ export const ExportDatasetModal = ({
       : {}),
   };
 
-  const selectOptions = [{ label: '(Create a new notebook)', value: '' }];
+  const selectOptions = [
+    { label: '(Create a new Jupyter notebook)', value: '' },
+  ];
   if (!isNotebooksLoading) {
     selectOptions.push(
       ...existingNotebooks.map((notebook) => ({
@@ -363,17 +365,18 @@ export const ExportDatasetModal = ({
                 value={creatingNewNotebook ? '' : notebookNameWithoutSuffix}
                 data-test-id='select-notebook'
                 options={selectOptions}
-                onChange={(v) => onNotebookSelect(v)}
+                onChange={onNotebookSelect}
               />
             </div>
 
             {creatingNewNotebook && (
               <label>
                 <SmallHeader style={{ fontSize: 14, marginTop: '1.5rem' }}>
-                  Notebook Name
+                  Jupyter Notebook Name
                 </SmallHeader>
                 <TextInput
-                  onChange={(v) => setNotebookNameWithoutSuffix(v)}
+                  onChange={setNotebookNameWithoutSuffix}
+                  onBlur={setNotebookNameWithoutSuffix}
                   value={notebookNameWithoutSuffix}
                   data-test-id='notebook-name-input'
                   disabled={shouldDisable}

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -363,8 +363,8 @@ export const ExportDatasetModal = ({
             <div>
               You can export the code to an existing or new{' '}
               <b>Jupyter Notebook in {JUPYTER_FILE_EXT} format</b>. You can also
-              copy the generated code to the clipboard and paste into any app in
-              the workbench, such as RStudio.
+              copy the generated code to the clipboard and paste into any
+              application in the workbench, such as RStudio.
             </div>
             <div style={headerStyles.formLabel}>
               Select programming language

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -364,7 +364,7 @@ export const ExportDatasetModal = ({
               You can export the code to an existing or new{' '}
               <b>Jupyter Notebook in {JUPYTER_FILE_EXT} format</b>. You can also
               copy the generated code to the clipboard and paste into any app in
-              the workbench.
+              the workbench, such as RStudio.
             </div>
             <div style={headerStyles.formLabel}>
               Select programming language

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -36,6 +36,7 @@ import { dataSetApi, notebooksApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import { isEmpty, reactStyles, summarizeErrors } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
+import { JUPYTER_FILE_EXT } from 'app/utils/constants';
 import { encodeURIComponentStrict, useNavigation } from 'app/utils/navigation';
 import { validateNewNotebookName } from 'app/utils/resources';
 import { ACTION_DISABLED_INVALID_BILLING } from 'app/utils/strings';
@@ -359,31 +360,12 @@ export const ExportDatasetModal = ({
         <div style={{ width: 'calc(450px - 3rem)' }}>
           <ModalTitle>Export Dataset</ModalTitle>
           <ModalBody>
-            <div style={{ marginTop: '1.5rem' }}>
-              <Select
-                isDisabled={shouldDisable}
-                value={creatingNewNotebook ? '' : notebookNameWithoutSuffix}
-                data-test-id='select-notebook'
-                options={selectOptions}
-                onChange={onNotebookSelect}
-              />
+            <div>
+              You can export the code to an existing or new{' '}
+              <b>Jupyter Notebook in {JUPYTER_FILE_EXT} format</b>. You can also
+              copy the generated code to the clipboard and paste into any app in
+              the workbench.
             </div>
-
-            {creatingNewNotebook && (
-              <label>
-                <SmallHeader style={{ fontSize: 14, marginTop: '1.5rem' }}>
-                  Jupyter Notebook Name
-                </SmallHeader>
-                <TextInput
-                  onChange={setNotebookNameWithoutSuffix}
-                  onBlur={setNotebookNameWithoutSuffix}
-                  value={notebookNameWithoutSuffix}
-                  data-test-id='notebook-name-input'
-                  disabled={shouldDisable}
-                />
-              </label>
-            )}
-
             <div style={headerStyles.formLabel}>
               Select programming language
             </div>
@@ -408,6 +390,31 @@ export const ExportDatasetModal = ({
                   {analysisLanguageValue}
                 </label>
               ))}
+
+            <div style={{ marginTop: '1.5rem' }}>
+              <Select
+                isDisabled={shouldDisable}
+                value={creatingNewNotebook ? '' : notebookNameWithoutSuffix}
+                data-test-id='select-notebook'
+                options={selectOptions}
+                onChange={onNotebookSelect}
+              />
+            </div>
+
+            {creatingNewNotebook && (
+              <label>
+                <SmallHeader style={{ fontSize: 14, marginTop: '1.5rem' }}>
+                  Jupyter Notebook Name
+                </SmallHeader>
+                <TextInput
+                  onChange={setNotebookNameWithoutSuffix}
+                  onBlur={setNotebookNameWithoutSuffix}
+                  value={notebookNameWithoutSuffix}
+                  data-test-id='notebook-name-input'
+                  disabled={shouldDisable}
+                />
+              </label>
+            )}
 
             {hasWgs() && analysisLanguage === AnalysisLanguage.PYTHON && (
               <React.Fragment>


### PR DESCRIPTION
Partial completion of RW-11801:
* Whenever a notebook is mentioned, we now specify that we mean a **Jupyter** notebook
* Text is added explaining that direct export to notebooks is only for Jupyter
* Language choice is now first

<img width="509" alt="Screenshot 2024-03-11 at 1 00 58 PM" src="https://github.com/all-of-us/workbench/assets/2701406/fc020171-bb01-4711-83b0-8a4e61dce1a6">

The "disable for SAS" portion of RW-11801 will be done along with SAS support in #8424

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
