### PR TITLE
[RW-12277][risk=low] Update localizeRuntime and localizeApp API to support localized all files

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -97,8 +97,12 @@ public class AppsController implements AppsApiDelegate {
     return ResponseEntity.ok(response);
   }
 
+  @Override
   public ResponseEntity<AppLocalizeResponse> localizeApp(
-      String workspaceNamespace, String appName, AppLocalizeRequest body) {
+      String workspaceNamespace,
+      String appName,
+      Boolean localizeAllFiles,
+      AppLocalizeRequest body) {
     DbUser user = userProvider.get();
     leonardoApiHelper.enforceComputeSecuritySuspension(user);
 
@@ -111,6 +115,7 @@ public class AppsController implements AppsApiDelegate {
                     body.getAppType(),
                     body.getFileNames(),
                     body.isPlaygroundMode(),
-                    false)));
+                    false,
+                    localizeAllFiles)));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -274,7 +274,7 @@ public class RuntimeController implements RuntimeApiDelegate {
 
   @Override
   public ResponseEntity<RuntimeLocalizeResponse> localize(
-      String workspaceNamespace, RuntimeLocalizeRequest body) {
+      String workspaceNamespace, Boolean localizeAllFiles, RuntimeLocalizeRequest body) {
     DbUser user = userProvider.get();
     leonardoApiHelper.enforceComputeSecuritySuspension(user);
     DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
@@ -295,6 +295,7 @@ public class RuntimeController implements RuntimeApiDelegate {
                     appType,
                     body.getNotebookNames(),
                     body.isPlaygroundMode(),
-                    true)));
+                    true,
+                    localizeAllFiles)));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.notebooks;
 import com.google.cloud.storage.Blob;
 import java.util.List;
 import org.json.JSONObject;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 
