### PR TITLE
[no ticket][risk=no] Add stopwatch bean back

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/CommonConfig.java
@@ -3,13 +3,16 @@ package org.pmiops.workbench.config;
 import static com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory;
 
 import com.google.api.client.json.JsonFactory;
+import com.google.common.base.Stopwatch;
 import java.security.SecureRandom;
 import java.time.Clock;
 import java.util.Random;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 @Configuration
 public class CommonConfig {
@@ -31,5 +34,11 @@ public class CommonConfig {
   @Bean
   Javers javers() {
     return JaversBuilder.javers().build();
+  }
+
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  public Stopwatch getStopwatch() {
+    return Stopwatch.createUnstarted();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
@@ -32,8 +32,7 @@ public class ReportingSnapshotServiceImpl implements ReportingSnapshotService {
   @Transactional(readOnly = true)
   @Override
   public ReportingSnapshot takeSnapshot() {
-    final Stopwatch stopwatch = stopwatchProvider.get();
-    stopwatch.reset().start();
+    final Stopwatch stopwatch = stopwatchProvider.get().reset().start();
     final ReportingSnapshot result =
         new ReportingSnapshot()
             .captureTimestamp(clock.millis())

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
@@ -32,7 +32,8 @@ public class ReportingSnapshotServiceImpl implements ReportingSnapshotService {
   @Transactional(readOnly = true)
   @Override
   public ReportingSnapshot takeSnapshot() {
-    final Stopwatch stopwatch = stopwatchProvider.get().start();
+    final Stopwatch stopwatch = stopwatchProvider.get();
+    stopwatch.reset().start();
     final ReportingSnapshot result =
         new ReportingSnapshot()
             .captureTimestamp(clock.millis())

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -222,7 +222,7 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
       ImmutableMultimap.Builder<TableId, InsertAllResponse> responseMapBuilder,
       StringBuilder performanceStringBuilder,
       InsertAllRequest request) {
-    stopwatch.start();
+    stopwatch.reset().start();
     final InsertAllResponse currentResponse = bigQueryService.insertAll(request);
     stopwatch.stop();
     responseMapBuilder.put(request.getTable(), currentResponse);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -130,7 +130,7 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
 
   private ReportingUploadDetails getUploadDetails(ReportingSnapshot snapshot) {
     final Stopwatch verifyStopwatch = stopwatchProvider.get();
-    verifyStopwatch.start();
+    verifyStopwatch.reset().start();
     final ReportingUploadDetails result =
         new ReportingUploadDetails()
             .snapshotTimestamp(snapshot.getCaptureTimestamp())


### PR DESCRIPTION
This is deleted in https://github.com/all-of-us/workbench/pull/8462/files#diff-c99d07856632444c11b1e0088c3c5bdd85bd88c798427c02aa900dc40673c709 but used by reporting services. 
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
