### PR TITLE
[risk=low][RW-12400] 3 Enzyme conversions and a small UI change

### DIFF
--- a/ui/src/app/components/runtime-status-indicator.spec.tsx
+++ b/ui/src/app/components/runtime-status-indicator.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
 
 import { RuntimeStatus } from 'generated/fetch';
 
+import { render, screen } from '@testing-library/react';
 import {
   registerCompoundRuntimeOperation,
   runtimeStore,
@@ -19,7 +19,7 @@ import {
 } from './environment-status-icon';
 import { RuntimeStatusIndicator } from './runtime-status-indicator';
 
-describe('Runtime Status Indicator', () => {
+describe(RuntimeStatusIndicator.name, () => {
   test.each([
     [RuntimeStatus.CREATING, UpdatingIcon],
     [RuntimeStatus.STOPPED, StoppedIcon],
@@ -36,10 +36,9 @@ describe('Runtime Status Indicator', () => {
         runtime: runtimeStub.runtime,
         runtimeLoaded: true,
       });
-      const wrapper = mount(<RuntimeStatusIndicator />);
-      expect(wrapper.exists()).toBeTruthy();
-      const statusIcon = wrapper.find(icon);
-      expect(statusIcon.exists()).toBeTruthy();
+      render(<RuntimeStatusIndicator />);
+      const statusIcon = screen.getByTestId(`runtime-status-icon-${status}`);
+      expect(statusIcon).toBeInTheDocument();
     }
   );
 
@@ -51,13 +50,10 @@ describe('Runtime Status Indicator', () => {
       runtime: runtimeStub.runtime,
       runtimeLoaded: true,
     });
-    const wrapper = mount(<RuntimeStatusIndicator />);
-    expect(wrapper.exists()).toBeTruthy();
-    const iconContainer = wrapper.find(
-      'div[data-test-id="runtime-status-icon-container"]'
-    );
-    expect(iconContainer.exists()).toBeTruthy();
-    expect(iconContainer.children().length).toEqual(0);
+    render(<RuntimeStatusIndicator />);
+    const iconContainer = screen.getByTestId('runtime-status-icon-container');
+    expect(iconContainer).toBeInTheDocument();
+    expect(iconContainer.children.length).toEqual(0);
   });
 
   it('Verify that a runtime that is part of a compound runtimeop is shown as updating', () => {
@@ -75,11 +71,10 @@ describe('Runtime Status Indicator', () => {
       aborter,
     });
 
-    const wrapper = mount(
+    render(
       <RuntimeStatusIndicator workspaceNamespace={currentWorkspaceNamespace} />
     );
-    expect(wrapper.exists()).toBeTruthy();
-    const statusIcon = wrapper.find(UpdatingIcon);
-    expect(statusIcon.exists()).toBeTruthy();
+    const statusIcon = screen.getByTestId('runtime-status-icon-updating');
+    expect(statusIcon).toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/runtime-status-indicator.spec.tsx
+++ b/ui/src/app/components/runtime-status-indicator.spec.tsx
@@ -1,8 +1,10 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 
 import { RuntimeStatus } from 'generated/fetch';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import {
   registerCompoundRuntimeOperation,
   runtimeStore,
@@ -10,25 +12,18 @@ import {
 
 import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
 
-import {
-  ErrorIcon,
-  RunningIcon,
-  StoppedIcon,
-  StoppingIcon,
-  UpdatingIcon,
-} from './environment-status-icon';
 import { RuntimeStatusIndicator } from './runtime-status-indicator';
 
 describe(RuntimeStatusIndicator.name, () => {
   test.each([
-    [RuntimeStatus.CREATING, UpdatingIcon],
-    [RuntimeStatus.STOPPED, StoppedIcon],
-    [RuntimeStatus.RUNNING, RunningIcon],
-    [RuntimeStatus.STOPPING, StoppingIcon],
-    [RuntimeStatus.ERROR, ErrorIcon],
+    [RuntimeStatus.CREATING, 'is updating'],
+    [RuntimeStatus.STOPPED, 'has stopped'],
+    [RuntimeStatus.RUNNING, 'is running'],
+    [RuntimeStatus.STOPPING, 'is stopping'],
+    [RuntimeStatus.ERROR, 'has encountered an error'],
   ])(
     'Runtime Status indicator renders correct indicator when runtime is in %s state',
-    (status, icon) => {
+    (status, iconMeaning) => {
       const runtimeStub = new RuntimeApiStub();
       runtimeStub.runtime.status = status;
       runtimeStore.set({
@@ -36,8 +31,12 @@ describe(RuntimeStatusIndicator.name, () => {
         runtime: runtimeStub.runtime,
         runtimeLoaded: true,
       });
-      render(<RuntimeStatusIndicator />);
-      const statusIcon = screen.getByTestId(`runtime-status-icon-${status}`);
+      const { getByTestId } = render(<RuntimeStatusIndicator />);
+
+      const iconContainer = getByTestId('runtime-status-icon-container');
+      const statusIcon = within(iconContainer).getByTitle(
+        `Icon indicating environment ${iconMeaning}`
+      );
       expect(statusIcon).toBeInTheDocument();
     }
   );
@@ -71,10 +70,14 @@ describe(RuntimeStatusIndicator.name, () => {
       aborter,
     });
 
-    render(
+    const { getByTestId } = render(
       <RuntimeStatusIndicator workspaceNamespace={currentWorkspaceNamespace} />
     );
-    const statusIcon = screen.getByTestId('runtime-status-icon-updating');
+
+    const iconContainer = getByTestId('runtime-status-icon-container');
+    const statusIcon = within(iconContainer).getByTitle(
+      'Icon indicating environment is updating'
+    );
     expect(statusIcon).toBeInTheDocument();
   });
 });

--- a/ui/src/app/components/search-input.spec.tsx
+++ b/ui/src/app/components/search-input.spec.tsx
@@ -43,13 +43,14 @@ describe(SearchInput.name, () => {
         accept(['bar']);
       });
     }
-    const { getByTestId } = render(<SearchInput onSearch={onSearch} />);
+    const { getByTestId, queryByTestId } = render(
+      <SearchInput onSearch={onSearch} />
+    );
     fireEvent.change(getSearchInput(), { target: { value: 'foo' } });
-    await waitFor(() => {
-      fireEvent.mouseDown(getByTestId('search-input-drop-down-element-0'));
-      fireEvent.blur(getSearchInput());
-      expect(getByTestId('search-input-drop-down')).not.toBeInTheDocument();
-    });
+    await waitFor(() => getByTestId('search-input-drop-down-element-0'));
+    fireEvent.mouseDown(getByTestId('search-input-drop-down-element-0'));
+    fireEvent.blur(getSearchInput());
+    expect(queryByTestId('search-input-drop-down')).not.toBeInTheDocument();
   });
 
   test('onChange handler is called when the contents changes', async () => {

--- a/ui/src/app/components/search-input.spec.tsx
+++ b/ui/src/app/components/search-input.spec.tsx
@@ -1,61 +1,69 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { SearchInput } from './search-input';
 
-test('component should render', () => {
-  const { getByTestId } = render(<SearchInput />);
-  expect(getByTestId('search-input')).toBeInTheDocument();
-});
+describe(SearchInput.name, () => {
+  const getSearchInput = () => screen.getByRole('textbox', { name: 'Search' });
 
-test('no dropdown is displayed on user input by default', async () => {
-  const { getByTestId } = render(<SearchInput />);
-  fireEvent.change(getByTestId('search-input'), { target: { value: 'foo' } });
-  await waitFor(() => {
-    expect(getByTestId('search-input-drop-down')).not.toBeInTheDocument();
+  test('component should render', () => {
+    render(<SearchInput />);
+    expect(getSearchInput()).toBeInTheDocument();
   });
-});
 
-test('dropdown is displayed when results are available', async () => {
-  function onSearch() {
-    return new Promise<Array<string>>((accept) => {
-      accept(['bar']);
+  test('no dropdown is displayed on user input by default', async () => {
+    render(<SearchInput />);
+    fireEvent.change(getSearchInput(), { target: { value: 'foo' } });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('search-input-drop-down')
+      ).not.toBeInTheDocument();
     });
-  }
-  const { getByTestId } = render(<SearchInput onSearch={onSearch} />);
-  fireEvent.change(getByTestId('search-input'), { target: { value: 'foo' } });
-  await waitFor(() => {
-    expect(getByTestId('search-input-drop-down')).toBeInTheDocument();
   });
-});
 
-test('selecting a result from the dropdown closes the dropdown', async () => {
-  function onSearch() {
-    return new Promise<Array<string>>((accept) => {
-      accept(['bar']);
+  test('dropdown is displayed when results are available', async () => {
+    function onSearch() {
+      return new Promise<Array<string>>((accept) => {
+        accept(['bar']);
+      });
+    }
+    const { getByTestId } = render(<SearchInput onSearch={onSearch} />);
+    fireEvent.change(getSearchInput(), { target: { value: 'foo' } });
+    await waitFor(() => {
+      expect(getByTestId('search-input-drop-down')).toBeInTheDocument();
     });
-  }
-  const { getByTestId } = render(<SearchInput onSearch={onSearch} />);
-  fireEvent.change(getByTestId('search-input'), { target: { value: 'foo' } });
-  await waitFor(() => {
-    fireEvent.mouseDown(getByTestId('search-input-drop-down-element-0'));
-    fireEvent.blur(getByTestId('search-input'));
-    expect(getByTestId('search-input-drop-down')).not.toBeInTheDocument();
   });
-});
 
-test('onChange handler is called when the contents changes', async () => {
-  let changed = false;
-  const { getByTestId } = render(
-    <SearchInput
-      onChange={() => {
-        changed = true;
-      }}
-    />
-  );
-  fireEvent.change(getByTestId('search-input'), { target: { value: 'foo' } });
-  await waitFor(() => {
-    expect(changed).toBeTruthy();
+  test('selecting a result from the dropdown closes the dropdown', async () => {
+    function onSearch() {
+      return new Promise<Array<string>>((accept) => {
+        accept(['bar']);
+      });
+    }
+    const { getByTestId } = render(<SearchInput onSearch={onSearch} />);
+    fireEvent.change(getSearchInput(), { target: { value: 'foo' } });
+    await waitFor(() => {
+      fireEvent.mouseDown(getByTestId('search-input-drop-down-element-0'));
+      fireEvent.blur(getSearchInput());
+      expect(getByTestId('search-input-drop-down')).not.toBeInTheDocument();
+    });
+  });
+
+  test('onChange handler is called when the contents changes', async () => {
+    let externalValue = false;
+    render(
+      <SearchInput
+        onChange={() => {
+          externalValue = true;
+        }}
+      />
+    );
+    fireEvent.change(getSearchInput(), { target: { value: 'foo' } });
+    await waitFor(() => {
+      expect(externalValue).toEqual(true);
+    });
   });
 });

--- a/ui/src/app/components/search-input.tsx
+++ b/ui/src/app/components/search-input.tsx
@@ -218,6 +218,7 @@ export class SearchInput extends React.Component<
         <TooltipTrigger
           content={this.props.tooltip}
           disabled={this.props.enabled}
+          data-test-id='search-input'
         >
           <TextInput
             aria-label='Search'

--- a/ui/src/app/components/search-input.tsx
+++ b/ui/src/app/components/search-input.tsx
@@ -218,9 +218,9 @@ export class SearchInput extends React.Component<
         <TooltipTrigger
           content={this.props.tooltip}
           disabled={this.props.enabled}
-          data-test-id='search-input'
         >
           <TextInput
+            aria-label='Search'
             value={this.props.value}
             style={inputStyle}
             onFocus={this._onFocus.bind(this)}

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
 
+import { fireEvent, render } from '@testing-library/react';
 import * as Authentication from 'app/utils/authentication';
 import * as ProfilePicture from 'app/utils/profile-utils';
 import { notificationStore } from 'app/utils/stores';
 
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
-import { SideNav, SideNavItem, SideNavProps } from './side-nav';
+import { SideNav, SideNavProps } from './side-nav';
 
 describe('SideNav', () => {
   const props: SideNavProps = {
@@ -18,11 +18,9 @@ describe('SideNav', () => {
   const spy = jest.spyOn(ProfilePicture, 'getProfilePictureSrc');
   spy.mockReturnValue('lol.png');
 
-  const component = () => mount(<SideNav {...props} />);
-
   it('should render', () => {
-    const wrapper = component();
-    expect(wrapper.exists()).toBeTruthy();
+    const { getByTestId } = render(<SideNav {...props} />);
+    expect(getByTestId('side-nav')).toBeInTheDocument();
   });
 
   it('should show an error when signout fails', () => {
@@ -30,7 +28,7 @@ describe('SideNav', () => {
     signOutSpy.mockImplementation(() => {
       throw new Error();
     });
-    const wrapper = mount(
+    const { getByTestId } = render(
       <SideNav
         {...props}
         profile={{
@@ -40,18 +38,14 @@ describe('SideNav', () => {
         }}
       />
     );
-    wrapper
-      .find('[data-test-id="TestGivenNameTestFamilyName-menu-item"]')
-      .first()
-      .simulate('click');
-
+    fireEvent.click(getByTestId('TestGivenNameTestFamilyName-menu-item'));
     expect(notificationStore.get()).toBeNull();
-    wrapper.find('[data-test-id="SignOut-menu-item"]').simulate('click');
+    fireEvent.click(getByTestId('SignOut-menu-item'));
     expect(notificationStore.get()).toBeTruthy();
   });
 
   it('disables options when user not registered', () => {
-    const wrapper = mount(
+    const { getByTestId } = render(
       <SideNav
         {...props}
         profile={{
@@ -62,36 +56,16 @@ describe('SideNav', () => {
         }}
       />
     );
-    wrapper
-      .find('[data-test-id="TesterMacTesterson-menu-item"]')
-      .first()
-      .simulate('click');
+    fireEvent.click(getByTestId('TesterMacTesterson-menu-item'));
     // These are our expected items to be disabled when you are not registered
-    let disabledItemText = [
+    const disabledItemText = [
       'Your Workspaces',
       'Featured Workspaces',
       'User Support Hub',
     ];
-    const sideNavItems = wrapper.find(SideNavItem);
-    let disabledItems = sideNavItems.filterWhere(
-      (sideNavItem) => sideNavItem.props().disabled
-    );
-    sideNavItems.forEach((sideNavItem) => {
-      const disabled = sideNavItem.props().disabled;
-      const sideNavItemText = sideNavItem.text();
-      if (disabledItemText.includes(sideNavItemText)) {
-        disabledItems = disabledItems.filterWhere(
-          (disabledItem) => disabledItem.text() !== sideNavItem.text()
-        );
-        disabledItemText = disabledItemText.filter(
-          (textItem) => textItem !== sideNavItemText
-        );
-        expect(disabled).toBeTruthy();
-      }
+    disabledItemText.forEach((item) => {
+      //      expect(getByTestId(`${item}-menu-item`).disabled).toBeTruthy();
+      expect(getByTestId(`${item}-menu-item`)).toBeTruthy();
     });
-    // Ensure all expected items to be found.
-    expect(disabledItemText.length).toBe(0);
-    // Ensure there are no other disabled items that we do not expect.
-    expect(disabledItems.length).toBe(0);
   });
 });

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 
 import * as React from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import * as Authentication from 'app/utils/authentication';
 import * as ProfilePicture from 'app/utils/profile-utils';
 import { notificationStore } from 'app/utils/stores';

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -7,10 +7,7 @@ import * as Authentication from 'app/utils/authentication';
 import * as ProfilePicture from 'app/utils/profile-utils';
 import { notificationStore } from 'app/utils/stores';
 
-import {
-  expectButtonElementDisabled,
-  expectMenuItemElementDisabled,
-} from 'testing/react-test-helpers';
+import { expectButtonElementDisabled } from 'testing/react-test-helpers';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
 import { SideNav, SideNavProps } from './side-nav';
@@ -77,7 +74,6 @@ describe(SideNav.name, () => {
       'Featured Workspaces',
       'User Support Hub',
     ];
-    screen.debug();
     disabledItemText.forEach((name) =>
       expectButtonElementDisabled(getByRole('button', { name }))
     );

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -2,11 +2,15 @@ import '@testing-library/jest-dom';
 
 import * as React from 'react';
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import * as Authentication from 'app/utils/authentication';
 import * as ProfilePicture from 'app/utils/profile-utils';
 import { notificationStore } from 'app/utils/stores';
 
+import {
+  expectButtonElementDisabled,
+  expectMenuItemElementDisabled,
+} from 'testing/react-test-helpers';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
 import { SideNav, SideNavProps } from './side-nav';
@@ -30,44 +34,52 @@ describe(SideNav.name, () => {
     signOutSpy.mockImplementation(() => {
       throw new Error();
     });
-    const { getByTestId } = render(
+
+    const givenName = 'TestGivenName';
+    const familyName = 'TestFamilyName';
+    const { getByText } = render(
       <SideNav
         {...props}
         profile={{
           ...ProfileStubVariables.PROFILE_STUB,
-          givenName: 'TestGivenName',
-          familyName: 'TestFamilyName',
+          givenName,
+          familyName,
         }}
       />
     );
-    fireEvent.click(getByTestId('TestGivenNameTestFamilyName-menu-item'));
+
+    fireEvent.click(getByText(`${givenName} ${familyName}`));
     expect(notificationStore.get()).toBeNull();
-    fireEvent.click(getByTestId('SignOut-menu-item'));
+
+    fireEvent.click(getByText('Sign Out'));
     expect(notificationStore.get()).toBeTruthy();
   });
 
   it('disables options when user not registered', () => {
-    const { getByTestId } = render(
+    const givenName = 'TestGivenName';
+    const familyName = 'TestFamilyName';
+    const { getByText, getByRole } = render(
       <SideNav
         {...props}
         profile={{
           ...ProfileStubVariables.PROFILE_STUB,
           accessTierShortNames: [],
-          givenName: 'Tester',
-          familyName: 'MacTesterson',
+          givenName,
+          familyName,
         }}
       />
     );
-    fireEvent.click(getByTestId('TesterMacTesterson-menu-item'));
+    fireEvent.click(getByText(`${givenName} ${familyName}`));
+
     // These are our expected items to be disabled when you are not registered
     const disabledItemText = [
       'Your Workspaces',
       'Featured Workspaces',
       'User Support Hub',
     ];
-    disabledItemText.forEach((item) => {
-      //      expect(getByTestId(`${item}-menu-item`).disabled).toBeTruthy();
-      expect(getByTestId(`${item}-menu-item`)).toBeTruthy();
-    });
+    screen.debug();
+    disabledItemText.forEach((name) =>
+      expectButtonElementDisabled(getByRole('button', { name }))
+    );
   });
 });

--- a/ui/src/app/components/side-nav.spec.tsx
+++ b/ui/src/app/components/side-nav.spec.tsx
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 import * as React from 'react';
 
 import { fireEvent, render } from '@testing-library/react';
@@ -9,7 +11,7 @@ import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 
 import { SideNav, SideNavProps } from './side-nav';
 
-describe('SideNav', () => {
+describe(SideNav.name, () => {
   const props: SideNavProps = {
     profile: ProfileStubVariables.PROFILE_STUB,
     onToggleSideNav: () => {},
@@ -19,8 +21,8 @@ describe('SideNav', () => {
   spy.mockReturnValue('lol.png');
 
   it('should render', () => {
-    const { getByTestId } = render(<SideNav {...props} />);
-    expect(getByTestId('side-nav')).toBeInTheDocument();
+    const { getByLabelText } = render(<SideNav {...props} />);
+    expect(getByLabelText('Side Navigation Bar')).toBeInTheDocument();
   });
 
   it('should show an error when signout fails', () => {

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -285,7 +285,7 @@ export const SideNav = (props: SideNavProps) => {
   ];
 
   return (
-    <div style={styles.sideNav}>
+    <div style={styles.sideNav} aria-label='Side Navigation Bar'>
       <SideNavItem
         hasProfileImage={true}
         content={`${profile.givenName} ${profile.familyName}`}

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -59,7 +59,7 @@ const styles = reactStyles({
   },
   sideNavItemDisabled: {
     color: colors.disabled,
-    cursor: 'auto',
+    cursor: 'not-allowed',
   },
   navIcon: {
     marginRight: '12px',
@@ -217,7 +217,7 @@ export const SideNavItem = (props: SideNavItemProps) => {
           {props.icon && (
             <ClrIcon
               shape={props.icon}
-              className={'is-solid'}
+              className='is-solid'
               style={styles.navIcon}
               size={iconSize}
             />
@@ -297,6 +297,7 @@ export const SideNav = (props: SideNavProps) => {
         userOptionsSubMenu.map((menu) => {
           return (
             <SideNavItem
+              key={menu.label}
               content={menu.label}
               onToggleSideNav={() => onToggleSideNav()}
               href={menu.href}
@@ -306,7 +307,7 @@ export const SideNav = (props: SideNavProps) => {
         })}
       {showUserOptions && (
         <SideNavItem
-          content={'Sign Out'}
+          content='Sign Out'
           onToggleSideNav={() => onToggleSideNav()}
           parentOnClick={withErrorModal(
             {
@@ -328,7 +329,7 @@ export const SideNav = (props: SideNavProps) => {
         icon='applications'
         content='Your Workspaces'
         onToggleSideNav={() => onToggleSideNav()}
-        href={'/workspaces'}
+        href='/workspaces'
         active={workspacesActive()}
         disabled={!hasRegisteredTierAccess(profile)}
       />
@@ -336,20 +337,20 @@ export const SideNav = (props: SideNavProps) => {
         icon='star'
         content='Featured Workspaces'
         onToggleSideNav={() => onToggleSideNav()}
-        href={'/library'}
+        href='/library'
         active={libraryActive()}
         disabled={!hasRegisteredTierAccess(profile)}
       />
       <SideNavItem
         icon='help'
-        content={'User Support Hub'}
+        content='User Support Hub'
         onToggleSideNav={() => onToggleSideNav()}
         parentOnClick={() => window.open(supportUrls.helpCenter, '_blank')}
         disabled={!hasRegisteredTierAccess(profile)}
       />
       <SideNavItem
         icon='envelope'
-        content={'Contact Us'}
+        content='Contact Us'
         onToggleSideNav={() => onToggleSideNav()}
         parentOnClick={() => openContactWidget()}
       />
@@ -368,54 +369,54 @@ export const SideNav = (props: SideNavProps) => {
       {hasAuthorityForAction(profile, AuthorityGuardedAction.USER_ADMIN) &&
         showAdminOptions && (
           <SideNavItem
-            content={'User Admin'}
+            content='User Admin'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/user'}
+            href='/admin/user'
             active={userAdminActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.USER_ADMIN) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Bulk Sync of User Access'}
+            content='Bulk Sync of User Access'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/bulk-sync-user-access'}
+            href='/admin/bulk-sync-user-access'
             active={userAccessActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.USER_AUDIT) &&
         showAdminOptions && (
           <SideNavItem
-            content={'User Audit'}
+            content='User Audit'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/user-audit/'}
+            href='/admin/user-audit/'
             active={userAuditActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.SERVICE_BANNER) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Service Banners'}
+            content='Service Banners'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/banner'}
+            href='/admin/banner'
             active={bannerAdminActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.WORKSPACE_ADMIN) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Workspaces'}
+            content='Workspaces'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'admin/workspaces'}
+            href='admin/workspaces'
             active={workspaceAdminActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.WORKSPACE_AUDIT) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Workspace Audit'}
+            content='Workspace Audit'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/workspace-audit/'}
+            href='/admin/workspace-audit/'
             active={workspaceAuditActive()}
           />
         )}
@@ -425,18 +426,18 @@ export const SideNav = (props: SideNavProps) => {
       ) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Institution Admin'}
+            content='Institution Admin'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'admin/institution'}
+            href='admin/institution'
             active={institutionAdminActive()}
           />
         )}
       {hasAuthorityForAction(profile, AuthorityGuardedAction.EGRESS_EVENTS) &&
         showAdminOptions && (
           <SideNavItem
-            content={'Egress Events'}
+            content='Egress Events'
             onToggleSideNav={() => onToggleSideNav()}
-            href={'/admin/egress-events'}
+            href='/admin/egress-events'
             active={egressAdminActive()}
           />
         )}


### PR DESCRIPTION
The disabled items on the left-hand Side Navigation Bar did not have our usual "not allowed" cursor styling.

Before
![normal_cursor](https://github.com/all-of-us/workbench/assets/2701406/6d18ef3e-6109-42e4-a70d-1991a5a92aee)


After
![not_allowed](https://github.com/all-of-us/workbench/assets/2701406/d137881e-2092-4df3-8be8-0cdc05c282ea)



---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
