### PR TITLE
[RW-11654][risk=no] Updated fields that have validation

### DIFF
--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -30,12 +30,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 class RuntimesApiTest {
 
   static Map<String, String> contentTypeJsonHeader = Map.of("Content-Type", "application/json");
-  static String gcrRegex =
-      "(^((?:us\\.|eu\\.|asia\\.)?gcr.io)/([\\w.-]+/[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
-  static String ghcrRegex =
-      "(^(ghcr.io)/((?:[\\w.-]+/)+[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
-
-  static String dockerRegex = gcrRegex + "|" + ghcrRegex;
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
@@ -47,8 +41,9 @@ class RuntimesApiTest {
             // tests.
             body.numberType("autopauseThreshold", 30);
             body.stringType("defaultClientId");
-            body.stringMatcher(
-                "toolDockerImage", dockerRegex, "us.gcr.io/example/image-for-contract-test:2.2.7");
+            // Requires a valid Docker image path, so an example is passed for use in tests
+            body.stringType(
+                "toolDockerImage", "us.gcr.io/example/image-for-contract-test:2.2.7");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -125,7 +125,7 @@ class RuntimesApiTest {
                     body -> {
                       body.stringType("runtimeName");
                       body.stringType("status");
-                      body.numberType("autopauseThreshold");
+                      body.numberType("autopauseThreshold", 50);
                       body.stringType("proxyUrl");
                       body.array("errors", errors -> {});
                       body.object(
@@ -196,7 +196,7 @@ class RuntimesApiTest {
                     body -> {
                       body.booleanType("allowStop");
                       body.booleanType("autopause");
-                      body.numberType("autopauseThreshold");
+                      body.numberType("autopauseThreshold", 30);
                     })
                 .build())
         .willRespondWith()
@@ -230,7 +230,7 @@ class RuntimesApiTest {
                     body -> {
                       body.booleanType("allowStop");
                       body.booleanType("autopause");
-                      body.numberType("autopauseThreshold");
+                      body.numberType("autopauseThreshold", 50);
                       body.object(
                           "runtimeConfig",
                           runtimeConfig -> {

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -30,8 +30,10 @@ import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 class RuntimesApiTest {
 
   static Map<String, String> contentTypeJsonHeader = Map.of("Content-Type", "application/json");
-  static String gcrRegex = "(^((?:us\\.|eu\\.|asia\\.)?gcr.io)/([\\w.-]+/[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
-  static String ghcrRegex = "(^(ghcr.io)/((?:[\\w.-]+/)+[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
+  static String gcrRegex =
+      "(^((?:us\\.|eu\\.|asia\\.)?gcr.io)/([\\w.-]+/[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
+  static String ghcrRegex =
+      "(^(ghcr.io)/((?:[\\w.-]+/)+[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
 
   static String dockerRegex = gcrRegex + "|" + ghcrRegex;
   static LambdaDslJsonBody createBody =
@@ -47,7 +49,8 @@ class RuntimesApiTest {
             body.booleanType("autopause");
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
-            body.stringMatcher("toolDockerImage",dockerRegex, "us.gcr.io/example/image-for-contract-test:2.2.7");
+            body.stringMatcher(
+                "toolDockerImage", dockerRegex, "us.gcr.io/example/image-for-contract-test:2.2.7");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -39,15 +39,13 @@ class RuntimesApiTest {
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
-            // These string matchers are used to ensure these fields are present and have the
-            // correct format. The third argument is the value that is stored in the contract.
-            // StringType will use a random string each time, but there is no way to ensure that
-            // the string is a valid URL.
-            body.stringMatcher("jupyterUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
-            body.stringMatcher(
-                "jupyterStartUserScriptUri", "\\bhttps?://\\S+\\b", "http://example.com");
+            // Requires a valid URL, so an example is passed for use in tests
+            body.stringType("jupyterUserScriptUri", "http://example.com");
+            body.stringType("jupyterStartUserScriptUri", "http://example.com");
             body.booleanType("autopause");
-            body.numberType("autopauseThreshold");
+            // Requires a value that within a specified range, so an example is passed for use in
+            // tests.
+            body.numberType("autopauseThreshold", 30);
             body.stringType("defaultClientId");
             body.stringMatcher(
                 "toolDockerImage", dockerRegex, "us.gcr.io/example/image-for-contract-test:2.2.7");

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -42,8 +42,7 @@ class RuntimesApiTest {
             body.numberType("autopauseThreshold", 30);
             body.stringType("defaultClientId");
             // Requires a valid Docker image path, so an example is passed for use in tests
-            body.stringType(
-                "toolDockerImage", "us.gcr.io/example/image-for-contract-test:2.2.7");
+            body.stringType("toolDockerImage", "us.gcr.io/example/image-for-contract-test:2.2.7");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")

--- a/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
+++ b/api/src/contracttest/java/org/pmiops/workbench/consumer/RuntimesApiTest.java
@@ -30,6 +30,10 @@ import org.pmiops.workbench.leonardo.model.LeonardoUpdateRuntimeRequest;
 class RuntimesApiTest {
 
   static Map<String, String> contentTypeJsonHeader = Map.of("Content-Type", "application/json");
+  static String gcrRegex = "(^((?:us\\.|eu\\.|asia\\.)?gcr.io)/([\\w.-]+/[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
+  static String ghcrRegex = "(^(ghcr.io)/((?:[\\w.-]+/)+[\\w.-]+)(?::(\\w[\\w.-]+))?(?:@([\\w+.-]+:[A-Fa-f0-9]{32,}))?$)";
+
+  static String dockerRegex = gcrRegex + "|" + ghcrRegex;
   static LambdaDslJsonBody createBody =
       newJsonBody(
           (body) -> {
@@ -43,7 +47,7 @@ class RuntimesApiTest {
             body.booleanType("autopause");
             body.numberType("autopauseThreshold");
             body.stringType("defaultClientId");
-            body.stringType("toolDockerImage");
+            body.stringMatcher("toolDockerImage",dockerRegex, "us.gcr.io/example/image-for-contract-test:2.2.7");
           });
 
   @Pact(consumer = "aou-rwb-api", provider = "leonardo")


### PR DESCRIPTION
Most contract tests specify attribute names and types that a given request should have.

In this base case, the contract is generated in such a way that a random value of the given type will be generated by the provider when the contract is validated.

There are a few instances, where the provider requires specific bounds for the variables:

- **jupyterUserScriptUri**: must be a valid URI rather than any random string
- **jupyterStartUserScriptUri**: must be a valid URI rather than any random string
- **autopauseThreshold**: specified in minutes and must be in the range of -+292 years.
- **toolDockerImage**: must be a valid Docker image path

We could write specific tests to handle each of the positive and negative cases, but [that starts going down the line of functional testing.](https://docs.pact.io/consumer/contract_tests_not_functional_tests) Instead, example values are included in cases like these so that we do not need to rely on random values. If desired, we can write a single contract test for what sort of status code and response is sent when invalid data is sent in general, but the specific validation cases are better left to the unit tests of the provider.
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
