### PR TITLE
[RW-12418][risk=no] Fixed duplicate aria label issue

### DIFF
--- a/ui/src/app/components/inputs.spec.tsx
+++ b/ui/src/app/components/inputs.spec.tsx
@@ -127,6 +127,7 @@ describe('inputs', () => {
     const { getByTestId, getByRole } = render(
       <TextAreaWithLengthValidationMessage
         id='test'
+        ariaLabel='testLabel'
         initialText='Hey'
         maxCharacters={15}
         onChange={() => {}}
@@ -135,7 +136,7 @@ describe('inputs', () => {
       />
     );
 
-    fireEvent.blur(getByRole('textbox', { name: 'test' }));
+    fireEvent.blur(getByRole('textbox', { name: 'testLabel' }));
     expect(getByTestId('warning').textContent).toBe('Testing too short');
   });
 
@@ -143,6 +144,7 @@ describe('inputs', () => {
     const { getByRole, queryByTestId } = render(
       <TextAreaWithLengthValidationMessage
         id='test'
+        ariaLabel='testLabel'
         initialText={initialText}
         maxCharacters={15}
         onChange={() => {}}
@@ -151,7 +153,7 @@ describe('inputs', () => {
       />
     );
 
-    fireEvent.blur(getByRole('textbox', { name: 'test' }));
+    fireEvent.blur(getByRole('textbox', { name: 'testLabel' }));
     expect(queryByTestId('warning')).toBeNull();
   });
 
@@ -159,13 +161,14 @@ describe('inputs', () => {
     const { getByRole, queryByTestId } = render(
       <TextAreaWithLengthValidationMessage
         id='test'
+        ariaLabel='testLabel'
         initialText={initialText}
         maxCharacters={15}
         onChange={() => {}}
       />
     );
 
-    fireEvent.blur(getByRole('textbox', { name: 'test' }));
+    fireEvent.blur(getByRole('textbox', { name: 'testLabel' }));
     expect(queryByTestId('warning')).toBeNull();
   });
 });

--- a/ui/src/app/components/inputs.tsx
+++ b/ui/src/app/components/inputs.tsx
@@ -240,8 +240,7 @@ export const TextAreaWithLengthValidationMessage = (
   return (
     <React.Fragment>
       <TextArea
-        {...{ id }}
-        aria-label={id}
+        {...{ ariaLabel, id }}
         style={{
           ...styles.textBoxWithLengthValidationTextBoxStyle,
           ...textBoxStyleOverrides,
@@ -250,7 +249,6 @@ export const TextAreaWithLengthValidationMessage = (
         value={text}
         onBlur={() => updateShowTooShortWarning()}
         onChange={(v) => onTextUpdate(v)}
-        ariaLabel={ariaLabel}
       />
       <FlexRow
         style={{


### PR DESCRIPTION
Two recent changes to input aria label logic caused some unexpected consequences in tests.

[I introduced a field (ariaLabel) to TextAreaWithLengthValidationMessage to support arbitrary aria labels.](https://github.com/all-of-us/workbench/pull/8511/files#diff-e20d25e18ad70d1c526af33dd200e80376f4c624abc466a553a1563a9c0eb3d7R165-R253)
[Joel added a change that auto populated aria-label to the id value](https://github.com/all-of-us/workbench/commit/7fbfeac86143b6d29dc26892e8af31c5f3ab5b27#diff-e20d25e18ad70d1c526af33dd200e80376f4c624abc466a553a1563a9c0eb3d7R236)

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
