### PR TITLE
[DT-792][risk=no] Fix overlay issue when deleting search group

### DIFF
--- a/ui/src/app/pages/data/cohort/search-group.tsx
+++ b/ui/src/app/pages/data/cohort/search-group.tsx
@@ -290,6 +290,16 @@ export const SearchGroup = withCurrentWorkspace()(
       }
     }
 
+    componentDidUpdate(prevProps: Readonly<Props>) {
+      const {
+        group: { id, status },
+      } = this.props;
+      if (prevProps.group.id !== id && status === 'active') {
+        // Group was deleted, prevent overlay of deleted group from remaining
+        this.setState({ overlayStyle: undefined });
+      }
+    }
+
     componentWillUnmount(): void {
       this.aborter.abort();
       clearTimeout(this.deleteTimeout);


### PR DESCRIPTION
Fixes display issue where deleting a group that has at least one group below it will cause the white overlay to remain after the group is removed.

![Screenshot 2024-03-21 at 9 34 31 AM](https://github.com/all-of-us/workbench/assets/40036095/5123ccc5-ca8c-4e1b-a5aa-9c7cfdb268a1)
