### PR TITLE
[RW-12513][risk=no] Remove eRA required toggle from insitution admin page

### DIFF
--- a/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.spec.tsx
@@ -30,15 +30,12 @@ const findRTDetails = (wrapper) =>
   wrapper.find('[data-test-id="registered-card-details"]');
 const findRTDropdown = (wrapper) =>
   wrapper.find('[data-test-id="registered-agreement-dropdown"]').first();
-const findRTERARequired = (wrapper) =>
-  wrapper.find('[data-test-id="registered-era-required-switch"]').first();
 
 const findCTDetails = (wrapper) =>
   wrapper.find('[data-test-id="controlled-card-details"]');
 const findCTDropdown = (wrapper) =>
   wrapper.find('[data-test-id="controlled-agreement-dropdown"]').first();
-const findCTERARequired = (wrapper) =>
-  wrapper.find('[data-test-id="controlled-era-required-switch"]').first();
+
 const findCTEnabled = (wrapper) =>
   wrapper.find('input[data-test-id="controlled-enabled-switch"]').first();
 
@@ -159,8 +156,6 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     expect(wrapper).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeFalsy();
 
-    expect(findRTERARequired(wrapper).props().checked).toBeTruthy();
-
     // update RT domains
 
     const testDomains = 'domain1.com,\n' + 'domain2.com,\n' + 'domain3.com';
@@ -180,7 +175,6 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     expect(findCTDomain(wrapper).exists()).toBeTruthy();
     expect(findCTAddress(wrapper).exists()).toBeFalsy();
-    expect(findCTERARequired(wrapper).props().checked).toBeTruthy();
 
     expect(textInputValue(findCTDomainInput(wrapper))).toBe(testDomains);
   });
@@ -190,8 +184,6 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     await waitOneTickAndUpdate(wrapper);
     expect(wrapper).toBeTruthy();
     expect(findCTDetails(wrapper).exists()).toBeFalsy();
-
-    expect(findRTERARequired(wrapper).props().checked).toBeTruthy();
 
     // change Registered from DOMAIN to ADDRESS
 
@@ -228,37 +220,8 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     expect(findCTAddress(wrapper).exists()).toBeTruthy();
     expect(findCTDomain(wrapper).exists()).toBeFalsy();
-    expect(findCTERARequired(wrapper).props().checked).toBeTruthy();
 
     expect(textInputValue(findCTAddressInput(wrapper))).toBe('');
