### PR TITLE
[no ticket][risk=no] Convert a few Enzyme tests with Copilot assistance.

### DIFF
--- a/ui/src/app/components/app-router.spec.tsx
+++ b/ui/src/app/components/app-router.spec.tsx
@@ -1,11 +1,11 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
 import { Redirect, Switch } from 'react-router-dom';
-import { mount } from 'enzyme';
 
+import { render, screen } from '@testing-library/react';
 import { AppRoute, AppRouter, Guard } from 'app/components/app-router';
-
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 
 jest.mock('react-router-dom', () => {
   const originalModule = jest.requireActual('react-router-dom');
@@ -100,7 +100,7 @@ const makeAppRouter = () => {
 
 describe('AppRouter', () => {
   const component = (initialEntries: string[], initialIndex: number) => {
-    return mount(
+    return render(
       <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
         {makeAppRouter()}
       </MemoryRouter>
@@ -108,51 +108,42 @@ describe('AppRouter', () => {
   };
 
   it('allows anyone into unprotected route', () => {
-    const wrapper = component(['/unprotected-route'], 0);
-    expect(wrapper.find('span').first().text()).toEqual('Unprotected Route');
+    component(['/unprotected-route'], 0);
+    expect(screen.getByText('Unprotected Route')).toBeInTheDocument();
   });
 
   it('punts when user fails guard', () => {
-    const wrapper = component(['/unreachable-path'], 0);
-    // don't want to pull all of angular into a test of react routerto test that a redirect is
-    // happening, so we'll check that the router is telling it to redirect to the right place
-    expect(wrapper.find('span').first().text()).toEqual('Punting');
+    component(['/unreachable-path'], 0);
+    expect(screen.getByText('Punting')).toBeInTheDocument();
   });
 
   it('renders when user passes guard', () => {
-    const wrapper = component(['/protected-route'], 0);
-    expect(wrapper.find('span').first().text()).toEqual('Protected Route');
+    component(['/protected-route'], 0);
+    expect(screen.getByText('Protected Route')).toBeInTheDocument();
   });
 
   it('renders for sibling routes under a guard', () => {
-    const wrapper = component(['/other-protected-route'], 0);
-    expect(wrapper.find('span').first().text()).toEqual(
-      'Other Protected Route'
-    );
+    component(['/other-protected-route'], 0);
+    expect(screen.getByText('Other Protected Route')).toBeInTheDocument();
   });
 
   it('renders for nested protectedRoutes', () => {
-    const wrapper = component(['/nested-protected-route'], 0);
-    expect(wrapper.find('span').first().text()).toEqual(
-      'Nested Protected Route'
-    );
+    component(['/nested-protected-route'], 0);
+    expect(screen.getByText('Nested Protected Route')).toBeInTheDocument();
   });
 
   it('punts on failed nested protected route', () => {
-    const wrapper = component(['/nested-unreachable-path'], 0);
-    // don't want to pull all of angular into a test of react router to test that a redirect is
-    // happening, so we'll check that the router is telling it to redirect to the right place
-    expect(wrapper.find('span').first().text()).toEqual('Punting');
+    component(['/nested-unreachable-path'], 0);
+    expect(screen.getByText('Punting')).toBeInTheDocument();
   });
 
   it('redirects to not found page when no route is matched', async () => {
-    const wrapper = component(['/wharrgarbl'], 0);
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('span').first().text()).toEqual('Not Found');
+    component(['/wharrgarbl'], 0);
+    expect(await screen.findByText('Not Found')).toBeInTheDocument();
   });
 
   it('renders content when guard fails', () => {
-    const wrapper = component(['/block-render-route'], 0);
-    expect(wrapper.text()).toEqual('guard component');
+    component(['/block-render-route'], 0);
+    expect(screen.getByText('guard component')).toBeInTheDocument();
   });
 });

--- a/ui/src/app/pages/admin/admin-institution.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution.spec.tsx
@@ -1,22 +1,22 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
-import { mount } from 'enzyme';
 
 import { InstitutionApi } from 'generated/fetch';
 
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { waitOneTickAndUpdate } from 'testing/react-test-helpers';
 import { InstitutionApiStub } from 'testing/stubs/institution-api-stub';
 
 import { AdminInstitution } from './admin-institution';
 
 describe('AdminInstitutionSpec', () => {
-  const component = () => {
-    return mount(
-      <AdminInstitution hideSpinner={() => {}} showSpinner={() => {}} />
-    );
+  const renderComponent = () => {
+    render(<AdminInstitution hideSpinner={() => {}} showSpinner={() => {}} />);
   };
 
   beforeEach(() => {
@@ -26,14 +26,16 @@ describe('AdminInstitutionSpec', () => {
   });
 
   it('should render', async () => {
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper).toBeTruthy();
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Institution admin table')).toBeInTheDocument();
+    });
   });
 
   it('should display all institutions', async () => {
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper.find('tbody').first().find('tr').length).toBe(4);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByRole('row')).toHaveLength(5); // 4 rows + 1 header row
+    });
   });
 });

--- a/ui/src/app/pages/admin/admin-institution.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution.spec.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { InstitutionApi } from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 import { serverConfigStore } from 'app/utils/stores';
 

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -208,7 +208,7 @@ export const ExportDatasetModal = ({
     return (
       <iframe
         id='export-preview-frame'
-        data-testid='export-preview-frame'
+        data-test-id='export-preview-frame'
         scrolling='yes'
         style={{
           width: '100%',

--- a/ui/src/app/pages/workspace/create-billing-account-modal.spec.tsx
+++ b/ui/src/app/pages/workspace/create-billing-account-modal.spec.tsx
@@ -1,8 +1,14 @@
-import * as React from 'react';
-import { mount } from 'enzyme';
+import '@testing-library/jest-dom';
 
+import * as React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
 import { profileStore } from 'app/utils/stores';
 
+import {
+  expectButtonElementDisabled,
+  getHTMLInputElementValue,
+} from 'testing/react-test-helpers';
 import { BROAD } from 'testing/stubs/institution-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
@@ -15,7 +21,7 @@ describe('CreateBillingAccountModal', () => {
   const profile = ProfileStubVariables.PROFILE_STUB;
 
   const component = () => {
-    return mount(<CreateBillingAccountModal onClose={() => {}} />);
+    return render(<CreateBillingAccountModal onClose={() => {}} />);
   };
 
   beforeEach(() => {
@@ -23,116 +29,78 @@ describe('CreateBillingAccountModal', () => {
   });
 
   it('simulate creating billing account with all steps correctly', async () => {
-    const wrapper = component();
+    const { getByTestId } = component();
     // Show step 0 at start.
-    expect(wrapper.find('[data-test-id="step-0-modal"]').exists()).toBeTruthy();
-    expect(wrapper.find('[data-test-id="step-1-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-id="step-2-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-id="step-3-modal"]').exists()).toBeFalsy();
+    expect(screen.getByTestId('step-0-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('step-1-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('step-2-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('step-3-modal')).not.toBeInTheDocument();
 
     // Show step 1 when click use-billing-partner-button button, verify value populated.
-    wrapper
-      .find('[data-test-id="use-billing-partner-button"]')
-      .first()
-      .simulate('click');
-    expect(wrapper.find('[data-test-id="step-0-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-id="step-1-modal"]').exists()).toBeTruthy();
+    fireEvent.click(screen.getByText('USE A BILLING PARTNER'));
+    expect(screen.queryByTestId('step-0-modal')).not.toBeInTheDocument();
+    expect(screen.getByTestId('step-1-modal')).toBeInTheDocument();
 
     // The only enabled input is user phone number. Others are populated from profile API.
-    expect(
-      wrapper.find('[data-test-id="user-first-name"]').first().prop('disabled')
-    ).toBeTruthy();
-    expect(
-      wrapper.find('[data-test-id="user-last-name"]').first().prop('disabled')
-    ).toBeTruthy();
-    expect(
-      wrapper
-        .find('[data-test-id="user-contact-email"]')
-        .first()
-        .prop('disabled')
-    ).toBeTruthy();
-    expect(
-      wrapper
-        .find('[data-test-id="user-workbench-id"]')
-        .first()
-        .prop('disabled')
-    ).toBeTruthy();
-    expect(
-      wrapper.find('[data-test-id="user-institution"]').first().prop('disabled')
-    ).toBeTruthy();
-    expect(
-      wrapper
-        .find('[data-test-id="user-phone-number"]')
-        .first()
-        .prop('disabled')
-    ).toBeFalsy();
+    expect(getByTestId('user-first-name')).toBeDisabled();
+    expect(getByTestId('user-last-name')).toBeDisabled();
+    expect(getByTestId('user-contact-email')).toBeDisabled();
+    expect(getByTestId('user-workbench-id')).toBeDisabled();
+    expect(getByTestId('user-institution')).toBeDisabled();
+    expect(getByTestId('user-phone-number')).not.toBeDisabled();
 
-    expect(
-      wrapper.find('[data-test-id="user-first-name"]').first().prop('value')
-    ).toEqual('Tester!@#$%^&*()><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-last-name"]').first().prop('value')
-    ).toEqual('MacTesterson!@#$%^&*()><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-phone-number"]').first().prop('value')
-    ).toBeUndefined();
-    expect(
-      wrapper.find('[data-test-id="user-contact-email"]').first().prop('value')
-    ).toEqual('tester@mactesterson.edu><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-workbench-id"]').first().prop('value')
-    ).toEqual('tester@fake-research-aou.org');
-    expect(
-      wrapper.find('[data-test-id="user-institution"]').first().prop('value')
-    ).toEqual(BROAD.displayName);
+    expect(getHTMLInputElementValue(getByTestId('user-first-name'))).toEqual(
+      'Tester!@#$%^&*()><script>alert("hello");</script>'
+    );
+    expect((getByTestId('user-last-name') as HTMLInputElement).value).toEqual(
+      'MacTesterson!@#$%^&*()><script>alert("hello");</script>'
+    );
+    expect(getHTMLInputElementValue(getByTestId('user-phone-number'))).toEqual(
+      ''
+    );
+    expect(getHTMLInputElementValue(getByTestId('user-contact-email'))).toEqual(
+      'tester@mactesterson.edu><script>alert("hello");</script>'
+    );
+    expect(getHTMLInputElementValue(getByTestId('user-workbench-id'))).toEqual(
+      'tester@fake-research-aou.org'
+    );
+    expect(getHTMLInputElementValue(getByTestId('user-institution'))).toEqual(
+      BROAD.displayName
+    );
 
     // Type invalid phone number then valid phone number
-    wrapper
-      .find('[data-test-id="user-phone-number"]')
-      .first()
-      .simulate('change', { target: { value: '1234x' } });
-    expect(
-      wrapper.find('[data-test-id="next-button"]').first().prop('disabled')
-    ).toBeTruthy();
-    wrapper
-      .find('[data-test-id="user-phone-number"]')
-      .first()
-      .simulate('change', { target: { value: '1234567890' } });
-    expect(
-      wrapper.find('[data-test-id="next-button"]').first().prop('disabled')
-    ).toBeFalsy();
+    fireEvent.change(getByTestId('user-phone-number'), {
+      target: { value: '1234x' },
+    });
+    expectButtonElementDisabled(screen.getByRole('button', { name: /next/i }));
+    fireEvent.change(getByTestId('user-phone-number'), {
+      target: { value: '1234567890' },
+    });
+    expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
 
     // Go to step 2 by clicking next button
-    wrapper.find('[data-test-id="next-button"]').first().simulate('click');
-    expect(wrapper.find('[data-test-id="step-1-modal"]').exists()).toBeFalsy();
-    expect(wrapper.find('[data-test-id="step-2-modal"]').exists()).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.queryByTestId('step-1-modal')).not.toBeInTheDocument();
+    expect(screen.getByTestId('step-2-modal')).toBeInTheDocument();
 
-    expect(
-      wrapper.find('[data-test-id="user-first-name-text"]').first().props()
-        .children
-    ).toEqual('Tester!@#$%^&*()><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-last-name-text"]').first().props()
-        .children
-    ).toEqual('MacTesterson!@#$%^&*()><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-phone-number-text"]').first().props()
-        .children
-    ).toEqual('1234567890');
-    expect(
-      wrapper.find('[data-test-id="user-contact-email-text"]').first().props()
-        .children
-    ).toEqual('tester@mactesterson.edu><script>alert("hello");</script>');
-    expect(
-      wrapper.find('[data-test-id="user-workbench-id-text"]').first().props()
-        .children
-    ).toEqual('tester@fake-research-aou.org');
-    expect(
-      wrapper.find('[data-test-id="user-institution-text"]').first().props()
-        .children
-    ).toEqual(BROAD.displayName);
-    expect(
-      wrapper.find('[data-test-id="nih-funded-text"]').first().props().children
-    ).toEqual('No');
+    expect(screen.getByTestId('user-first-name-text')).toHaveTextContent(
+      'Tester!@#$%^&*()><script>alert("hello");</script>'
+    );
+    expect(screen.getByTestId('user-last-name-text')).toHaveTextContent(
+      'MacTesterson!@#$%^&*()><script>alert("hello");</script>'
+    );
+    expect(screen.getByTestId('user-phone-number-text')).toHaveTextContent(
+      '1234567890'
+    );
+    expect(screen.getByTestId('user-contact-email-text')).toHaveTextContent(
+      'tester@mactesterson.edu><script>alert("hello");</script>'
+    );
+    expect(screen.getByTestId('user-workbench-id-text')).toHaveTextContent(
+      'tester@fake-research-aou.org'
+    );
+    expect(screen.getByTestId('user-institution-text')).toHaveTextContent(
+      BROAD.displayName
+    );
+    expect(screen.getByTestId('nih-funded-text')).toHaveTextContent('No');
   });
 });

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -5,6 +5,7 @@
  * @copyright 2017 Airbnb, Inc.
  */
 const enzyme = require('enzyme');
+const rtl = require('@testing-library/react');
 const Adapter = require('@wojtekmaj/enzyme-adapter-react-17');
 
 const { setupCustomValidators } = require('app/services/setup');
@@ -61,6 +62,7 @@ global.afterEach(() => {
 });
 
 enzyme.configure({ adapter: new ReactAdapterWithMountTracking() });
+rtl.configure({ testIdAttribute: 'data-test-id' });
 
 module.exports = {
   mockNavigate: mockNavigate,

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -190,5 +190,9 @@ export const expectDropdownDisabled = (
   ).not.toBeInTheDocument();
 };
 
+export const getHTMLInputElementValue = (element: HTMLElement): string => {
+  return (element as HTMLInputElement).value;
+};
+
 // by default, screen.debug() cuts off after 7000 chars.  let's output more than that
 export const debugAll = () => screen.debug(undefined, 1_000_000);


### PR DESCRIPTION
Converted three Enzyme tests with assistance of Copilot.

I described some of my process here:
https://docs.google.com/document/d/1LDxH33OzrWM0-ZpgNrR5WQb8yG5AmaKqd7cZlLTo1v0/edit

Configured RTL to use 'data-test-id' rather than 'data-testid' for its selector:
https://docs.google.com/document/d/1LDxH33OzrWM0-ZpgNrR5WQb8yG5AmaKqd7cZlLTo1v0/edit#heading=h.yohb9h5pqgoa

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
