### PR TITLE
[risk=low][no ticket] npe getting user

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -128,18 +128,17 @@ public class CloudTaskInitialCreditsExpiryController
             .filter(entry -> !newlyExpiredUsers.contains(usersCache.get(entry.getKey())))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+    logger.info("Free tier Billing Service: Handling cost alerts for users: {}", users);
     logger.info(
-            "Free tier Billing Service: Handling cost alerts for users: {}", users);
-    logger.info(
-            "DB costs by creator: {}, live costs by creator: {}",
-            dbCostByCreator,
-            liveCostByCreator);
+        "DB costs by creator: {}, live costs by creator: {}", dbCostByCreator, liveCostByCreator);
 
     filteredLiveCostByCreator.forEach(
         (userId, currentCost) -> {
           final double previousCost = dbCostByCreator.getOrDefault(userId, 0.0);
           maybeAlertOnCostThresholds(
-              usersCache.containsKey(userId)? usersCache.get(userId) : userDao.findUserByUserId(userId),
+              usersCache.containsKey(userId)
+                  ? usersCache.get(userId)
+                  : userDao.findUserByUserId(userId),
               Math.max(currentCost, previousCost),
               previousCost,
               costThresholdsInDescOrder);

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -128,11 +128,18 @@ public class CloudTaskInitialCreditsExpiryController
             .filter(entry -> !newlyExpiredUsers.contains(usersCache.get(entry.getKey())))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+    logger.info(
+            "Free tier Billing Service: Handling cost alerts for users: {}", users);
+    logger.info(
+            "DB costs by creator: {}, live costs by creator: {}",
+            dbCostByCreator,
+            liveCostByCreator);
+
     filteredLiveCostByCreator.forEach(
         (userId, currentCost) -> {
           final double previousCost = dbCostByCreator.getOrDefault(userId, 0.0);
           maybeAlertOnCostThresholds(
-              usersCache.get(userId),
+              usersCache.containsKey(userId)? usersCache.get(userId) : userDao.findUserByUserId(userId),
               Math.max(currentCost, previousCost),
               previousCost,
               costThresholdsInDescOrder);

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -128,7 +128,7 @@ public class CloudTaskInitialCreditsExpiryController
             .filter(entry -> !newlyExpiredUsers.contains(usersCache.get(entry.getKey())))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    logger.info("Free tier Billing Service: Handling cost alerts for users: {}", users);
+    logger.info("Handling cost alerts for users: {}", usersCache.keySet());
     logger.info(
         "DB costs by creator: {}, live costs by creator: {}", dbCostByCreator, liveCostByCreator);
 

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
@@ -660,6 +660,44 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     assertSingleWorkspaceTestDbState(anotherWorkspace, BillingStatus.INACTIVE);
   }
 
+  @Test
+  public void handleInitialCreditsExpiry_withMissingUsersInRequest_NoNPE() throws Exception {
+
+    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 300.0;
+
+    DbUser user1 = createUser("user1@test.com");
+    DbUser user2 = createUser("user2@test.com");
+    DbUser user3 = createUser("user3@test.com");
+
+    createWorkspace(user1, SINGLE_WORKSPACE_TEST_PROJECT);
+    createWorkspace(user2, SINGLE_WORKSPACE_TEST_PROJECT);
+    createWorkspace(user3, SINGLE_WORKSPACE_TEST_PROJECT);
+
+    ExpiredInitialCreditsEventRequest request = new ExpiredInitialCreditsEventRequest();
+    request.setUsers(Arrays.asList(user1.getUserId(), user2.getUserId()));
+
+    Map<String, Double> liveCostByCreator = new HashMap<>();
+    liveCostByCreator.put(String.valueOf(user1.getUserId()), 310.0);
+    liveCostByCreator.put(String.valueOf(user2.getUserId()), 250.0);
+    liveCostByCreator.put(String.valueOf(user3.getUserId()), 151.0);
+    request.setLiveCostByCreator(liveCostByCreator);
+
+    request.setDbCostByCreator(
+        Map.of(
+            String.valueOf(user1.getUserId()), 0d,
+            String.valueOf(user2.getUserId()), 0d,
+            String.valueOf(user3.getUserId()), 0d));
+
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiry(request);
+
+    verify(mailService)
+        .alertUserInitialCreditsDollarThreshold(eq(user3), eq(0.5d), eq(151.0d), eq(149.0d));
+    verify(mailService)
+        .alertUserInitialCreditsDollarThreshold(eq(user2), eq(0.75d), eq(250.0d), eq(50.0d));
+    verify(mailService).alertUserInitialCreditsExpiration(eq(user1));
+    verifyNoMoreInteractions(mailService);
+  }
+
   private void assertSingleWorkspaceTestDbState(
       DbWorkspace workspaceForQuerying, BillingStatus billingStatus) {
 


### PR DESCRIPTION
Ran the cron twice, the tasks are passing now
<img width="1419" alt="image" src="https://github.com/all-of-us/workbench/assets/9085153/e32e00ef-5222-4cac-8584-fd38139ec34f">

Logs show that the task is completed
Free tier Billing Service: Finished handling initial credits expiry event for users: [4599, 4485]

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