@@ -16,6 +17,12 @@ public interface NotebooksService {
    * input value should be trusted.
    */
   List<FileDetail> getNotebooksAsService(
+      String bucketName, String workspaceNamespace, String workspaceName);
+
+  List<FileDetail> getAllNotebooksByAppType(
+      String bucketName, String workspaceNamespace, String workspaceName, AppType appType);
+
+  List<FileDetail> getAllJupyterNotebooks(
       String bucketName, String workspaceNamespace, String workspaceName);
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/notebooks/NotebooksServiceImpl.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.BlobId;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import org.pmiops.workbench.exceptions.NotImplementedException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.GoogleCloudLocators;
+import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.KernelTypeEnum;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -121,6 +123,32 @@ public class NotebooksServiceImpl implements NotebooksService {
         .stream()
         .filter(this::isManagedNotebookBlob)
         .map(blob -> cloudStorageClient.blobToFileDetail(blob, bucketName, workspaceUsers))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<FileDetail> getAllNotebooksByAppType(
+      String bucketName, String workspaceNamespace, String workspaceName, AppType appType) {
+    List<FileDetail> allNotebooks =
+        getNotebooksAsService(bucketName, workspaceNamespace, workspaceName);
+    if (appType.equals(AppType.RSTUDIO)) {
+      return allNotebooks.stream()
+          .filter(fileDetail -> NotebookUtils.isRStudioFile(fileDetail.getName()))
+          .collect(Collectors.toList());
+    } else if (appType.equals(AppType.SAS)) {
+      return allNotebooks.stream()
+          .filter(fileDetail -> NotebookUtils.isSasFile(fileDetail.getName()))
+          .collect(Collectors.toList());
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  @Override
+  public List<FileDetail> getAllJupyterNotebooks(
+      String bucketName, String workspaceNamespace, String workspaceName) {
+    return getNotebooksAsService(bucketName, workspaceNamespace, workspaceName).stream()
+        .filter(fileDetail -> NotebookUtils.isJupyterNotebook(fileDetail.getName()))
         .collect(Collectors.toList());
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -832,6 +832,15 @@ paths:
         required: true
         schema:
           type: string
+      - in: query
+        name: localizeAllFiles
+        description: |
+          Optional query that will localize all files associate with this app. 
+          If true, it will ignore fileNames in body and localize all files instead.
+        required: false
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Localization request.
         content:
@@ -1102,6 +1111,15 @@ paths:
         required: true
         schema:
           type: string
+      - in: query
+        name: localizeAllFiles
+        description: |
+          Optional query that will localize all files associate with this app. 
+          If true, it will ignore fileNames in body and localize all files instead.
+        required: false
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Localization request.
         content:

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -1321,7 +1321,7 @@ public class RuntimeControllerTest {
 
     assertThrows(
         FailedPreconditionException.class,
-        () -> runtimeController.localize(WORKSPACE_NS, new RuntimeLocalizeRequest()));
+        () -> runtimeController.localize(WORKSPACE_NS, false, new RuntimeLocalizeRequest()));
   }
 
   @Test
@@ -1331,7 +1331,8 @@ public class RuntimeControllerTest {
         .validateActiveBilling(WORKSPACE_NS, WORKSPACE_ID);
 
     RuntimeLocalizeRequest req = new RuntimeLocalizeRequest();
-    assertThrows(ForbiddenException.class, () -> runtimeController.localize(WORKSPACE_NS, req));
+    assertThrows(
+        ForbiddenException.class, () -> runtimeController.localize(WORKSPACE_NS, false, req));
   }
 
   @Test
@@ -1342,7 +1343,8 @@ public class RuntimeControllerTest {
 
     RuntimeLocalizeRequest req = new RuntimeLocalizeRequest();
 
-    assertThrows(ForbiddenException.class, () -> runtimeController.localize(WORKSPACE_NS, req));
+    assertThrows(
+        ForbiddenException.class, () -> runtimeController.localize(WORKSPACE_NS, false, req));
     verify(mockWorkspaceAuthService, never()).validateActiveBilling(anyString(), anyString());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/notebooks/NotebooksServiceTest.java
@@ -587,6 +587,13 @@ public class NotebooksServiceTest {
     assertThat(jupyterNotebooks).containsExactly("f1.ipynb");
     assertThat(rstudioNotebooks).containsExactly("f2.Rmd");
     assertThat(sasNotebooks).containsExactly("f3.sas");
+    assertThat(
+            notebooksService.getAllNotebooksByAppType(
+                BUCKET_NAME,
+                dbWorkspace.getWorkspaceNamespace(),
+                dbWorkspace.getFirecloudName(),
+                AppType.CROMWELL))
+        .isEmpty();
   }
 
   @Test

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -394,6 +394,7 @@ describe('ExpandedApp', () => {
           expect(localizeSpy).toHaveBeenCalledWith(
             WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
             appName,
+            false,
             {
               appType: toAppType[appType],
               fileNames: [],

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -657,6 +657,7 @@ export const LeonardoAppLauncher = fp.flow(
       const resp = await this.runtimeRetry(() =>
         runtimeApi().localize(
           workspace.namespace,
+          false,
           {
             notebookNames,
             playgroundMode: this.isPlaygroundMode(),

--- a/ui/src/testing/stubs/apps-api-stub.ts
+++ b/ui/src/testing/stubs/apps-api-stub.ts
@@ -109,6 +109,7 @@ export class AppsApiStub extends AppsApi {
   public localizeApp(
     _workspaceNamespace: string,
     _appName: string,
+    _localizeAllFiles: boolean,
     _body: AppLocalizeRequest,
     _options: any
   ): Promise<AppLocalizeResponse> {


### PR DESCRIPTION
Add a new query parameter (default as `false`), it will localize all files under `WS bucket/notebooks dir` when setting to `true`
Background detail see: https://docs.google.com/document/d/1dnpjLDZd1nhv7cRfdBlgCnnOw7QvOGZClE2HJnNruww/edit 
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
