### PR TITLE
[risk=low][no ticket] Visited links in the Analysis tab were low-contrast

### DIFF
--- a/ui/src/app/components/breadcrumb.tsx
+++ b/ui/src/app/components/breadcrumb.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link as RouterLink, matchPath } from 'react-router-dom';
+import { Link, matchPath } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 
 import {
@@ -294,7 +294,7 @@ export const getTrail = (
 };
 
 const BreadcrumbLink = ({ href, ...props }) => {
-  return <RouterLink to={href} {...props} />;
+  return <Link to={href} {...props} />;
 };
 
 interface Props {

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
@@ -9,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FileDetail } from 'generated/fetch';
 
 import { AppBanner } from 'app/components/apps-panel/app-banner';
+import { StyledRouterLink } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { ListPageHeader } from 'app/components/headers';
@@ -171,9 +171,9 @@ export const AppFilesList = withCurrentWorkspace()(
       const { name } = row;
       const url = `${analysisTabPath(namespace, id)}/preview/${name}`;
       return row.sizeInBytes <= notebookSizeThreshold ? (
-        <RouterLink to={url} data-test-id='notebook-navigation'>
+        <StyledRouterLink path={url} data-test-id='notebook-navigation'>
           {row.name}
-        </RouterLink>
+        </StyledRouterLink>
       ) : (
         <div
           onClick={() => {


### PR DESCRIPTION
A Prod Eng Demos participant pointed out that some of the links on our Analysis tab are low-contrast, which is bad for accessibility.  Ideally we should have a [contrast ratio of 4.5 or higher](https://www.siegemedia.com/contrast-ratio).

This PR changes the behavior of "visited" links to behave in the same way as "non-visited" links on the page: they remain dark blue instead of changing to light blue, improving their contrast ratios from 2.7 to 4.7.

Before (the dark links here are un-visited)
<img width="717" alt="light-links" src="https://github.com/all-of-us/workbench/assets/2701406/15096ade-62df-46fc-bd1b-5467e7834cf1">


After
<img width="706" alt="dark-links" src="https://github.com/all-of-us/workbench/assets/2701406/0b9be9da-6a1c-4d93-a08b-9d386e64eefd">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
