### PR TITLE
[risk=low][RW-12516] Split runtimes and apps from workspace admin endpoint

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 import org.pmiops.workbench.workspaceadmin.WorkspaceAdminService;
@@ -41,6 +42,18 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
   public ResponseEntity<WorkspaceAdminView> getWorkspaceAdminView(String workspaceNamespace) {
     return ResponseEntity.ok(workspaceAdminService.getWorkspaceAdminView(workspaceNamespace));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  public ResponseEntity<List<ListRuntimeResponse>> listRuntimes(String workspaceNamespace) {
+    return ResponseEntity.ok(workspaceAdminService.listRuntimes(workspaceNamespace));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  public ResponseEntity<List<UserAppEnvironment>> listUserApps(String workspaceNamespace) {
+    return ResponseEntity.ok(workspaceAdminService.listUserApps(workspaceNamespace));
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -46,13 +46,15 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
-  public ResponseEntity<List<ListRuntimeResponse>> listRuntimes(String workspaceNamespace) {
+  public ResponseEntity<List<ListRuntimeResponse>> adminListRuntimesInWorkspace(
+      String workspaceNamespace) {
     return ResponseEntity.ok(workspaceAdminService.listRuntimes(workspaceNamespace));
   }
 
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
-  public ResponseEntity<List<UserAppEnvironment>> listUserApps(String workspaceNamespace) {
+  public ResponseEntity<List<UserAppEnvironment>> adminListUserAppsInWorkspace(
+      String workspaceNamespace) {
     return ResponseEntity.ok(workspaceAdminService.listUserApps(workspaceNamespace));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAdminView;
 import org.pmiops.workbench.model.WorkspaceAuditLogQueryResponse;
 
@@ -26,6 +27,10 @@ public interface WorkspaceAdminService {
   CloudStorageTraffic getCloudStorageTraffic(String workspaceNamespace);
 
   WorkspaceAdminView getWorkspaceAdminView(String workspaceNamespace);
+
+  List<ListRuntimeResponse> listRuntimes(String workspaceNamespace);
+
+  List<UserAppEnvironment> listUserApps(String workspaceNamespace);
 
   WorkspaceAuditLogQueryResponse getWorkspaceAuditLogEntries(
       String workspaceNamespace,

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -222,9 +222,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     final AdminWorkspaceResources adminWorkspaceResources =
         new AdminWorkspaceResources()
             .workspaceObjects(getAdminWorkspaceObjects(dbWorkspace.getWorkspaceId()))
-            .cloudStorage(adminWorkspaceCloudStorageCounts)
-            .runtimes(List.of())
-            .userApps(List.of());
+            .cloudStorage(adminWorkspaceCloudStorageCounts);
 
     final RawlsWorkspaceDetails firecloudWorkspace =
         fireCloudService

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -50,6 +50,7 @@ import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.TimeSeriesPoint;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceAdminView;
@@ -218,20 +219,12 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         getAdminWorkspaceCloudStorageCounts(
             dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
 
-    final List<ListRuntimeResponse> workbenchListRuntimeResponses =
-        leonardoNotebooksClient
-            .listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
-            .stream()
-            .map(leonardoMapper::toApiListRuntimeResponse)
-            .toList();
-
     final AdminWorkspaceResources adminWorkspaceResources =
         new AdminWorkspaceResources()
             .workspaceObjects(getAdminWorkspaceObjects(dbWorkspace.getWorkspaceId()))
             .cloudStorage(adminWorkspaceCloudStorageCounts)
-            .runtimes(workbenchListRuntimeResponses)
-            .userApps(
-                leonardoNotebooksClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject()));
+            .runtimes(List.of())
+            .userApps(List.of());
 
     final RawlsWorkspaceDetails firecloudWorkspace =
         fireCloudService
@@ -251,6 +244,22 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         .workspace(workspaceMapper.toApiWorkspace(dbWorkspace, new RawlsWorkspaceDetails()))
         .workspaceDatabaseId(dbWorkspace.getWorkspaceId())
         .activeStatus(dbWorkspace.getWorkspaceActiveStatusEnum());
+  }
+
+  @Override
+  public List<ListRuntimeResponse> listRuntimes(String workspaceNamespace) {
+    final DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
+    return leonardoNotebooksClient
+        .listRuntimesByProjectAsService(dbWorkspace.getGoogleProject())
+        .stream()
+        .map(leonardoMapper::toApiListRuntimeResponse)
+        .toList();
+  }
+
+  @Override
+  public List<UserAppEnvironment> listUserApps(String workspaceNamespace) {
+    final DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
+    return leonardoNotebooksClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
   }
 
   @Override

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2196,7 +2196,7 @@ paths:
       tags:
         - workspaceAdmin
       description: Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
-      operationId: listRuntimes
+      operationId: adminListRuntimesInWorkspace
       parameters:
         - name: workspaceNamespace
           in: path
@@ -2218,7 +2218,7 @@ paths:
       tags:
         - workspaceAdmin
       description: Get a list of user apps in this Workspace. RESEARCHER_DATA_VIEW authority required.
-      operationId: listUserApps
+      operationId: adminListUserAppsInWorkspace
       parameters:
         - name: workspaceNamespace
           in: path
@@ -9688,12 +9688,12 @@ components:
         cloudStorage:
           $ref: '#/components/schemas/AdminWorkspaceCloudStorageCounts'
         runtimes:
-          description: DEPRECATED - will be removed after a release.  Replaced by listRuntimes.
+          description: DEPRECATED - will be removed after a release.  Replaced by adminListRuntimesInWorkspace.
           type: array
           items:
             $ref: '#/components/schemas/ListRuntimeResponse'
         userApps:
-          description: DEPRECATED - will be removed after a release.  Replaced by listUserApps.
+          description: DEPRECATED - will be removed after a release.  Replaced by adminListUserAppsInWorkspace.
           type: array
           items:
             $ref: '#/components/schemas/UserAppEnvironment'

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9688,12 +9688,12 @@ components:
         cloudStorage:
           $ref: '#/components/schemas/AdminWorkspaceCloudStorageCounts'
         runtimes:
-          description: DEPRECATED.  Call [TBD] separately for improved performance
+          description: DEPRECATED - will be removed after a release.  Replaced by listRuntimes.
           type: array
           items:
             $ref: '#/components/schemas/ListRuntimeResponse'
         userApps:
-          description: DEPRECATED.  Call [TBD] separately for improved performance
+          description: DEPRECATED - will be removed after a release.  Replaced by listUserApps.
           type: array
           items:
             $ref: '#/components/schemas/UserAppEnvironment'

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2191,6 +2191,50 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FileDetail'
+  /v1/admin/workspaces/{workspaceNamespace}/runtimes:
+    get:
+      tags:
+        - workspaceAdmin
+      description: Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
+      operationId: listRuntimes
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: The Workspace namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of runtimes in this Workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ListRuntimeResponse'
+  /v1/admin/workspaces/{workspaceNamespace}/userApps:
+    get:
+      tags:
+        - workspaceAdmin
+      description: Get a list of user apps in this Workspace. RESEARCHER_DATA_VIEW authority required.
+      operationId: listUserApps
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: The Workspace namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of user apps in this Workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserAppEnvironment'
   /v1/admin/egressEvents:
     post:
       tags:
@@ -9644,10 +9688,12 @@ components:
         cloudStorage:
           $ref: '#/components/schemas/AdminWorkspaceCloudStorageCounts'
         runtimes:
+          description: DEPRECATED.  Call [TBD] separately for improved performance
           type: array
           items:
             $ref: '#/components/schemas/ListRuntimeResponse'
         userApps:
+          description: DEPRECATED.  Call [TBD] separately for improved performance
           type: array
           items:
             $ref: '#/components/schemas/UserAppEnvironment'

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -68,7 +68,6 @@ import org.pmiops.workbench.model.AdminWorkspaceResources;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
-import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.TimeSeriesPoint;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAdminView;
@@ -298,9 +297,6 @@ public class WorkspaceAdminServiceTest {
     assertThat(cloudStorageCounts.getNotebookFileCount()).isEqualTo(0);
     assertThat(cloudStorageCounts.getNonNotebookFileCount()).isEqualTo(0);
     assertThat(cloudStorageCounts.getStorageBytesUsed()).isEqualTo(0L);
-
-    List<ListRuntimeResponse> runtimes = resources.getRuntimes();
-    assertThat(runtimes).isEmpty();
   }
 
   private final long dummyTime = Instant.now().toEpochMilli();

--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -84,12 +84,12 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
     // to the main admin view call
 
     workspaceAdminApi()
-      .listRuntimes(ns)
+      .adminListRuntimesInWorkspace(ns)
       .then((runtimes) => this.setState({ runtimes }))
       .catch(this.handleDataLoadError);
 
     workspaceAdminApi()
-      .listUserApps(ns)
+      .adminListUserAppsInWorkspace(ns)
       .then((userApps) => this.setState({ userApps }))
       .catch(this.handleDataLoadError);
 

--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -34,9 +34,7 @@ interface Props
 interface State {
   workspaceDetails?: WorkspaceAdminView;
   cloudStorageTraffic?: CloudStorageTraffic;
-  loadingAdminView?: boolean;
-  loadingRuntimes?: boolean;
-  loadingUserApps?: boolean;
+  loadingWorkspace?: boolean;
   dataLoadError?: Response;
   runtimes?: ListRuntimeResponse[];
   userApps?: UserAppEnvironment[];
@@ -74,11 +72,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
 
   async populateFederatedWorkspaceInformation() {
     const { ns } = this.props.match.params;
-    this.setState({
-      loadingAdminView: true,
-      loadingRuntimes: true,
-      loadingUserApps: true,
-    });
+    this.setState({ loadingWorkspace: true });
 
     // cloud storage traffic isn't always available (e.g. for a deleted workspace) so we need to allow for that
     workspaceAdminApi()
@@ -92,28 +86,24 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
     workspaceAdminApi()
       .listRuntimes(ns)
       .then((runtimes) => this.setState({ runtimes }))
-      .catch(this.handleDataLoadError)
-      .finally(() => this.setState({ loadingRuntimes: false }));
+      .catch(this.handleDataLoadError);
 
     workspaceAdminApi()
       .listUserApps(ns)
       .then((userApps) => this.setState({ userApps }))
-      .catch(this.handleDataLoadError)
-      .finally(() => this.setState({ loadingUserApps: false }));
+      .catch(this.handleDataLoadError);
 
     workspaceAdminApi()
       .getWorkspaceAdminView(ns)
       .then((workspaceDetails) => this.setState({ workspaceDetails }))
       .catch(this.handleDataLoadError)
-      .finally(() => this.setState({ loadingAdminView: false }));
+      .finally(() => this.setState({ loadingWorkspace: false }));
   }
 
   render() {
     const {
       cloudStorageTraffic,
-      loadingAdminView,
-      loadingRuntimes,
-      loadingUserApps,
+      loadingWorkspace,
       dataLoadError,
       workspaceDetails: { collaborators, resources, workspace, activeStatus },
       runtimes,
@@ -129,9 +119,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
             development team.
           </ErrorDiv>
         )}
-        {(loadingAdminView || loadingRuntimes || loadingUserApps) && (
-          <SpinnerOverlay />
-        )}
+        {loadingWorkspace && <SpinnerOverlay />}
         {workspace && (
           <div>
             {activeStatus === WorkspaceActiveStatus.ACTIVE && (

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -112,11 +112,6 @@ export const CloudEnvironmentsTable = ({
     );
   };
 
-  const cloudEnvironments = [
-    ...(runtimes?.map(runtimeToRow) || []),
-    ...(userApps?.map(userAppToRow) || []),
-  ];
-
   return runtimes && userApps ? (
     <div>
       {confirmDeleteRuntime && (
@@ -140,7 +135,10 @@ export const CloudEnvironmentsTable = ({
         </Modal>
       )}
       <DataTable
-        value={cloudEnvironments}
+        value={[
+          ...(runtimes?.map(runtimeToRow) || []),
+          ...(userApps?.map(userAppToRow) || []),
+        ]}
         emptyMessage='No active cloud environments exist for this workspace.'
       >
         <Column field='appType' header='Environment Type' />

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -3,11 +3,7 @@ import { useState } from 'react';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
 
-import {
-  AdminWorkspaceResources,
-  ListRuntimeResponse,
-  UserAppEnvironment,
-} from 'generated/fetch';
+import { ListRuntimeResponse, UserAppEnvironment } from 'generated/fetch';
 
 import {
   fromRuntimeStatus,
@@ -61,14 +57,16 @@ const userAppToRow = (userApp: UserAppEnvironment): CloudEnvironmentRow => {
 };
 
 interface Props {
-  resources: AdminWorkspaceResources;
   workspaceNamespace: string;
   onDelete: () => void;
+  runtimes?: ListRuntimeResponse[];
+  userApps?: UserAppEnvironment[];
 }
 export const CloudEnvironmentsTable = ({
-  resources: { runtimes, userApps },
   workspaceNamespace,
   onDelete,
+  runtimes = [],
+  userApps = [],
 }: Props) => {
   const [runtimeToDelete, setRuntimeToDelete] = useState<string>();
   const [confirmDeleteRuntime, setConfirmDeleteRuntime] = useState(false);

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -19,6 +19,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { TooltipTrigger } from 'app/components/popups';
+import { Spinner } from 'app/components/spinners';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 import { getCreator } from 'app/utils/runtime-utils';
 
@@ -65,8 +66,8 @@ interface Props {
 export const CloudEnvironmentsTable = ({
   workspaceNamespace,
   onDelete,
-  runtimes = [],
-  userApps = [],
+  runtimes,
+  userApps,
 }: Props) => {
   const [runtimeToDelete, setRuntimeToDelete] = useState<string>();
   const [confirmDeleteRuntime, setConfirmDeleteRuntime] = useState(false);
@@ -112,11 +113,11 @@ export const CloudEnvironmentsTable = ({
   };
 
   const cloudEnvironments = [
-    ...runtimes?.map(runtimeToRow),
-    ...userApps?.map(userAppToRow),
+    ...(runtimes?.map(runtimeToRow) || []),
+    ...(userApps?.map(userAppToRow) || []),
   ];
 
-  return (
+  return runtimes && userApps ? (
     <div>
       {confirmDeleteRuntime && (
         <Modal onRequestClose={cancelDeleteRuntime}>
@@ -153,5 +154,7 @@ export const CloudEnvironmentsTable = ({
         />
       </DataTable>
     </div>
+  ) : (
+    <Spinner />
   );
 };


### PR DESCRIPTION
This does not resolve RW-12516, but it improves Admin Workspace UI performance and should also help with debugging.

Instead of calling List Runtimes and List Apps internally to the Workspace Admin View call, separate those into new endpoints, and call them in parallel.

Tested by running locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
