### PR TITLE
[no ticket][risk=low]Switch local and test environments back to staging RAS.

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -142,8 +142,8 @@
     "exportTerraDataWarehouse": false
   },
   "ras": {
-    "host": "https:\/\/stsprep.nih.gov",
-    "clientId": "989e7869-12f4-4129-9930-a1091d208c94",
+    "host": "https:\/\/stsstg.nih.gov",
+    "clientId": "e5c5d714-d597-48c8-b564-a249d729d0c9",
     "logoutUrl": "https:\/\/authtest.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
   "offlineBatch": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -144,8 +144,8 @@
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app_usage_dev"
   },
   "ras": {
-    "host": "https:\/\/stsprep.nih.gov",
-    "clientId": "989e7869-12f4-4129-9930-a1091d208c94",
+    "host": "https:\/\/stsstg.nih.gov",
+    "clientId": "e5c5d714-d597-48c8-b564-a249d729d0c9",
     "logoutUrl": "https:\/\/authtest.nih.gov\/siteminderagent\/smlogoutredirector.asp?TARGET="
   },
   "offlineBatch": {


### PR DESCRIPTION
Switching local and test environments back to using staging version of RAS.

These environments have been using a pre-production environment of RAS since just before ID.me was released.

Switching back because pre-prod RAS is supposed to be temporary.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
