### PR TITLE
[risk=low][RW-12099] Fix RStudio by splitting too-long lines

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -91,6 +91,7 @@ import org.pmiops.workbench.monitoring.GaugeDataCollector;
 import org.pmiops.workbench.monitoring.MeasurementBundle;
 import org.pmiops.workbench.monitoring.labels.MetricLabel;
 import org.pmiops.workbench.monitoring.views.GaugeMetric;
+import org.pmiops.workbench.utils.WorkbenchStringUtils;
 import org.pmiops.workbench.workspaces.resources.UserRecentResourceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -131,6 +132,12 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
           + "\nAND UPPER(domain) = %s";
   private static final String LIMIT_20 = " LIMIT 20";
   private static final String PERSON_ID_COLUMN_NAME = "PERSON_ID";
+
+  // RStudio has a line length limit of 4096 characters.  Pasting lines longer than this will
+  // FAIL SILENTLY, CAUSING WRONG RESULTS, so it's critical to produce output shorter than this.
+  // https://github.com/rstudio/rstudio/issues/14420
+  private static final int RSTUDIO_LINE_LENGTH_MINUS_BUFFER = 4000;
+
   private static final ImmutableList<Domain> OUTER_QUERY_DOMAIN =
       ImmutableList.of(
           Domain.CONDITION,
@@ -1489,10 +1496,15 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
     String rPythonSqlComment = "# " + sqlComment;
     String sasSqlComment = "/* " + sqlComment + " */";
 
-    String sqlQuery =
+    String rawSqlQuery =
         fillInQueryParams(
             generateSqlWithEnvironmentVariables(queryJobConfiguration.getQuery(), analysisLanguage),
             queryJobConfiguration.getNamedParameters());
+
+    // Split long lines in the SQL query into multiple, to avoid exceeding RStudio's length limit
+    String sqlQuery =
+        WorkbenchStringUtils.splitTooLongLines(
+            rawSqlQuery, RSTUDIO_LINE_LENGTH_MINUS_BUFFER, ",", System.lineSeparator());
 
     switch (analysisLanguage) {
       case PYTHON:

--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetServiceImpl.java
@@ -136,7 +136,7 @@ public class DataSetServiceImpl implements DataSetService, GaugeDataCollector {
   // RStudio has a line length limit of 4096 characters.  Pasting lines longer than this will
   // FAIL SILENTLY, CAUSING WRONG RESULTS, so it's critical to produce output shorter than this.
   // https://github.com/rstudio/rstudio/issues/14420
-  private static final int RSTUDIO_LINE_LENGTH_MINUS_BUFFER = 4000;
+  private static final int RSTUDIO_LINE_LENGTH_MINUS_BUFFER = 1000;
 
   private static final ImmutableList<Domain> OUTER_QUERY_DOMAIN =
       ImmutableList.of(

--- a/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
@@ -45,6 +45,10 @@ public class WorkbenchStringUtils {
    */
   public static List<String> splitByLength(String line, int limit, String tokenSeparator) {
     String[] tokens = line.split(tokenSeparator);
+    if (tokens.length < 2) {
+      return List.of(line);
+    }
+
     ArrayList<String> outLines = new ArrayList<>();
     StringBuilder currentLine = new StringBuilder();
 

--- a/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
@@ -1,0 +1,78 @@
+package org.pmiops.workbench.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Generic utilities for string manipulation. The name "StringUtils" was already taken by Apache
+ * Commons.
+ */
+public class WorkbenchStringUtils {
+  /**
+   * Transform an input string of many lines into a result string also with many lines, converting
+   * any line which is too long to multiple lines in a best-effort process. See {@link
+   * org.pmiops.workbench.utils.WorkbenchStringUtilsTest} for examples.
+   *
+   * @param input string
+   * @param limit max line length
+   * @param tokenSeparator a string (e.g. ",") representing where it is acceptable to split lines
+   * @param lineSeparator the string used to split lines in the input and output strings
+   * @return the transformed string
+   */
+  public static String splitTooLongLines(
+      String input, int limit, String tokenSeparator, String lineSeparator) {
+    return Arrays.stream(input.split(lineSeparator))
+        .flatMap(
+            line ->
+                line.length() < limit
+                    ? Stream.of(line)
+                    : splitByLength(line, limit, tokenSeparator).stream())
+        .collect(Collectors.joining(lineSeparator));
+  }
+
+  /**
+   * Split a line into multiple lines, taking a best-effort approach to ensure that each resulting
+   * line length is below the limit. See {@link org.pmiops.workbench.utils.WorkbenchStringUtilsTest}
+   * for examples.
+   *
+   * @param line the input string, assumed to be a single line
+   * @param limit max line length
+   * @param tokenSeparator a string (e.g. ",") representing where it is acceptable to split lines
+   * @return the resulting list of split lines
+   */
+  public static List<String> splitByLength(String line, int limit, String tokenSeparator) {
+    String[] tokens = line.split(tokenSeparator);
+    ArrayList<String> outLines = new ArrayList<>();
+    StringBuilder currentLine = new StringBuilder();
+
+    for (int i = 0; i < tokens.length; i++) {
+      String nextToken = tokens[i];
+      if (currentLine.isEmpty()) {
+        // if we have not yet started building the current line, simply add the token
+        currentLine.append(nextToken);
+      } else {
+        // add the next token plus the separator, if they fit
+        if (currentLine.length() + tokenSeparator.length() + nextToken.length() <= limit) {
+          currentLine.append(tokenSeparator).append(nextToken);
+        } else {
+          // complete the current line
+          // Note: this may go over the limit by up to `tokenSeparator.length()`
+          currentLine.append(tokenSeparator);
+
+          // add current line to output and initialize the next line
+          outLines.add(currentLine.toString());
+          currentLine = new StringBuilder(nextToken);
+        }
+      }
+    }
+
+    if (!currentLine.isEmpty()) {
+      outLines.add(currentLine.toString());
+    }
+
+    return outLines;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
@@ -55,6 +55,33 @@ public class WorkbenchStringUtilsTest {
   }
 
   @Test
+  public void testSplitByLength_NoSeparator() {
+    String line = "abcdefghij";
+    int limit = 5;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitByLength_TrailingSeparator_ShorterThanLimit() {
+    String line = "abcdefghij,";
+    int limit = 50;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitByLength_TrailingSeparator_LongerThanLimit() {
+    String line = "abcdefghij,";
+    int limit = 5;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
   public void testSplitTooLongLines_ShorterThanLimit() {
     String input =
         """

--- a/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
@@ -1,0 +1,125 @@
+package org.pmiops.workbench.utils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class WorkbenchStringUtilsTest {
+
+  @Test
+  public void testSplitByLength_ShorterThanLimit() {
+    String line = "a,b";
+    int limit = 5;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitByLength_EqualToLimit() {
+    String line = "a, b, c";
+    int limit = 7;
+    String tokenSeparator = ", ";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitByLength_LongerThanLimit() {
+    String line = "a, b, c";
+    int limit = 6;
+    String tokenSeparator = ", ";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of("a, b, ", "c"));
+  }
+
+  @Test
+  public void testSplitByLength_LongerThanSmallerLimit() {
+    String line = "a, b, c";
+    int limit = 3;
+    String tokenSeparator = ", ";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of("a, ", "b, ", "c"));
+  }
+
+  @Test
+  public void testSplitByLength_LongerThanLimit_cantSplit() {
+    String line = "abcdefg";
+    int limit = 6;
+    assertThat(line.length()).isGreaterThan(limit); // sanity check
+
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitTooLongLines_ShorterThanLimit() {
+    String input =
+        """
+          SELECT * FROM table
+          WHERE column = 'value';
+          """;
+    int limit = 100;
+    String tokenSeparator = ",";
+    String lineSeparator = System.lineSeparator();
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result.trim()).isEqualTo(input.trim());
+  }
+
+  @Test
+  public void testSplitTooLongLines_EqualsLimit() {
+    String input =
+        """
+          SELECT * FROM table
+          WHERE column = 'value';
+          """;
+    int limit = 23; // length of longest line in input text
+    String tokenSeparator = ",";
+    String lineSeparator = System.lineSeparator();
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result.trim()).isEqualTo(input.trim());
+  }
+
+  @Test
+  public void testSplitTooLongLines_LongerThanLimit_cantSplit() {
+    String input =
+        """
+          SELECT * FROM table
+          WHERE column = 'value';
+          """;
+    int limit = 5;
+    String tokenSeparator = ","; // no commas in input
+    String lineSeparator = System.lineSeparator();
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result.trim()).isEqualTo(input.trim());
+  }
+
+  @Test
+  public void testSplitTooLongLines_LongerThanLimit() {
+    String input =
+        """
+          SELECT * FROM table
+          WHERE id IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+          """;
+    int limit = 30;
+    String tokenSeparator = ", ";
+    String lineSeparator = System.lineSeparator();
+
+    // a trailing space is expected on the split line here because the tokenSeparator is ", "
+    String expected =
+        """
+          SELECT * FROM table
+          WHERE id IN (1, 2, 3, 4, 5, 6,\s
+          7, 8, 9, 10);
+          """;
+
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result.trim()).isEqualTo(expected.trim());
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/WorkbenchStringUtilsTest.java
@@ -82,6 +82,33 @@ public class WorkbenchStringUtilsTest {
   }
 
   @Test
+  public void testSplitByLength_EmptyInput() {
+    String line = "";
+    int limit = 5;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
+  public void testSplitByLength_ZeroLimit() {
+    String line = "a,b,c";
+    int limit = 0;
+    String tokenSeparator = ",";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of("a,", "b,", "c"));
+  }
+
+  @Test
+  public void testSplitByLength_EmptyTokenSeparator() {
+    String line = "a,b,c";
+    int limit = 5;
+    String tokenSeparator = "";
+    assertThat(WorkbenchStringUtils.splitByLength(line, limit, tokenSeparator))
+        .isEqualTo(List.of(line));
+  }
+
+  @Test
   public void testSplitTooLongLines_ShorterThanLimit() {
     String input =
         """
@@ -148,5 +175,38 @@ public class WorkbenchStringUtilsTest {
     String result =
         WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
     assertThat(result.trim()).isEqualTo(expected.trim());
+  }
+
+  @Test
+  public void testSplitTooLongLines_EmptyLineSeparator() {
+    String input = "a,b,c" + System.lineSeparator() + "d,e,f";
+    int limit = 5;
+    String tokenSeparator = ",";
+    String lineSeparator = "";
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result).isEqualTo(input);
+  }
+
+  @Test
+  public void testSplitTooLongLines_InputOnlyTokenSeparator() {
+    String input = ",,,";
+    int limit = 5;
+    String tokenSeparator = ",";
+    String lineSeparator = System.lineSeparator();
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result).isEqualTo(input);
+  }
+
+  @Test
+  public void testSplitTooLongLines_InputOnlyLineSeparator() {
+    String input = System.lineSeparator() + System.lineSeparator() + System.lineSeparator();
+    int limit = 5;
+    String tokenSeparator = ",";
+    String lineSeparator = System.lineSeparator();
+    String result =
+        WorkbenchStringUtils.splitTooLongLines(input, limit, tokenSeparator, lineSeparator);
+    assertThat(result.trim()).isEqualTo(input.trim());
   }
 }


### PR DESCRIPTION
RStudio silently gives the wrong results when line lengths are too long: https://github.com/rstudio/rstudio/issues/14420

This PR ensures that the long SQL lines in the Dataset Builder output are short enough, by splitting on commas.

Tested locally by running split and unsplit versions of the same Dataset Builder queries in RStudio.

Portion of SQL code generated by setting a very short line length parameter (20)
```
                   JOIN
                        (
                            SELECT
                                CAST(cr.id as string) AS id       
                            FROM
                                `cb_criteria` cr       
                            WHERE
                                concept_id IN (
                                    192671,
 193250, 197925,
 198212, 26727,
 37311947, 378756,
 4002659, 4025198,
 4026112, 4059114,
 4169954, 4177600,
 4226021, 4245614,
 42538062, 42709921,
 4271696, 42873123,
 4299449, 4307580,
 4338544, 437312,
 439040, 46273183
                                )       
                                AND full_text LIKE '%_rank1]%'      
                        ) a 
```

with a more reasonable parameter (100)
```
JOIN
                        (
                            SELECT
                                CAST(cr.id as string) AS id       
                            FROM
                                `cb_criteria` cr       
                            WHERE
                                concept_id IN (
                                    192671, 193250, 197925, 198212, 26727, 37311947, 378756, 4002659,
 4025198, 4026112, 4059114, 4169954, 4177600, 4226021, 4245614, 42538062, 42709921, 4271696,
 42873123, 4299449, 4307580, 4338544, 437312, 439040, 46273183
                                )       
                                AND full_text LIKE '%_rank1]%'      
                        ) a 
```

with the parameter in this PR (4000)
```
 JOIN
                        (
                            SELECT
                                CAST(cr.id as string) AS id       
                            FROM
                                `cb_criteria` cr       
                            WHERE
                                concept_id IN (
                                    192671, 193250, 197925, 198212, 26727, 37311947, 378756, 4002659, 4025198, 4026112, 4059114, 4169954, 4177600, 4226021, 4245614, 42538062, 42709921, 4271696, 42873123, 4299449, 4307580, 4338544, 437312, 439040, 46273183
                                )       
                                AND full_text LIKE '%_rank1]%'      
                        ) a 
```

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
