### PR TITLE
[risk=low][RW-12234] Playground is for Jupyter only

### DIFF
--- a/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/interactiveanalysis/InteractiveAnalysisServiceTest.java
@@ -156,17 +156,14 @@ public class InteractiveAnalysisServiceTest {
   @Test
   public void testLocalize_RStudio_editMode() {
     String editDir = "";
-    String playgroundDir = "workspaces_playground";
     List<String> notebookLists = List.of("foo.Rmd");
     StorageLink expectedStorageLink =
         new StorageLink()
             .cloudStorageDirectory(NOTEBOOK_DIR)
             .localBaseDirectory(editDir)
-            .localSafeModeBaseDirectory(playgroundDir)
             .pattern(RSTUDIO_DELOC_PATTERN);
     Map<String, String> expectedLocalizeMap = new HashMap<>();
     expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put("foo.Rmd", NOTEBOOK_DIR + "/foo.Rmd");
 
     interactiveAnalysisService.localize(
@@ -177,69 +174,20 @@ public class InteractiveAnalysisServiceTest {
   }
 
   @Test
-  public void testLocalize_RStudio_playground() {
-    String editDir = "";
-    String playgroundDir = "workspaces_playground";
-    List<String> notebookLists = List.of("foo.Rmd");
-    StorageLink expectedStorageLink =
-        new StorageLink()
-            .cloudStorageDirectory(NOTEBOOK_DIR)
-            .localBaseDirectory(editDir)
-            .localSafeModeBaseDirectory(playgroundDir)
-            .pattern(RSTUDIO_DELOC_PATTERN);
-    Map<String, String> expectedLocalizeMap = new HashMap<>();
-    expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/foo.Rmd", NOTEBOOK_DIR + "/foo.Rmd");
-
-    interactiveAnalysisService.localize(
-        WORKSPACE_NS, APP_NAME, AppType.RSTUDIO, notebookLists, true, false);
-    verify(mockLeonardoApiClient)
-        .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
-    verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
-  }
-
-  @Test
   public void testLocalize_SAS_editMode() {
     String editDir = "";
-    String playgroundDir = "workspaces_playground";
     List<String> notebookLists = List.of("foo.sas");
     StorageLink expectedStorageLink =
         new StorageLink()
             .cloudStorageDirectory(NOTEBOOK_DIR)
             .localBaseDirectory(editDir)
-            .localSafeModeBaseDirectory(playgroundDir)
             .pattern(SAS_DELOC_PATTERN);
     Map<String, String> expectedLocalizeMap = new HashMap<>();
     expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
     expectedLocalizeMap.put("foo.sas", NOTEBOOK_DIR + "/foo.sas");
 
     interactiveAnalysisService.localize(
         WORKSPACE_NS, APP_NAME, AppType.SAS, notebookLists, false, false);
-    verify(mockLeonardoApiClient)
-        .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
-    verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);
-  }
-
-  @Test
-  public void testLocalize_SAS_playground() {
-    String editDir = "";
-    String playgroundDir = "workspaces_playground";
-    List<String> notebookLists = List.of("foo.sas");
-    StorageLink expectedStorageLink =
-        new StorageLink()
-            .cloudStorageDirectory(NOTEBOOK_DIR)
-            .localBaseDirectory(editDir)
-            .localSafeModeBaseDirectory(playgroundDir)
-            .pattern(SAS_DELOC_PATTERN);
-    Map<String, String> expectedLocalizeMap = new HashMap<>();
-    expectedLocalizeMap.put(".all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/.all_of_us_config.json", aouConfigDataUri);
-    expectedLocalizeMap.put(playgroundDir + "/foo.sas", NOTEBOOK_DIR + "/foo.sas");
-
-    interactiveAnalysisService.localize(
-        WORKSPACE_NS, APP_NAME, AppType.SAS, notebookLists, true, false);
     verify(mockLeonardoApiClient)
         .createStorageLinkForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedStorageLink);
     verify(mockLeonardoApiClient).localizeForApp(GOOGLE_PROJECT_ID, APP_NAME, expectedLocalizeMap);


### PR DESCRIPTION
We configure a Playground Mode for Jupyter runtimes, but the concept does not apply to RStudio and SAS.  Previously, we created a "workspaces_playground" folder for these apps, but it serves no purpose.  Remove it to avoid confusing users.

Tested locally by:
* observing the lack of playground directory in RStudio and SAS, and confirming that localization still works in these apps.
* observing that localization and playground continue to work in Jupyter

SAS
<img width="208" alt="Screenshot 2024-03-29 at 2 38 27 PM" src="https://github.com/all-of-us/workbench/assets/2701406/8d18b4c2-6728-4769-9d5e-f3fb8a62dc7d">

RStudio
<img width="154" alt="Screenshot 2024-03-29 at 2 41 28 PM" src="https://github.com/all-of-us/workbench/assets/2701406/c5dd7e57-73d9-4750-a007-d5ba341bdb16">


Jupyter still has a playground
<img width="369" alt="Screenshot 2024-03-29 at 2 38 12 PM" src="https://github.com/all-of-us/workbench/assets/2701406/c80d7220-7b59-4bac-8dd7-b3ce28f1f1c6">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
