### PR TITLE
[DT-777][DT-791][risk=no] Refine display for variant filter selections

### DIFF
--- a/ui/src/app/pages/data/cohort/constant.ts
+++ b/ui/src/app/pages/data/cohort/constant.ts
@@ -142,5 +142,4 @@ export const VARIANT_DISPLAY = {
   overTenThousand: '> 10,000 Participants',
   overHundredThousand: '> 100,000 Participants',
   overTwoHundredThousand: '> 200,000 Participants',
-
-}
+};

--- a/ui/src/app/pages/data/cohort/constant.ts
+++ b/ui/src/app/pages/data/cohort/constant.ts
@@ -123,3 +123,24 @@ export const MODIFIERS_MAP = {
     },
   },
 };
+
+export const VARIANT_DISPLAY = {
+  searchTerm: 'Search Terms',
+  geneList: 'Gene',
+  consequenceList: 'Consequence',
+  clinicalSignificanceList: 'ClinVar Significance',
+  countMin: 'Allele Count Min',
+  countMax: 'Allele Count Max',
+  numberMin: 'Allele Number Min',
+  numberMax: 'Allele Number Max',
+  frequencyMin: 'Allele Frequency Min',
+  frequencyMax: 'Allele Frequency Max',
+  vidsCount: 'Total Variant Count',
+  participantCount: 'Total Participant Count',
+  lessThanOrEqualToFiveThousand: '<= 5,000 Participants',
+  overFiveThousand: '> 5,000 Participants',
+  overTenThousand: '> 10,000 Participants',
+  overHundredThousand: '> 100,000 Participants',
+  overTwoHundredThousand: '> 200,000 Participants',
+
+}

--- a/ui/src/app/pages/data/cohort/search-group-item.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.tsx
@@ -11,13 +11,14 @@ import {
   ModifierType,
   ResourceType,
   SearchGroupItem as Item,
+  VariantFilter,
 } from 'generated/fetch';
 
 import { Button, Clickable } from 'app/components/buttons';
 import { ClrIcon } from 'app/components/icons';
 import { Modal, ModalFooter, ModalTitle } from 'app/components/modals';
 import { RenameModal } from 'app/components/rename-modal';
