### PR TITLE
[risk=low][RW-12152] Update copying-notebooks message in the UI

### DIFF
--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -18,6 +18,9 @@ export const BasicInformation = ({ workspace, activeStatus }: Props) => (
       <WorkspaceInfoField labelText='Active Status'>
         {activeStatus}
       </WorkspaceInfoField>
+      <WorkspaceInfoField labelText='Billing Status'>
+        {workspace.billingStatus}
+      </WorkspaceInfoField>
       <WorkspaceInfoField labelText='Workspace Name'>
         {workspace.name}
       </WorkspaceInfoField>
@@ -29,9 +32,6 @@ export const BasicInformation = ({ workspace, activeStatus }: Props) => (
       </WorkspaceInfoField>
       <WorkspaceInfoField labelText='Google Project Id'>
         {workspace.googleProject}
-      </WorkspaceInfoField>
-      <WorkspaceInfoField labelText='Billing Status'>
-        {workspace.billingStatus}
       </WorkspaceInfoField>
       <WorkspaceInfoField labelText='Billing Account Type'>
         {isUsingFreeTierBillingAccount(workspace)

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -75,9 +75,10 @@ const WaitingForFiles = () => (
         size='2x'
       />
     </div>
+    <div>Copying 1 or more notebooks from another workspace.</div>
     <div>
-      Copying 1 or more notebooks from another workspace. This often happens
-      quickly, but in some circumstances it can take <b>minutes to hours</b>.
+      Notebook copy should happen quickly, but in can sometime take <b>hours</b>{' '}
+      to complete.
     </div>
     <div>
       If you continue to see this message after a few minutes have passed,

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -76,8 +76,8 @@ const WaitingForFiles = () => (
       />
     </div>
     <div>
-      Copying 1 or more notebooks from another workspace. This may take{' '}
-      <b>a few minutes</b>.
+      Copying 1 or more notebooks from another workspace. This often happens
+      quickly, but in some circumstances it can take <b>minutes to hours</b>.
     </div>
     <div>
       If you continue to see this message after a few minutes have passed,

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -15,7 +15,6 @@ import { FlexColumn, FlexRow } from 'app/components/flex';
 import { ListPageHeader } from 'app/components/headers';
 import { withErrorModal } from 'app/components/modals';
 import { NotebookSizeWarningModal } from 'app/components/notebook-size-warning-modal';
-import { SupportMailto } from 'app/components/support';
 import { NotebookActionMenu } from 'app/pages/analysis/notebook-action-menu';
 import { getAppInfoFromFileName, listNotebooks } from 'app/pages/analysis/util';
 import { analysisTabPath } from 'app/routing/utils';

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -77,12 +77,12 @@ const WaitingForFiles = () => (
     </div>
     <div>Copying 1 or more notebooks from another workspace.</div>
     <div>
-      Notebook copy should happen quickly, but in can sometime take <b>hours</b>{' '}
-      to complete.
+      Notebook copy should happen quickly, but it can sometimes take{' '}
+      <b>minutes to hours</b> to complete.
     </div>
     <div>
-      If you continue to see this message after a few minutes have passed,
-      please contact support at <SupportMailto />.
+      If it takes longer than a few minutes, try duplicating the original
+      workspace again.
     </div>
   </FlexColumn>
 );


### PR DESCRIPTION
I feel that we're giving unrealistically optimistic estimates for notebook copying time.  I've seen it take longer than an hour before.

<img width="997" alt="Screenshot 2024-03-21 at 10 45 45 AM" src="https://github.com/all-of-us/workbench/assets/2701406/bfdfcd8b-621b-47e1-9089-1ddcaf417fcf">

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
