### PR TITLE
[no ticket][risk=low] Upgrade auth library and use legacy bundle service

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -443,7 +443,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$project.ext.GSON_VERSION"
     implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
-    implementation 'com.google.protobuf:protobuf-java:3.25.7'
+    implementation 'com.google.protobuf:protobuf-java:3.21.7'
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2'
 
     implementation "org.hibernate:hibernate-core:$project.ext.HIBERNATE_VERSION"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -425,15 +425,14 @@ dependencies {
 
     // TODO: consider switching google deps to the BOM.  https://cloud.google.com/java/docs/bom
 
-    implementation 'com.google.api-client:google-api-client-appengine:1.35.2'
     implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev20220919-2.0.0'
     implementation 'com.google.apis:google-api-services-cloudbilling:v1-rev20220908-2.0.0'
     implementation 'com.google.apis:google-api-services-cloudresourcemanager:v3-rev20220925-2.0.0'
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20220825-2.0.0'
     implementation 'com.google.api-client:google-api-client-appengine:2.2.0'
-    implementation 'com.google.auth:google-auth-library-appengine:1.11.0'
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.11.0'
+    implementation 'com.google.auth:google-auth-library-appengine:1.23.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
     implementation 'com.google.cloud.sql:mysql-socket-factory:1.7.0'
     implementation 'com.google.cloud:google-cloud-bigquery:2.25.0'
     implementation 'com.google.cloud:google-cloud-iamcredentials:2.3.6'
@@ -444,7 +443,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$project.ext.GSON_VERSION"
     implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
-    implementation 'com.google.protobuf:protobuf-java:3.21.7'
+    implementation 'com.google.protobuf:protobuf-java:3.25.7'
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2'
 
     implementation "org.hibernate:hibernate-core:$project.ext.HIBERNATE_VERSION"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     // External properties on the default project. Values declared in ext blocks
     // outside of the buildscript block aren't usable here.
     ext {
+        GAE_VERSION = '2.0.9'
         GOOGLE_TRUTH_VERSION = '1.1.3'
         GSON_VERSION = '2.9.0'
         HIBERNATE_VERSION = '5.6.15.Final'
@@ -425,6 +426,7 @@ dependencies {
 
     // TODO: consider switching google deps to the BOM.  https://cloud.google.com/java/docs/bom
 
+    implementation "com.google.appengine:appengine-api-1.0-sdk:$project.ext.GAE_VERSION"
     implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev20220919-2.0.0'
     implementation 'com.google.apis:google-api-services-cloudbilling:v1-rev20220908-2.0.0'
     implementation 'com.google.apis:google-api-services-cloudresourcemanager:v3-rev20220925-2.0.0'

--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -1,9 +1,12 @@
 package org.pmiops.workbench.auth;
 
+import static org.pmiops.workbench.utils.AppEngineUtils.IS_GAE;
+
 import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 import com.google.auth.appengine.AppEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import org.pmiops.workbench.utils.AppEngineUtils;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -36,11 +39,15 @@ public class ServiceAccounts {
    */
   public static GoogleCredentials getScopedServiceCredentials(List<String> scopes)
       throws IOException {
-    GoogleCredentials credentials =
-        AppEngineCredentials.newBuilder()
-            .setScopes(scopes)
-            .setAppIdentityService(AppIdentityServiceFactory.getAppIdentityService())
-            .build();
+    GoogleCredentials credentials;
+    if (IS_GAE) {
+      credentials = AppEngineCredentials.newBuilder()
+          .setScopes(scopes)
+          .setAppIdentityService(AppIdentityServiceFactory.getAppIdentityService())
+          .build();
+    } else {
+      credentials = GoogleCredentials.getApplicationDefault().createScoped(scopes);
+    }
     credentials.refreshIfExpired();
     return credentials;
   }

--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -6,7 +6,6 @@ import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 import com.google.auth.appengine.AppEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import org.pmiops.workbench.utils.AppEngineUtils;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,11 @@ public class ServiceAccounts {
       throws IOException {
     GoogleCredentials credentials;
     if (IS_GAE) {
-      credentials = AppEngineCredentials.newBuilder()
-          .setScopes(scopes)
-          .setAppIdentityService(AppIdentityServiceFactory.getAppIdentityService())
-          .build();
+      credentials =
+          AppEngineCredentials.newBuilder()
+              .setScopes(scopes)
+              .setAppIdentityService(AppIdentityServiceFactory.getAppIdentityService())
+              .build();
     } else {
       credentials = GoogleCredentials.getApplicationDefault().createScoped(scopes);
     }

--- a/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
+++ b/api/src/main/java/org/pmiops/workbench/auth/ServiceAccounts.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.auth;
 
+import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
+import com.google.auth.appengine.AppEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.util.List;
@@ -34,7 +36,11 @@ public class ServiceAccounts {
    */
   public static GoogleCredentials getScopedServiceCredentials(List<String> scopes)
       throws IOException {
-    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault().createScoped(scopes);
+    GoogleCredentials credentials =
+        AppEngineCredentials.newBuilder()
+            .setScopes(scopes)
+            .setAppIdentityService(AppIdentityServiceFactory.getAppIdentityService())
+            .build();
     credentials.refreshIfExpired();
     return credentials;
   }

--- a/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.rawls;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -17,7 +16,6 @@ import org.springframework.web.context.annotation.RequestScope;
 
 @org.springframework.context.annotation.Configuration
 public class RawlsConfig {
-  private static final Logger log = Logger.getLogger(RawlsConfig.class.getName());
   public static final List<String> BILLING_SCOPES =
       ImmutableList.<String>builder()
           .addAll(RawlsApiClientFactory.SCOPES)
@@ -67,9 +65,7 @@ public class RawlsConfig {
   public ApiClient allOfUsApiClient(RawlsApiClientFactory factory) {
     ApiClient apiClient = factory.newRawlsApiClient();
     try {
-      String token = ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES);
-      apiClient.setAccessToken(token);
-      log.severe("Service account access token: " + token);
+      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES));
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }

--- a/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.rawls;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Logger;
 import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -16,6 +17,7 @@ import org.springframework.web.context.annotation.RequestScope;
 
 @org.springframework.context.annotation.Configuration
 public class RawlsConfig {
+  private static final Logger log = Logger.getLogger(RawlsConfig.class.getName());
   public static final List<String> BILLING_SCOPES =
       ImmutableList.<String>builder()
           .addAll(RawlsApiClientFactory.SCOPES)
@@ -65,7 +67,9 @@ public class RawlsConfig {
   public ApiClient allOfUsApiClient(RawlsApiClientFactory factory) {
     ApiClient apiClient = factory.newRawlsApiClient();
     try {
-      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES));
+      String token = ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES);
+      apiClient.setAccessToken(token);
+      log.severe("Service account access token: " + token);
     } catch (IOException e) {
       throw new ServerErrorException(e);
     }

--- a/api/src/main/java/org/pmiops/workbench/utils/AppEngineUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/AppEngineUtils.java
@@ -1,0 +1,6 @@
+package org.pmiops.workbench.utils;
+public class AppEngineUtils {
+  public static boolean IS_GAE =
+      System.getProperty("com.google.appengine.runtime.version") != null
+          && !System.getProperty("com.google.appengine.runtime.version").startsWith("dev");
+}

--- a/api/src/main/java/org/pmiops/workbench/utils/AppEngineUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/AppEngineUtils.java
@@ -1,4 +1,5 @@
 package org.pmiops.workbench.utils;
+
 public class AppEngineUtils {
   public static boolean IS_GAE =
       System.getProperty("com.google.appengine.runtime.version") != null

--- a/api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -13,6 +13,7 @@
     <env-var name="CDR_DB_PASSWORD" value="${CDR_DB_PASSWORD}" />
   </env-variables>
 
+ <app-engine-apis>true</app-engine-apis>
   <system-properties>
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
   </system-properties>


### PR DESCRIPTION
Similar to  https://github.com/googleapis/google-auth-library-java/pull/1087, upgrading auth breaks `createScoped` when using appengine's SA. 
This PR brings the old way back.
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