-import { MODIFIERS_MAP } from 'app/pages/data/cohort/constant';
+import { MODIFIERS_MAP, VARIANT_DISPLAY } from 'app/pages/data/cohort/constant';
 import {
   encountersStore,
   searchRequestStore,
@@ -97,6 +98,12 @@ const styles = reactStyles({
     opacity: 0.6,
     fontSize: '12px',
   },
+  variantList: {
+    lineHeight: '1.25rem',
+    listStyle: 'none',
+    margin: 0,
+    paddingLeft: '1rem',
+  },
 });
 
 const itemStyles = `
@@ -151,6 +158,32 @@ class SearchGroupItemParameter extends React.Component<
           onMouseLeave={() => tooltip && this.overlay.hide()}
         >
           {showCode && <b>{parameter.code}</b>} {parameter.name}
+          {!!parameter.variantFilter && (
+            <ul style={styles.variantList}>
+              {Object.entries(parameter.variantFilter as VariantFilter)
+                .filter(
+                  ([key, value]) =>
+                    !(
+                      (Array.isArray(value) && value.length === 0) ||
+                      ['', null].includes(value) ||
+                      key === 'sortBy'
+                    )
+                )
+                .map(([key, value]) => (
+                  <li style={{ whiteSpace: 'normal' }}>
+                    <b>{VARIANT_DISPLAY[key]}</b>:{' '}
+                    {Array.isArray(value) ? (
+                      <>
+                        <br />
+                        {value.join(', ')}
+                      </>
+                    ) : (
+                      value.toLocaleString()
+                    )}
+                  </li>
+                ))}
+            </ul>
+          )}
         </span>
         {tooltip && (
           <OverlayPanel

--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -7,19 +7,23 @@ import {
   Domain,
   Modifier,
   VariantFilter,
+  VariantFilterInfoResponse,
 } from 'generated/fetch';
 
 import { Button, Clickable } from 'app/components/buttons';
 import { FlexColumn, FlexRow, FlexRowWrap } from 'app/components/flex';
 import { ClrIcon } from 'app/components/icons';
 import { TooltipTrigger } from 'app/components/popups';
+import { Spinner } from 'app/components/spinners';
 import { AttributesPage } from 'app/pages/data/cohort/attributes-page';
 import {
   getItemFromSearchRequest,
   saveCriteria,
 } from 'app/pages/data/cohort/cohort-search';
+import { VARIANT_DISPLAY } from 'app/pages/data/cohort/constant';
 import { ModifierPage } from 'app/pages/data/cohort/modifier-page';
 import { nameDisplay, typeDisplay } from 'app/pages/data/cohort/utils';
+import { cohortBuilderApi } from 'app/services/swagger-fetch-clients';
 import colors from 'app/styles/colors';
 import {
   reactStyles,
@@ -29,6 +33,7 @@ import {
 import {
   attributesSelectionStore,
   currentCohortCriteriaStore,
+  currentWorkspaceStore,
   sidebarActiveIconStore,
 } from 'app/utils/navigation';
 import arrowLeft from 'assets/icons/arrow-left-regular.svg';
@@ -189,7 +194,9 @@ interface SelectionInfoProps {
 
 interface SelectionInfoState {
   filtersExpanded: boolean;
+  loadingVariantBuckets: boolean;
   truncated: boolean;
+  variantFilterInfoResponse: VariantFilterInfoResponse;
 }
 
 export class SelectionInfo extends React.Component<
@@ -199,10 +206,16 @@ export class SelectionInfo extends React.Component<
   name: HTMLDivElement;
   constructor(props: SelectionInfoProps) {
     super(props);
-    this.state = { filtersExpanded: false, truncated: false };
+    this.state = {
+      filtersExpanded: false,
+      loadingVariantBuckets: !!props.selection.variantFilter,
+      truncated: false,
+      variantFilterInfoResponse: null,
+    };
   }
 
   componentDidMount(): void {
+    this.getVariantFilterBuckets();
     const { offsetWidth, scrollWidth } = this.name;
     this.setState({ truncated: scrollWidth > offsetWidth });
   }
@@ -213,6 +226,23 @@ export class SelectionInfo extends React.Component<
       Domain.DRUG.toString(),
       Domain.SURVEY.toString(),
     ].includes(this.props.selection.domainId);
+  }
+
+  async getVariantFilterBuckets() {
+    const { namespace, id } = currentWorkspaceStore.getValue();
+    try {
+      const filterBucketResponse =
+        await cohortBuilderApi().findVariantFilterInfo(
+          namespace,
+          id,
+          this.props.selection.variantFilter
+        );
+      this.setState({ variantFilterInfoResponse: filterBucketResponse });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      this.setState({ loadingVariantBuckets: false });
+    }
   }
 
   renderVariantFilters() {
@@ -229,9 +259,26 @@ export class SelectionInfo extends React.Component<
           )
           .map(([key, value]) => (
             <li>
-              <b>{key}</b>: {Array.isArray(value) ? value.join(', ') : value}
+              <b>{VARIANT_DISPLAY[key]}</b>:{' '}
+              {Array.isArray(value) ? value.join(', ') : value.toLocaleString()}
             </li>
           ))}
+        <li>
+          <b>Participant Count Overview:</b>
+          {this.state.loadingVariantBuckets ? (
+            <Spinner size={24} style={{ margin: '1rem 5rem' }} />
+          ) : (
+            <ul>
+              {Object.entries(this.state.variantFilterInfoResponse)
+                .filter(([, value]) => value !== 0)
+                .map(([key, value]) => (
+                  <li>
+                    <b>{VARIANT_DISPLAY[key]}</b>: {value.toLocaleString()}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </li>
       </ul>
     );
   }

--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -158,10 +158,16 @@ const styles = reactStyles({
     marginTop: '3px',
     transition: 'transform 0.1s ease-out',
   },
-  filterList: {
+  filterContainer: {
     height: 'auto',
     overflow: 'hidden',
     transition: 'max-height 0.4s ease-out',
+  },
+  filterList: {
+    lineHeight: '1.25rem',
+    listStyle: 'none',
+    margin: 0,
+    paddingLeft: '1rem',
   },
 });
 
@@ -247,7 +253,7 @@ export class SelectionInfo extends React.Component<
 
   renderVariantFilters() {
     return (
-      <ul>
+      <ul style={styles.filterList}>
         {Object.entries(this.props.selection.variantFilter)
           .filter(
             ([key, value]) =>
@@ -260,15 +266,24 @@ export class SelectionInfo extends React.Component<
           .map(([key, value]) => (
             <li>
               <b>{VARIANT_DISPLAY[key]}</b>:{' '}
-              {Array.isArray(value) ? value.join(', ') : value.toLocaleString()}
+              {Array.isArray(value) ? (
+                <>
+                  <br />
+                  {value.join(', ')}
+                </>
+              ) : (
+                value.toLocaleString()
+              )}
             </li>
           ))}
         <li>
           <b>Participant Count Overview:</b>
           {this.state.loadingVariantBuckets ? (
-            <Spinner size={24} style={{ margin: '1rem 5rem' }} />
+            <div>
+              <Spinner size={24} style={{ margin: '1rem 5rem' }} />
+            </div>
           ) : (
-            <ul>
+            <ul style={styles.filterList}>
               {Object.entries(this.state.variantFilterInfoResponse)
                 .filter(([, value]) => value !== 0)
                 .map(([key, value]) => (
@@ -329,7 +344,7 @@ export class SelectionInfo extends React.Component<
         {!!selection.variantFilter && (
           <div
             style={{
-              ...styles.filterList,
+              ...styles.filterContainer,
               maxHeight: filtersExpanded ? '22.5rem' : 0,
             }}
           >

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -382,7 +382,8 @@ export const VariantSearch = fp.flow(
   };
 
   const disableSelectAll =
-    searchResults.length < 2 ||
+    totalCount < 100 ||
+    totalCount > 10000 ||
     criteria.some((crit) => crit.parameterId === getFilterParamId());
   const displayResults = searchResults?.slice(first, first + pageSize);
   return (

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -366,7 +366,7 @@ export const VariantSearch = fp.flow(
       parameterId: getFilterParamId(),
       parentId: null,
       type: CriteriaType.NONE,
-      name: `Filter group: ${selectAllFilters.searchTerm}`,
+      name: `Select All Group: ${selectAllFilters.searchTerm}`,
       group: false,
       domainId: Domain.SNP_INDEL_VARIANT,
       hasAttributes: false,
@@ -375,7 +375,7 @@ export const VariantSearch = fp.flow(
       variantFilter: selectAllFilters,
     };
     AnalyticsTracker.CohortBuilder.SelectCriteria(
-      `Select Variant Filter Group - '${selectAllFilters.searchTerm}'`
+      `Select All Variant Filter Group - '${selectAllFilters.searchTerm}'`
     );
     select(param);
     clearSearch();


### PR DESCRIPTION
- Make display more user-friendly for select all filters in variant search
- Use same layout for displaying filters in search group items UI (excluding the Participant Count Overview section)
![Screenshot 2024-03-26 at 12 28 07 PM](https://github.com/all-of-us/workbench/assets/40036095/d07e7952-8a21-45af-99c1-b3f4cd22c8a2)
![Screenshot 2024-03-26 at 12 31 10 PM](https://github.com/all-of-us/workbench/assets/40036095/baea78fa-724a-4088-aed5-bf6dddaaf4e0)

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
