### PR TITLE
[no ticket][risk=no] Changing ordering of contract requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ jobs:
         name: Pact Broker, can I deploy?
         working_directory: ~
         command: |
-          pact-broker can-i-deploy --broker-base-url "https://pact-broker.dsp-eng-tools.broadinstitute.org/" --pacticipant aou-rwb-api --version ${CIRCLE_SHA1} --to-environment dev --retry-while-unknown 3 --retry-interval 30
+          pact-broker can-i-deploy --broker-base-url "https://pact-broker.dsp-eng-tools.broadinstitute.org/" --pacticipant aou-rwb-api --version ${CIRCLE_SHA1} --to-environment dev --retry-while-unknown 10 --retry-interval 30
 
   #Updates the pacticipant version in the pact broker for our test environment which is referred to as dev in Pact Broker
   api-contract-update-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -938,7 +938,7 @@ workflows:
           - api-contract-test
       - api-contract-can-i-deploy:
           requires:
-          - api-contract-update-test
+          - api-contract-upload
       # Deploy to "test" on main branch merges
       - api-deploy-to-test:
           <<: *filter-main-branch
@@ -978,7 +978,7 @@ workflows:
       - api-contract-update-test:
           <<: *filter-main-branch
           requires:
-            - api-contract-upload
+            - api-deploy-to-test
 
   playground:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -936,15 +936,15 @@ workflows:
       - api-contract-upload:
           requires:
           - api-contract-test
-      - api-contract-can-i-deploy:
-          requires:
-          - api-contract-upload
+#      - api-contract-can-i-deploy:
+#          requires:
+#          - api-contract-upload
       # Deploy to "test" on main branch merges
       - api-deploy-to-test:
           <<: *filter-main-branch
           requires:
             - api-unit-test
-            - api-contract-can-i-deploy
+            - api-contract-upload
       - ui-deploy-to-test:
           <<: *filter-main-branch
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -938,12 +938,13 @@ workflows:
           - api-contract-test
       - api-contract-can-i-deploy:
           requires:
-          - api-contract-upload
+          - api-contract-update-test
       # Deploy to "test" on main branch merges
       - api-deploy-to-test:
           <<: *filter-main-branch
           requires:
             - api-unit-test
+            - api-contract-can-i-deploy
       - ui-deploy-to-test:
           <<: *filter-main-branch
           requires:
@@ -978,7 +979,6 @@ workflows:
           <<: *filter-main-branch
           requires:
             - api-contract-upload
-            - api-deploy-to-test
 
   playground:
     jobs:


### PR DESCRIPTION
This was ordering of CI as introduced in https://github.com/all-of-us/workbench/pull/8454
![image](https://github.com/all-of-us/workbench/assets/24514630/18c4f31d-9476-4456-a4e1-77e9371d75f2)

Desired ordering:
![image](https://github.com/all-of-us/workbench/assets/24514630/a7910cbb-b8a1-407c-a6e5-6f23673bcb40)



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
