### PR TITLE
[no ticket][risk=no] Variant select all edit fix

### DIFF
--- a/ui/src/app/pages/data/cohort/cohort-criteria-menu.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-criteria-menu.tsx
@@ -473,10 +473,9 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
                                           <ul style={styles.subMenu}>
                                             {menuItem.children?.map(
                                               (subMenuItem, s) => (
-                                                <li>
+                                                <li key={s}>
                                                   <a
                                                     role='menuitem'
-                                                    key={s}
                                                     style={{
                                                       ...styles.subMenuItem,
                                                       ...(subHoverId ===

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -249,13 +249,13 @@ export const VariantSearch = fp.flow(
         setVariantFilters(variantFilter);
         setExcludeFromSelectAll(variantFilter.exclusionList ?? []);
         setEditSelectAllResults(true);
+        setLoading(true);
         setSearching(true);
       }
     }, [cohortContext]);
 
     useEffect(() => {
       if (editSelectAllResults) {
-        setLoading(true);
         searchVariants(false);
       }
     }, [editSelectAllResults]);
@@ -471,7 +471,7 @@ export const VariantSearch = fp.flow(
       criteria.some((crit) => crit.parameterId === getFilterParamId());
     const disableSelectAllSave =
       excludeFromSelectAll.length ===
-      cohortContext.editSelectAll?.variantFilter.exclusionList.length;
+      cohortContext.editSelectAll?.variantFilter.exclusionList?.length;
     const displayResults = searchResults?.slice(first, first + pageSize);
     return (
       <>
@@ -484,6 +484,7 @@ export const VariantSearch = fp.flow(
                 style={styles.searchInput}
                 value={searchTerms}
                 placeholder='Search Variants'
+                disabled={editSelectAllResults}
                 onChange={(e) => setSearchTerms(e)}
                 onKeyPress={handleInput}
               />
@@ -560,8 +561,8 @@ export const VariantSearch = fp.flow(
                     />
                     Save Select All Exclusions (
                     {excludeFromSelectAll.length -
-                      cohortContext.editSelectAll.variantFilter.exclusionList
-                        .length}
+                      (cohortContext.editSelectAll.variantFilter.exclusionList
+                        ?.length || 0)}
                     )
                   </Clickable>
                   <Clickable


### PR DESCRIPTION
- Prevents UI from breaking if `exclusionList` is undefined
- Disable search input when editing select all filter