### PR TITLE
[risk=low][no ticket] Can simplify some cases b/c Option.map() is null safe

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/actionaudit/targetproperties/EgressEscalationTargetProperty.java
+++ b/api/src/main/java/org/pmiops/workbench/actionaudit/targetproperties/EgressEscalationTargetProperty.java
@@ -18,7 +18,7 @@ public enum EgressEscalationTargetProperty implements ModelBackedTargetProperty<
       "suspend_duration",
       escalation ->
           Optional.ofNullable(escalation.suspendCompute)
-              .flatMap(s -> Optional.ofNullable(s.durationMinutes))
+              .map(s -> s.durationMinutes)
               .map(Object::toString)
               .orElse(null));
 

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -218,8 +218,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   public boolean isValidResource(DbUserRecentlyModifiedResource resource) {
     // handle null and unparseable resourceIds
     final Optional<Long> resourceId =
-        Optional.ofNullable(resource.getResourceId())
-            .flatMap(str -> Optional.ofNullable(Longs.tryParse(str)));
+        Optional.ofNullable(resource.getResourceId()).map(Longs::tryParse);
     switch (resource.getResourceType()) {
       case COHORT:
         return resourceId.flatMap(cohortService::findByCohortId).isPresent();

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoLabelHelper.java
@@ -39,7 +39,7 @@ public class LeonardoLabelHelper {
   @SuppressWarnings("unchecked")
   public static Optional<AppType> maybeMapLeonardoLabelsToGkeApp(@Nullable Object diskLabels) {
     return Optional.ofNullable((Map<String, String>) diskLabels)
-        .flatMap(m -> Optional.ofNullable(m.get(LEONARDO_LABEL_APP_TYPE)))
+        .map(m -> m.get(LEONARDO_LABEL_APP_TYPE))
         .map(LeonardoLabelHelper::labelValueToAppType);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -245,7 +245,7 @@ public class NotebooksServiceImpl implements NotebooksService {
     try {
       String language =
           Optional.of(notebookFile.getJSONObject("metadata"))
-              .flatMap(metaDataObj -> Optional.of(metaDataObj.getJSONObject("kernelspec")))
+              .map(metaDataObj -> metaDataObj.getJSONObject("kernelspec"))
               .map(kernelSpec -> kernelSpec.getString("language"))
               .orElse("Python");
 

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -225,7 +225,7 @@ public class WorkspaceAuditorTest {
         eventsSent.stream()
             .filter(e -> e.targetType() == TargetType.USER)
             .findFirst()
-            .flatMap(e -> Optional.ofNullable(e.targetPropertyMaybe()));
+            .map(ActionAuditEvent::targetPropertyMaybe);
 
     assertThat(targetPropertyMaybe.isPresent()).isTrue();
     assertThat(targetPropertyMaybe.get()).isEqualTo(AclTargetProperty.ACCESS_LEVEL.toString());


### PR DESCRIPTION
I have been using an overly verbose pattern in some cases, based on a mistaken assumption that I need to account for nulls when using  `Optional.map()`:

`Optional.ofNullable(foo).flatMap(f -> Optional.ofNullable(f.getBar()))`

But the actual implementation of `Optional.map()` already includes this, so instead we can just call `map()`

`Optional.ofNullable(foo).map(FooType::getBar)`

Tested locally with no problems.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
