### PR TITLE
[RW-12347][risk=no] Updated three Enzyme tests to RTL

### DIFF
--- a/ui/src/app/pages/data/cohort/list-search.spec.tsx
+++ b/ui/src/app/pages/data/cohort/list-search.spec.tsx
@@ -1,8 +1,10 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import { CohortBuilderApi } from 'generated/fetch';
 
+import { render, screen } from '@testing-library/react';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 
 import { CohortBuilderServiceStub } from 'testing/stubs/cohort-builder-service-stub';
@@ -14,10 +16,18 @@ beforeEach(() => {
 });
 
 describe('ListSearchComponent', () => {
+  const searchTerms = 'selected search term';
   it('should render', () => {
-    const wrapper = shallow(
-      <ListSearch hierarchy={() => {}} selections={[]} wizard={{}} />
+    render(
+      <ListSearch
+        hierarchy={() => {}}
+        searchContext={{ domain: '' }}
+        searchTerms={searchTerms}
+        selections={[]}
+        wizard={{}}
+        workspace={{}}
+      />
     );
-    expect(wrapper.exists()).toBeTruthy();
+    expect(screen.getByDisplayValue(searchTerms)).toBeTruthy();
   });
 });

--- a/ui/src/app/pages/data/cohort/selection-list.spec.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.spec.tsx
@@ -1,13 +1,16 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import { Domain } from 'generated/fetch';
+
+import { render, screen } from '@testing-library/react';
 
 import { SelectionList } from './selection-list';
 
 describe('SelectionList', () => {
   it('should create', () => {
-    const wrapper = shallow(
+    render(
       <SelectionList
         back={() => {}}
         close={() => {}}
@@ -20,6 +23,8 @@ describe('SelectionList', () => {
         view={''}
       />
     );
-    expect(wrapper).toBeTruthy();
+    screen.getByRole('img', {
+      name: /close/i,
+    });
   });
 });

--- a/ui/src/app/pages/login/account-creation/account-creation-modals.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-modals.spec.tsx
@@ -1,8 +1,11 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import { ProfileApi } from 'generated/fetch';
 
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
@@ -18,20 +21,20 @@ beforeEach(() => {
 
 describe('AccountCreationResendModal', () => {
   it('should render', () => {
-    const wrapper = shallow(
+    render(
       <AccountCreationResendModal
         username='a'
         creationNonce='b'
         onClose={() => {}}
       />
     );
-    expect(wrapper.exists()).toBeTruthy();
+    expect(screen.getByText('Resend Instructions')).toBeInTheDocument();
   });
 });
 
 describe('AccountCreationUpdateModal', () => {
   it('should render', () => {
-    const wrapper = shallow(
+    render(
       <AccountCreationUpdateModal
         username='a'
         creationNonce='b'
@@ -39,6 +42,6 @@ describe('AccountCreationUpdateModal', () => {
         onClose={() => {}}
       />
     );
-    expect(wrapper.exists()).toBeTruthy();
+    expect(screen.getByText('Change contact email')).toBeInTheDocument();
   });
 });

--- a/ui/src/app/pages/login/account-creation/account-creation-modals.spec.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-modals.spec.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { ProfileApi } from 'generated/fetch';
 
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
 
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';


### PR DESCRIPTION
Updated the following tests from Enzyme to RTL:
ui/src/app/pages/data/cohort/list-search.spec.tsx
ui/src/app/pages/data/cohort/selection-list.spec.tsx
ui/src/app/pages/login/account-creation/account-creation-modals.spec.tsx

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
