### PR TITLE
[risk=low] RW-12040 Allow workspace deletion

### DIFF
--- a/ui/src/app/components/confirm-workspace-delete-modal.tsx
+++ b/ui/src/app/components/confirm-workspace-delete-modal.tsx
@@ -14,7 +14,6 @@ export interface ConfirmWorkspaceDeleteModalProps {
   closeFunction: Function;
   receiveDelete: Function;
   workspaceName: string;
-  workspaceNamespace: string;
 }
 export const ConfirmWorkspaceDeleteModal = ({
   closeFunction,

--- a/ui/src/app/components/confirm-workspace-delete-modal.tsx
+++ b/ui/src/app/components/confirm-workspace-delete-modal.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Button } from 'app/components/buttons';
 import { TextInput } from 'app/components/inputs';
-import { WarningMessage } from 'app/components/messages';
 import {
   Modal,
   ModalBody,
   ModalFooter,
   ModalTitle,
 } from 'app/components/modals';
-import { appsApi } from 'app/services/swagger-fetch-clients';
 
 export interface ConfirmWorkspaceDeleteModalProps {
   closeFunction: Function;
@@ -22,25 +20,9 @@ export const ConfirmWorkspaceDeleteModal = ({
   closeFunction,
   receiveDelete,
   workspaceName,
-  workspaceNamespace,
 }: ConfirmWorkspaceDeleteModalProps) => {
   const [loading, setLoading] = useState(false);
   const [deleteDisabled, setDeleteDisabled] = useState(true);
-  const [checkingForUserApps, setCheckingForUserApps] = useState(true);
-  const [appsExist, setAppsExist] = useState(false);
-
-  useEffect(() => {
-    setCheckingForUserApps(true);
-    appsApi()
-      .listAppsInWorkspace(workspaceNamespace)
-      .then((userApps) => {
-        setAppsExist(userApps?.length > 0);
-        setCheckingForUserApps(false);
-      })
-      .finally(() => {
-        setCheckingForUserApps(false);
-      });
-  }, []);
 
   const emitDelete = () => {
     setLoading(true);
@@ -50,8 +32,6 @@ export const ConfirmWorkspaceDeleteModal = ({
   const validateDeleteText = (event) => {
     setDeleteDisabled(!event.toLowerCase().match('delete'));
   };
-
-  const displayUserInput = !checkingForUserApps && !appsExist;
 
   return (
     <Modal loading={loading}>
@@ -71,26 +51,14 @@ export const ConfirmWorkspaceDeleteModal = ({
             access to the workspace. If you still wish to delete this workspace
             and all items within it, type DELETE below to confirm.
           </div>
-          {displayUserInput && (
+          {
             <TextInput
               placeholder='type DELETE to confirm'
               style={{ marginTop: '0.75rem' }}
               onChange={validateDeleteText}
               onBlur=''
             />
-          )}
-          {checkingForUserApps && (
-            <div style={{ paddingTop: '1rem' }}>
-              {' '}
-              Checking for any existing User Apps....
-            </div>
-          )}
-          {appsExist && (
-            <WarningMessage>
-              You cannot delete the workspace as there are Apps you must delete
-              first
-            </WarningMessage>
-          )}
+          }
         </div>
       </ModalBody>
       <ModalFooter style={{ paddingTop: '1.5rem' }}>
@@ -103,9 +71,7 @@ export const ConfirmWorkspaceDeleteModal = ({
         </Button>
         <Button
           aria-label='Confirm Delete'
-          disabled={
-            loading || deleteDisabled || checkingForUserApps || appsExist
-          }
+          disabled={loading || deleteDisabled}
           style={{ marginLeft: '0.75rem' }}
           data-test-id='confirm-delete'
           onClick={() => emitDelete()}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -922,7 +922,6 @@ export const HelpSidebar = fp.flow(
                     this.setState({ currentModal: CurrentModal.None })
                   }
                   receiveDelete={() => this.deleteWorkspace()}
-                  workspaceNamespace={this.props.workspace.namespace}
                   workspaceName={this.props.workspace.name}
                 />
               ),

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -317,7 +317,6 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                 AnalyticsTracker.Workspaces.Delete();
                 this.deleteWorkspace();
               }}
-              workspaceNamespace={workspace.namespace}
               workspaceName={workspace.name}
             />
           )}


### PR DESCRIPTION
Remove the warning that prevents users from deleting their workspaces when there's app in the workspace.

New banner looks like this when trying to delete workspace
![Screenshot 2024-03-11 at 4 42 54 PM](https://github.com/all-of-us/workbench/assets/32771737/45fb668a-5c59-4b61-bb81-b41c7e394c0b)

Note if you have a workspace that previously has orphaned Sam resources for apps. Workspace deletion will still fail, and eng will have to step in to help users to clean up

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
