### PR TITLE
[risk=low][no ticket] Remove the unused "runtimeImages" config block

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": ["test-gce-docker-image"],
-      "dataproc": ["test-dataproc-docker-image"]
-    },
     "gceVmZone": "us-central1-c"
   },
   "billing": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "workspaceLogsProject": "fc-aou-logs-preprod",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": [],
-      "dataproc": []
-    },
     "gceVmZone": "us-central1-a"
   },
   "billing": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "workspaceLogsProject": "fc-aou-logs-prod",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": [],
-      "dataproc": []
-    },
     "gceVmZone": "us-central1-a"
   },
   "billing": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "workspaceLogsProject": "fc-aou-logs-stable",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": [],
-      "dataproc": []
-    },
     "gceVmZone": "us-central1-a"
   },
   "billing": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com",
     "workspaceLogsProject": "fc-aou-logs-staging",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": [],
-      "dataproc": []
-    },
     "gceVmZone": "us-central1-a"
   },
   "billing": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -17,10 +17,6 @@
     "shibbolethUiBaseUrl": "https:\/\/broad-shibboleth-prod.appspot.com/dev",
     "workspaceLogsProject": "fc-aou-logs-test",
     "workspaceBucketLocation": "us-central1",
-    "runtimeImages": {
-      "gce": [],
-      "dataproc": []
-    },
     "gceVmZone": "us-central1-c"
   },
   "billing": {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -170,15 +170,8 @@ public class WorkbenchConfig {
     // The workspace GCS bucket location
     public String workspaceBucketLocation;
 
-    public RuntimeImages runtimeImages;
-
     // The deployment area of the GCE VM. For example, us-east1-a or europe-west2-c
     public String gceVmZone;
-  }
-
-  public static class RuntimeImages {
-    public List<String> gce;
-    public List<String> dataproc;
   }
 
   public static class AuthConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -19,27 +19,8 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
     config = MapStructConfig.class,
     uses = {AccessModuleNameMapper.class})
 public interface WorkbenchConfigMapper {
-  default RuntimeImage dataprocToModel(String imageName) {
-    return new RuntimeImage().cloudService(CloudServiceEnum.DATAPROC.toString()).name(imageName);
-  }
-
-  default RuntimeImage gceToModel(String imageName) {
-    return new RuntimeImage().cloudService(CloudServiceEnum.GCE.toString()).name(imageName);
-  }
-
-  @BeforeMapping
-  default void mapRuntimeImages(WorkbenchConfig source, @MappingTarget ConfigResponse target) {
-    target.runtimeImages(
-        Stream.concat(
-                source.firecloud.runtimeImages.dataproc.stream().map(this::dataprocToModel),
-                source.firecloud.runtimeImages.gce.stream().map(this::gceToModel))
-            .collect(Collectors.toList()));
-  }
-
   AccessModuleConfig mapAccessModule(DbAccessModule accessModule);
 
-  // handled by mapRuntimeImages()
-  @Mapping(target = "runtimeImages", ignore = true)
   @Mapping(target = "accessRenewalLookback", source = "config.access.renewal.lookbackPeriod")
   @Mapping(target = "gsuiteDomain", source = "config.googleDirectoryService.gSuiteDomain")
   @Mapping(target = "projectId", source = "config.server.projectId")

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -1,18 +1,12 @@
 package org.pmiops.workbench.config;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.mapstruct.BeforeMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.pmiops.workbench.access.AccessModuleNameMapper;
 import org.pmiops.workbench.db.model.DbAccessModule;
-import org.pmiops.workbench.leonardo.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.model.AccessModuleConfig;
 import org.pmiops.workbench.model.ConfigResponse;
-import org.pmiops.workbench.model.RuntimeImage;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6775,10 +6775,6 @@ components:
         rasLogoutUrl:
           type: string
           description: The URL that can sign out RAS login session.
-        runtimeImages:
-          type: array
-          items:
-            $ref: '#/components/schemas/RuntimeImage'
         freeTierBillingAccountId:
           type: string
           description: The free tier billing account id
@@ -6818,13 +6814,6 @@ components:
           type: boolean
           default: false
           description: Enable variant select all
-    RuntimeImage:
-      type: object
-      properties:
-        cloudService:
-          type: string
-        name:
-          type: string
     AccessModuleConfig:
       required:
       - expirable


### PR DESCRIPTION
Nothing in the UI references this.  I can't find any evidence that we ever used this.  The most recent reference I could find to this config block was from 2020: #4063

Tested locally by creating and interacting with GCE and DataProc runtimes.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
