### PR TITLE
[DT-774][risk=no] Changing sql generation for variant select all

### DIFF
--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -115,7 +115,7 @@
     "enableSasGKEApp": true,
     "enableDataExplorer": false,
     "enableGKEAppPausing": true,
-    "enableVariantSelectAll": false
+    "enableVariantSelectAll": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -77,6 +77,7 @@ import org.pmiops.workbench.model.SearchParameter;
 import org.pmiops.workbench.model.TemporalMention;
 import org.pmiops.workbench.model.TemporalTime;
 import org.pmiops.workbench.model.Variant;
+import org.pmiops.workbench.model.VariantFilter;
 import org.pmiops.workbench.model.VariantFilterRequest;
 import org.pmiops.workbench.model.VariantFilterResponse;
 import org.pmiops.workbench.model.VariantListResponse;
@@ -624,6 +625,15 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
         .variantId("1-101504524-G-A");
   }
 
+  private static SearchParameter variantFilter() {
+    VariantFilter variantFilter = new VariantFilter().searchTerm("gene1");
+    return new SearchParameter()
+            .domain(Domain.SNP_INDEL_VARIANT.toString())
+            .ancestorData(false)
+            .group(false)
+            .variantFilter(variantFilter);
+  }
+
   /**
    * This SearchParameter specifically represents the case that uses the
    * has_physical_measurement_data flag.
@@ -1098,6 +1108,15 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             Domain.SNP_INDEL_VARIANT.toString(), ImmutableList.of(variant()), new ArrayList<>());
     assertParticipants(
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
+  public void countParticipantsVariantDataUsingVariantFilter() {
+    CohortDefinition cohortDefinition =
+            createCohortDefinition(
+                    Domain.SNP_INDEL_VARIANT.toString(), ImmutableList.of(variantFilter()), new ArrayList<>());
+    assertParticipants(
+            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1136,19 +1136,24 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countParticipantsVariantDataUsingVidAndVariantFilters() {
     VariantFilter variantFilter = new VariantFilter().searchTerm("gene");
-    variantFilter.addClinicalSignificanceListItem("pathogenic").addConsequenceListItem("intron_variant").countMax(0L).countMax(5L);
-    SearchParameter sp = new SearchParameter()
+    variantFilter
+        .addClinicalSignificanceListItem("pathogenic")
+        .addConsequenceListItem("intron_variant")
+        .countMax(0L)
+        .countMax(5L);
+    SearchParameter sp =
+        new SearchParameter()
             .domain(Domain.SNP_INDEL_VARIANT.toString())
             .ancestorData(false)
             .group(false)
             .variantFilter(variantFilter);
     CohortDefinition cohortDefinition =
-            createCohortDefinition(
-                    Domain.SNP_INDEL_VARIANT.toString(),
-                    ImmutableList.of(variant(), sp),
-                    new ArrayList<>());
+        createCohortDefinition(
+            Domain.SNP_INDEL_VARIANT.toString(),
+            ImmutableList.of(variant(), sp),
+            new ArrayList<>());
     assertParticipants(
-            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test
@@ -2601,9 +2606,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   public void findVariantsFilterByParticipantCount() {
     VariantFilterRequest request = new VariantFilterRequest();
     ParticipantCountFilter pcf =
-        new ParticipantCountFilter()
-            .operator(Operator.LESS_THAN)
-            .operands(ImmutableList.of("2000"));
+        new ParticipantCountFilter().operator(Operator.LESS_THAN).operands(ImmutableList.of(2000));
     request.searchTerm("gene4").participantCountRange(pcf);
     Variant expectedVariant =
         new Variant()

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -626,12 +626,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   private static SearchParameter variantFilter() {
-    VariantFilter variantFilter = new VariantFilter().searchTerm("gene1");
+    VariantFilter variantFilter = new VariantFilter().searchTerm("gene");
     return new SearchParameter()
-            .domain(Domain.SNP_INDEL_VARIANT.toString())
-            .ancestorData(false)
-            .group(false)
-            .variantFilter(variantFilter);
+        .domain(Domain.SNP_INDEL_VARIANT.toString())
+        .ancestorData(false)
+        .group(false)
+        .variantFilter(variantFilter);
   }
 
   /**
@@ -1113,10 +1113,34 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countParticipantsVariantDataUsingVariantFilter() {
     CohortDefinition cohortDefinition =
-            createCohortDefinition(
-                    Domain.SNP_INDEL_VARIANT.toString(), ImmutableList.of(variantFilter()), new ArrayList<>());
+        createCohortDefinition(
+            Domain.SNP_INDEL_VARIANT.toString(),
+            ImmutableList.of(variantFilter()),
+            new ArrayList<>());
     assertParticipants(
-            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
+  public void countParticipantsVariantDataUsingVidsAndVariantFilter() {
+    CohortDefinition cohortDefinition =
+        createCohortDefinition(
+            Domain.SNP_INDEL_VARIANT.toString(),
+            ImmutableList.of(variant(), variantFilter()),
+            new ArrayList<>());
+    assertParticipants(
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
+  public void countParticipantsVariantDataUsingTwoVariantFilters() {
+    CohortDefinition cohortDefinition =
+        createCohortDefinition(
+            Domain.SNP_INDEL_VARIANT.toString(),
+            ImmutableList.of(variantFilter(), variantFilter()),
+            new ArrayList<>());
+    assertParticipants(
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -71,6 +71,7 @@ import org.pmiops.workbench.model.GenderSexRaceOrEthType;
 import org.pmiops.workbench.model.Modifier;
 import org.pmiops.workbench.model.ModifierType;
 import org.pmiops.workbench.model.Operator;
+import org.pmiops.workbench.model.ParticipantCountFilter;
 import org.pmiops.workbench.model.SearchGroup;
 import org.pmiops.workbench.model.SearchGroupItem;
 import org.pmiops.workbench.model.SearchParameter;
@@ -1122,7 +1123,7 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
-  public void countParticipantsVariantDataUsingVidsAndVariantFilter() {
+  public void countParticipantsVariantDataUsingVidAndVariantFilter() {
     CohortDefinition cohortDefinition =
         createCohortDefinition(
             Domain.SNP_INDEL_VARIANT.toString(),
@@ -1130,6 +1131,24 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             new ArrayList<>());
     assertParticipants(
         controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
+  public void countParticipantsVariantDataUsingVidAndVariantFilters() {
+    VariantFilter variantFilter = new VariantFilter().searchTerm("gene");
+    variantFilter.addClinicalSignificanceListItem("pathogenic").addConsequenceListItem("intron_variant").countMax(0L).countMax(5L);
+    SearchParameter sp = new SearchParameter()
+            .domain(Domain.SNP_INDEL_VARIANT.toString())
+            .ancestorData(false)
+            .group(false)
+            .variantFilter(variantFilter);
+    CohortDefinition cohortDefinition =
+            createCohortDefinition(
+                    Domain.SNP_INDEL_VARIANT.toString(),
+                    ImmutableList.of(variant(), sp),
+                    new ArrayList<>());
+    assertParticipants(
+            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test
@@ -2575,6 +2594,28 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
             .alleleNumber(18242L)
             .alleleFrequency(0.000277)
             .participantCount(1L);
+    assertFindVariantsResponse(request, expectedVariant, 1);
+  }
+
+  @Test
+  public void findVariantsFilterByParticipantCount() {
+    VariantFilterRequest request = new VariantFilterRequest();
+    ParticipantCountFilter pcf =
+        new ParticipantCountFilter()
+            .operator(Operator.LESS_THAN)
+            .operands(ImmutableList.of("2000"));
+    request.searchTerm("gene4").participantCountRange(pcf);
+    Variant expectedVariant =
+        new Variant()
+            .vid("2-100550658-T-CC")
+            .gene("gene4")
+            .consequence("")
+            .clinVarSignificance("")
+            .proteinChange("change")
+            .alleleCount(7L)
+            .alleleNumber(18226L)
+            .alleleFrequency(0.000266)
+            .participantCount(100L);
     assertFindVariantsResponse(request, expectedVariant, 1);
   }
 

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_variant_attribute_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_variant_attribute_data.json
@@ -90,5 +90,43 @@
     "cons_str": "",
     "consequence": [],
     "participant_count": 1
+  },
+  {
+    "vid": "2-100550658-T-CC",
+    "protein_change": "change",
+    "dna_change": "",
+    "allele_count": 7,
+    "allele_number": 18226,
+    "allele_frequency": 0.000266,
+    "clinical_significance": [],
+    "clinical_significance_string": "",
+    "transcript": "",
+    "contig": "chr20",
+    "position": 3000,
+    "ref_allele": "T",
+    "alt_allele": "C",
+    "cons_str": "",
+    "consequence": [],
+    "genes": "gene4",
+    "participant_count": 100
+  },
+  {
+    "vid": "2-100550658-T-CD",
+    "protein_change": "change",
+    "dna_change": "",
+    "allele_count": 7,
+    "allele_number": 18226,
+    "allele_frequency": 0.000266,
+    "clinical_significance": [],
+    "clinical_significance_string": "",
+    "transcript": "",
+    "contig": "chr20",
+    "position": 3000,
+    "ref_allele": "T",
+    "alt_allele": "C",
+    "cons_str": "",
+    "consequence": [],
+    "genes": "gene4",
+    "participant_count": 2500
   }
 ]

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_variant_attribute_genes_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_variant_attribute_genes_data.json
@@ -18,5 +18,13 @@
   {
     "vid": "1-100550658-T-AA",
     "gene_symbol": "GENE3"
+  },
+  {
+    "vid": "2-100550658-T-CC",
+    "gene_symbol": "GENE4"
+  },
+  {
+    "vid": "2-100550658-T-CD",
+    "gene_symbol": "GENE4"
   }
 ]

--- a/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/cdr/ConceptBigQueryService.java
@@ -52,7 +52,7 @@ public class ConceptBigQueryService {
           innerSql, domain, "standardConceptIds", 1, standardList, paramMap);
       innerSql.append("\n");
       if (!sourceList.isEmpty()) {
-        innerSql.append(" UNION ALL\n");
+        innerSql.append(" UNION DISTINCT\n");
       }
     }
     if (!sourceList.isEmpty()) {

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/CohortQueryBuilder.java
@@ -35,7 +35,7 @@ public class CohortQueryBuilder extends QueryBuilder {
   private static final String ID_SQL_TEMPLATE =
       "SELECT distinct person_id\n FROM `${projectId}.${dataSetId}.cb_search_person` cb_search_person\n WHERE\n";
 
-  private static final String UNION_TEMPLATE = "UNION ALL\n";
+  private static final String UNION_TEMPLATE = "UNION DISTINCT\n";
 
   private static final Logger log = Logger.getLogger(CohortQueryBuilder.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/QueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/QueryBuilder.java
@@ -22,7 +22,7 @@ public class QueryBuilder {
       "${mainTable}.person_id NOT IN unnest(@" + PERSON_ID_BLACKLIST_PARAM + ")\n";
   private static final String EXCLUDE_SQL_TEMPLATE =
       "${mainTable}.person_id NOT IN\n" + "(${excludeSql})\n";
-  private static final String UNION_TEMPLATE = "UNION ALL\n";
+  private static final String UNION_TEMPLATE = "UNION DISTINCT\n";
   private static final Logger log = Logger.getLogger(QueryBuilder.class.getName());
 
   public void addWhereClause(

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -88,7 +88,6 @@ public final class SearchGroupItemQueryBuilder {
   // sql parts to help construct BigQuery sql statements
   private static final String OR = " OR ";
   private static final String AND = " AND ";
-  private static final String UNION_TEMPLATE = "UNION ALL\n";
 
   private static final String UNION_DISTINCT_TEMPLATE = "UNION DISTINCT\n";
   private static final String DESC = " DESC";
@@ -326,7 +325,7 @@ public final class SearchGroupItemQueryBuilder {
       queryPartsSql =
           PERSON_ID_IN
               + CB_SEARCH_ALL_EVENTS_WHERE
-              + String.join(UNION_TEMPLATE + CB_SEARCH_ALL_EVENTS_WHERE, queryParts)
+              + String.join(UNION_DISTINCT_TEMPLATE + CB_SEARCH_ALL_EVENTS_WHERE, queryParts)
               + ")";
     } else {
       queryPartsSql = "(" + String.join(OR + "\n", queryParts) + ")";
@@ -374,7 +373,7 @@ public final class SearchGroupItemQueryBuilder {
                       ? ageSql
                       : ageSql + AGE_DEC_SQL);
             });
-        return String.join(UNION_TEMPLATE, queryParts);
+        return String.join(UNION_DISTINCT_TEMPLATE, queryParts);
       case GENDER:
       case SEX:
       case ETHNICITY:

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/VariantQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/VariantQueryBuilder.java
@@ -521,16 +521,16 @@ public final class VariantQueryBuilder {
         case GREATER_THAN, GREATER_THAN_OR_EQUAL_TO -> {
           namedParameter1 =
               QueryParameterUtil.addQueryParameterValue(
-                  params, QueryParameterValue.int64(Integer.parseInt(range.getOperands().get(0))));
+                  params, QueryParameterValue.int64(range.getOperands().get(0)));
           replaceParams.put("@participantCount", namedParameter1);
         }
         case BETWEEN -> {
           namedParameter1 =
               QueryParameterUtil.addQueryParameterValue(
-                  params, QueryParameterValue.int64(Integer.parseInt(range.getOperands().get(0))));
+                  params, QueryParameterValue.int64(range.getOperands().get(0)));
           namedParameter2 =
               QueryParameterUtil.addQueryParameterValue(
-                  params, QueryParameterValue.int64(Integer.parseInt(range.getOperands().get(1))));
+                  params, QueryParameterValue.int64(range.getOperands().get(1)));
           replaceParams.put("@participantCount1", namedParameter1);
           replaceParams.put("@participantCount2", namedParameter2);
         }
@@ -539,7 +539,7 @@ public final class VariantQueryBuilder {
               QueryParameterUtil.addQueryParameterValue(params, QueryParameterValue.int64(1));
           namedParameter2 =
               QueryParameterUtil.addQueryParameterValue(
-                  params, QueryParameterValue.int64(Integer.parseInt(range.getOperands().get(0))));
+                  params, QueryParameterValue.int64(range.getOperands().get(0)));
           replaceParams.put("@participantCount1", namedParameter1);
           replaceParams.put("@participantCount2", namedParameter2);
         }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -11230,7 +11230,7 @@ components:
         operands:
           type: array
           items:
-            type: string
+            type: integer
     VariantFilterResponse:
       allOf:
         - $ref: '#/components/schemas/BaseVariantFilter'


### PR DESCRIPTION
Changing sql generation for variant select all

@dolbeew I've added another filter to the VariantFilterRequest object(need to add to variant filter on UI side):

This range supports the following operators: `GREATER_THAN, GREATER_THAN_OR_EQUAL_TO, LESS_THAN, LESS_THAN_OR_EQUAL_TO, BETWEEN`
participantCountRange:
          $ref: '#/components/schemas/ParticipantCountFilter'

    ParticipantCountFilter:
      required:
        - operator
        - operands
      type: object
      properties:
        operator:
          $ref: '#/components/schemas/Operator'
        operands:
          type: array
          items:
            type: integer

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
