### PR TITLE
[DT-807][risk=no] CB variant select all fixes

### DIFF
--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -238,9 +238,8 @@ export const SelectionInfo = withCurrentCohortSearchContext()(
 
     componentDidUpdate(prevProps: Readonly<SelectionInfoProps>) {
       if (
-        this.props.selection.variantFilter &&
-        this.props.selection.variantFilter.exclusionList !==
-          prevProps.selection.variantFilter.exclusionList
+        this.props.selection.variantFilter?.exclusionList !==
+        prevProps.selection.variantFilter?.exclusionList
       ) {
         this.setState({ loadingVariantBuckets: true });
         this.getVariantFilterBuckets();
@@ -305,13 +304,14 @@ export const SelectionInfo = withCurrentCohortSearchContext()(
               </div>
             ) : (
               <ul style={styles.filterList}>
-                {Object.entries(this.state.variantFilterInfoResponse)
-                  .filter(([, value]) => value !== 0)
-                  .map(([key, value], index) => (
-                    <li key={index}>
-                      <b>{VARIANT_DISPLAY[key]}</b>: {value.toLocaleString()}
-                    </li>
-                  ))}
+                {!!this.state.variantFilterInfoResponse &&
+                  Object.entries(this.state.variantFilterInfoResponse)
+                    .filter(([, value]) => value !== 0)
+                    .map(([key, value], index) => (
+                      <li key={index}>
+                        <b>{VARIANT_DISPLAY[key]}</b>: {value.toLocaleString()}
+                      </li>
+                    ))}
               </ul>
             )}
           </li>

--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -190,6 +190,7 @@ function mapCriteria(crit: Selection) {
     name: crit.name,
     parameterId: crit.parameterId,
     type: crit.type,
+    variantFilter: crit.variantFilter,
   };
 }
 
@@ -283,8 +284,8 @@ export const SelectionInfo = withCurrentCohortSearchContext()(
                   key === 'sortBy'
                 )
             )
-            .map(([key, value]) => (
-              <li>
+            .map(([key, value], index) => (
+              <li key={index}>
                 <b>{VARIANT_DISPLAY[key]}</b>:{' '}
                 {Array.isArray(value) ? (
                   <>
@@ -306,8 +307,8 @@ export const SelectionInfo = withCurrentCohortSearchContext()(
               <ul style={styles.filterList}>
                 {Object.entries(this.state.variantFilterInfoResponse)
                   .filter(([, value]) => value !== 0)
-                  .map(([key, value]) => (
-                    <li>
+                  .map(([key, value], index) => (
+                    <li key={index}>
                       <b>{VARIANT_DISPLAY[key]}</b>: {value.toLocaleString()}
                     </li>
                   ))}

--- a/ui/src/app/pages/data/cohort/variant-search-filters.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search-filters.tsx
@@ -134,9 +134,8 @@ export const VariantSearchFilters = ({
           {expanded.includes('geneList') && (
             <div>
               {filters.geneList?.map((checkboxName, index) => (
-                <div style={{ display: 'flex' }}>
+                <div key={index} style={{ display: 'flex' }}>
                   <input
-                    key={index}
                     style={{ marginRight: '0.25rem' }}
                     type='checkbox'
                     name={checkboxName}
@@ -201,9 +200,8 @@ export const VariantSearchFilters = ({
           {expanded.includes('clinicalSignificanceList') && (
             <div>
               {filters.clinicalSignificanceList?.map((checkboxName, index) => (
-                <div style={{ display: 'flex' }}>
+                <div key={index} style={{ display: 'flex' }}>
                   <input
-                    key={index}
                     style={{ marginRight: '0.25rem' }}
                     type='checkbox'
                     name={checkboxName}

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -154,6 +154,16 @@ const searchTooltip = (
     </ul>
   </div>
 );
+const resultsTooltip = (
+  <div style={{ marginLeft: '0.5rem' }}>
+    Number of results must be between 100 and 10,000 to Select All Results
+  </div>
+);
+const duplicateFilterTooltip = (
+  <div style={{ marginLeft: '0.5rem' }}>
+    A Select All Group with these filter selections has already been selected
+  </div>
+);
 
 export const VariantSearch = fp.flow(
   withCurrentWorkspace(),
@@ -586,25 +596,35 @@ export const VariantSearch = fp.flow(
                   </Clickable>
                 </>
               ) : (
-                <Clickable
-                  style={
-                    disableSelectAll
-                      ? { ...styles.selectAll, ...styles.disabled }
-                      : styles.selectAll
+                <TooltipTrigger
+                  side='top'
+                  content={
+                    totalCount < 100 || totalCount > 10000
+                      ? resultsTooltip
+                      : duplicateFilterTooltip
                   }
-                  onClick={() => handleSelectAllResults()}
-                  disabled={disableSelectAll}
+                  disabled={!disableSelectAll}
                 >
-                  <ClrIcon
-                    shape='plus-circle'
-                    class='is-solid'
-                    size={18}
-                    style={{
-                      marginRight: '0.25rem',
-                    }}
-                  />
-                  Select All Results
-                </Clickable>
+                  <Clickable
+                    style={
+                      disableSelectAll
+                        ? { ...styles.selectAll, ...styles.disabled }
+                        : styles.selectAll
+                    }
+                    onClick={() => handleSelectAllResults()}
+                    disabled={disableSelectAll}
+                  >
+                    <ClrIcon
+                      shape='plus-circle'
+                      class='is-solid'
+                      size={18}
+                      style={{
+                        marginRight: '0.25rem',
+                      }}
+                    />
+                    Select All Results
+                  </Clickable>
+                </TooltipTrigger>
               ))}
           </div>
         )}


### PR DESCRIPTION
- Fix issue where save criteria button stays disabled when editing filter for an existing search item
- Fix issue where deleting an single variant when a select all group also exists breaks the UI
- Fix React console errors due to missing `key` props
- Add tooltips when Select All Results button is disabled
<img width="1096" alt="Screenshot 2024-04-19 at 1 22 16 PM" src="https://github.com/all-of-us/workbench/assets/40036095/cc5b5170-eb59-4bdb-b8a2-8d64acd7c5ff">
<img width="1710" alt="Screenshot 2024-04-19 at 1 23 44 PM" src="https://github.com/all-of-us/workbench/assets/40036095/400f97a1-2966-4c13-9476-3c8114f1ed20">