-  });
-
-  it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper).toBeTruthy();
-
-    expect(findRTERARequired(wrapper).props().checked).toBeTruthy();
-    expect(findCTERARequired(wrapper).props().checked).toBeTruthy();
-    expect(findCTEnabled(wrapper).props().checked).toBeTruthy();
-
-    // change Registered from DOMAIN to ADDRESS
-
-    expect(findRTDomain(wrapper).exists()).toBeTruthy();
-    expect(findRTAddress(wrapper).exists()).toBeFalsy();
-
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.ADDRESSES
-    );
-
-    expect(findRTAddress(wrapper).exists()).toBeTruthy();
-    expect(findRTDomain(wrapper).exists()).toBeFalsy();
-
-    expect(findRTERARequired(wrapper).props().checked).toBeTruthy();
-    expect(findCTERARequired(wrapper).props().checked).toBeTruthy();
-    expect(findCTEnabled(wrapper).props().checked).toBeTruthy();
   });
 
   it('should update institution tier requirement', async () => {
@@ -797,32 +760,6 @@ describe('AdminInstitutionEditSpec - add mode', () => {
 
     // RT no change
     expect(textInputValue(findRTAddressInput(wrapper))).toBe('user@domain.com');
-  });
-
-  it('should not change eRA Required and tier enabled switches when changing tier requirement', async () => {
-    const wrapper = component();
-    await waitOneTickAndUpdate(wrapper);
-    expect(wrapper).toBeTruthy();
-
-    // false by default
-    expect(findRTERARequired(wrapper).props().checked).toBeFalsy();
-    expect(findCTERARequired(wrapper).props().checked).toBeFalsy();
-
-    // change Registered to ADDRESS
-
-    expect(findRTAddress(wrapper).exists()).toBeFalsy();
-
-    await simulateComponentChange(
-      wrapper,
-      findRTDropdown(wrapper),
-      InstitutionMembershipRequirement.ADDRESSES
-    );
-
-    expect(findRTAddress(wrapper).exists()).toBeTruthy();
-    expect(findRTDomain(wrapper).exists()).toBeFalsy();
-
-    expect(findRTERARequired(wrapper).props().checked).toBeFalsy();
-    expect(findCTERARequired(wrapper).props().checked).toBeFalsy();
   });
 
   it('Should display error in case of invalid email Address Format in Registered Tier requirement', async () => {

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -117,30 +117,6 @@ const getInvalidEmailDomains = (emailDomains: Array<string>): Array<string> =>
   emailDomains.filter(isDomainInvalid);
 
 const nonEmpty = (item: string): boolean => item && !!item.trim();
-
-const EraRequiredSwitch = (props: {
-  tierConfig: InstitutionTierConfig;
-  onToggle: (boolean) => void;
-}) => {
-  const { tierConfig, onToggle } = props;
-  const {
-    config: { enableRasLoginGovLinking },
-  } = useStore(serverConfigStore);
-  return (
-    <CommonToggle
-      name='eRA account required'
-      dataTestId={`${tierConfig.accessTierShortName}-era-required-switch`}
-      onToggle={(e) => onToggle(e)}
-      checked={tierConfig.eraRequired}
-      disabled={
-        !enableRasLoginGovLinking ||
-        tierConfig.membershipRequirement ===
-          InstitutionMembershipRequirement.NO_ACCESS
-      }
-    />
-  );
-};
-
 const EnableCtSwitch = (props: {
   institution: Institution;
   onToggle: (boolean) => void;
@@ -254,10 +230,6 @@ const TierConfig = (props: TierConfigProps) => {
           {displayNameForTier(accessTierShortName)} access
         </label>
         <FlexRow style={{ gap: '0.45rem' }}>
-          <EraRequiredSwitch
-            tierConfig={tierConfig}
-            onToggle={setEraRequired}
-          />
           {accessTierShortName === AccessTierShortNames.Controlled && (
             <EnableCtSwitch
               institution={institution}

--- a/ui/src/app/pages/admin/admin-institution-edit.tsx
+++ b/ui/src/app/pages/admin/admin-institution-edit.tsx
@@ -55,7 +55,7 @@ import {
   updateTierEmailDomains,
 } from 'app/utils/institutions';
 import { NavigationProps } from 'app/utils/navigation';
-import { MatchParams, serverConfigStore, useStore } from 'app/utils/stores';
+import { MatchParams } from 'app/utils/stores';
 import { canonicalizeUrl } from 'app/utils/urls';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 
@@ -192,7 +192,6 @@ interface TierConfigProps {
   institution: Institution;
   accessTierShortName: string;
   setEnableControlledTier?: (boolean) => void;
-  setEraRequired: (boolean) => void;
   setTierRequirement: (InstitutionMembershipRequirement) => void;
   filterEmptyAddresses: Function;
   setTierAddresses: (string) => void;
@@ -204,7 +203,6 @@ const TierConfig = (props: TierConfigProps) => {
     institution,
     accessTierShortName,
     setEnableControlledTier,
-    setEraRequired,
     setTierRequirement,
     filterEmptyAddresses,
     setTierAddresses,
@@ -916,9 +914,6 @@ export const AdminInstitutionEdit = fp.flow(
                   institution={institution}
                   setEnableControlledTier={(value) =>
                     this.setEnableControlledTier(value)
-                  }
-                  setEraRequired={(value) =>
-                    this.setRequireEra(accessTierShortName, value)
                   }
                   setTierRequirement={(requirement) =>
                     this.setMembershipRequirement(


### PR DESCRIPTION
This is to unblock Broad deprecate shibboleth server, after this, there will no institution require eRA hence no shibboleth call from us
![Screenshot 2024-05-01 at 7 50 53 PM](https://github.com/all-of-us/workbench/assets/6351731/a6ca0331-9dba-4565-b1b0-6e277440a118)


<!--
Reminder: If you decid
![Screenshot 2024-05-01 at 7 50 34 PM](https://github.com/all-of-us/workbench/assets/6351731/af2da467-bd07-4b1e-938e-913f0323a135)
e to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
