### PR TITLE
[risk=low][no ticket] Fix display name for "can't delete workspace"

### DIFF
--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -105,7 +105,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
     deleteWorkspace = withErrorModal(
       {
         title: 'Error Deleting Workspace',
-        message: `Could not delete workspace '${this.props.workspace.id}'.`,
+        message: `Could not delete workspace '${this.props.workspace.name}'.`,
         showBugReportLink: true,
         onDismiss: () => {
           this.setState({ confirmDeleting: false });


### PR DESCRIPTION
It was choosing the "id" (terra name) for display instaad of the name which is meaningful to users.

<img width="421" alt="Screenshot 2024-03-29 at 2 37 53 PM" src="https://github.com/all-of-us/workbench/assets/2701406/0c21c568-8028-48cb-8387-cebc9522fb22">

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
