### PR TITLE
[DT-811][risk=no] adding has_wear_consent flag

### DIFF
--- a/api/db-cdr/generate-cdr/bq-schemas/cb_search_person.json
+++ b/api/db-cdr/generate-cdr/bq-schemas/cb_search_person.json
@@ -118,5 +118,10 @@
     "mode": "NULLABLE",
     "name": "state_of_residence",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_wear_consent",
+    "type": "INTEGER"
   }
 ]

--- a/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
+++ b/api/db-cdr/generate-cdr/build-cb-criteria-menu.sh
@@ -34,6 +34,11 @@ query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\
 where has_structural_variant_data = 1"
 structuralVariantDataCount=$(bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql "$query" | tr -dc '0-9')
 
+echo "Getting Wear Consent data count"
+query="select count(*) as count from \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\`
+where has_wear_consent = 1"
+wearConsentDataCount=$(bq --quiet --project_id="$BQ_PROJECT" query --nouse_legacy_sql "$query" | tr -dc '0-9')
+
 ###############################
 # CREATE cb_criteria_menu TABLE
 ###############################
@@ -54,7 +59,7 @@ insertCriteriaMenu "
 if [[ $fitbitCount > 0 ]];
 then
   echo "Insert fitbit into cb_criteria_menu"
-  insertCriteriaMenu "($((++ID)),0,'Program Data','FITBIT','FITBIT','Fitbit',1,$ID)"
+  insertCriteriaMenu "($((++ID)),0,'Program Data','WEARABLES','','Wearables',1,$ID)"
 fi
 
 if [[ $wgvCount > 0 || $longReadWGSCount > 0 || $arrayCount > 0 || $structuralVariantDataCount > 0 || "$TABLE_LIST" == *"prep_vat"* ]];
@@ -123,6 +128,12 @@ then
   insertCriteriaMenu "($((++ID)),$PARENT_ID,'Program Data','FITBIT_INTRADAY_STEPS','FITBIT_INTRADAY_STEPS','Fitbit Steps Intraday',0,$((++SORT_ORDER)))"
   insertCriteriaMenu "($((++ID)),$PARENT_ID,'Program Data','FITBIT_SLEEP_DAILY_SUMMARY','FITBIT_SLEEP_DAILY_SUMMARY','Fitbit Sleep Daily Summary',0,$((++SORT_ORDER)))"
   insertCriteriaMenu "($((++ID)),$PARENT_ID,'Program Data','FITBIT_SLEEP_LEVEL','FITBIT_SLEEP_LEVEL','Fitbit Sleep Level',0,$((++SORT_ORDER)))"
+  
+  if [[ $wearConsentDataCount > 0 ]];
+  then
+    echo "Insert wear consent into cb_criteria_menu"
+    insertCriteriaMenu "($((++ID)),$PARENT_ID,'Program Data','WEAR_CONSENT','WEAR_CONSENT','Wear Consent',0,$((++SORT_ORDER)))"
+  fi
 fi
 
 echo "Getting parent id for GENOMICS"

--- a/api/db-cdr/generate-cdr/build-cb-search-person.sh
+++ b/api/db-cdr/generate-cdr/build-cb-search-person.sh
@@ -409,3 +409,26 @@ FROM
             ) sl on (p.person_id = sl.person_id)
     ) y
 WHERE x.person_id = y.person_id"
+
+################################################
+# set wear consent table flags
+################################################
+echo "set wear consent table flags in cb_search_person"
+bq --quiet --project_id=$BQ_PROJECT query --nouse_legacy_sql \
+"UPDATE \`$BQ_PROJECT.$BQ_DATASET.cb_search_person\` x
+SET x.has_wear_consent = y.has_wear_consent
+FROM
+    (
+        SELECT
+              p.person_id
+            , CASE
+                WHEN ws.person_id is null THEN 0
+                ELSE 1
+              END has_wear_consent
+        FROM \`$BQ_PROJECT.$BQ_DATASET.person\` p
+        LEFT JOIN
+            (
+                SELECT distinct person_id FROM \`$BQ_PROJECT.$BQ_DATASET.wear_study\`
+            ) ws on (p.person_id = ws.person_id)
+    ) y
+WHERE x.person_id = y.person_id"

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1718,12 +1718,12 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   @Test
   public void countParticipantsWearConsent() {
     CohortDefinition cohortDefinition =
-            createCohortDefinition(
-                    Domain.WEAR_CONSENT.toString(),
-                    ImmutableList.of(fitbit(Domain.WEAR_CONSENT)),
-                    new ArrayList<>());
+        createCohortDefinition(
+            Domain.WEAR_CONSENT.toString(),
+            ImmutableList.of(fitbit(Domain.WEAR_CONSENT)),
+            new ArrayList<>());
     assertParticipants(
-            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+        controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
   }
 
   @Test

--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortBuilderControllerBQTest.java
@@ -1716,6 +1716,17 @@ public class CohortBuilderControllerBQTest extends BigQueryBaseTest {
   }
 
   @Test
+  public void countParticipantsWearConsent() {
+    CohortDefinition cohortDefinition =
+            createCohortDefinition(
+                    Domain.WEAR_CONSENT.toString(),
+                    ImmutableList.of(fitbit(Domain.WEAR_CONSENT)),
+                    new ArrayList<>());
+    assertParticipants(
+            controller.countParticipants(WORKSPACE_NAMESPACE, WORKSPACE_ID, cohortDefinition), 1);
+  }
+
+  @Test
   public void countParticipantsWholeGenomeVariant() {
     CohortDefinition cohortDefinition =
         createCohortDefinition(

--- a/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
+++ b/api/src/bigquerytest/resources/bigquery/cbdata/cb_search_person_data.json
@@ -21,7 +21,8 @@
     "has_whole_genome_variant": 1,
     "has_array_data": 1,
     "has_lr_whole_genome_variant": 1,
-    "has_structural_variant_data": 1
+    "has_structural_variant_data": 1,
+    "has_wear_consent": 1
   },
   {
     "person_id": 2,

--- a/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
+++ b/api/src/bigquerytest/resources/bigquery/schema/cb_search_person.json
@@ -113,5 +113,10 @@
     "mode": "NULLABLE",
     "name": "state_of_residence",
     "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_wear_consent",
+    "type": "INTEGER"
   }
 ]

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -84,8 +84,7 @@ public final class SearchGroupItemQueryBuilder {
               Domain.LR_WHOLE_GENOME_VARIANT, "has_lr_whole_genome_variant"),
           new AbstractMap.SimpleEntry<>(
               Domain.STRUCTURAL_VARIANT_DATA, "has_structural_variant_data"),
-              new AbstractMap.SimpleEntry<>(
-                      Domain.WEAR_CONSENT, "has_wear_consent"));
+          new AbstractMap.SimpleEntry<>(Domain.WEAR_CONSENT, "has_wear_consent"));
 
   // sql parts to help construct BigQuery sql statements
   private static final String OR = " OR ";

--- a/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
+++ b/api/src/main/java/org/pmiops/workbench/cohortbuilder/SearchGroupItemQueryBuilder.java
@@ -83,7 +83,9 @@ public final class SearchGroupItemQueryBuilder {
           new AbstractMap.SimpleEntry<>(
               Domain.LR_WHOLE_GENOME_VARIANT, "has_lr_whole_genome_variant"),
           new AbstractMap.SimpleEntry<>(
-              Domain.STRUCTURAL_VARIANT_DATA, "has_structural_variant_data"));
+              Domain.STRUCTURAL_VARIANT_DATA, "has_structural_variant_data"),
+              new AbstractMap.SimpleEntry<>(
+                      Domain.WEAR_CONSENT, "has_wear_consent"));
 
   // sql parts to help construct BigQuery sql statements
   private static final String OR = " OR ";

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -219,6 +219,7 @@ public final class DbStorageEnums {
           .put(Domain.CONCEPT_SET, (short) 27)
           .put(Domain.CONCEPT_QUICK_ADD, (short) 28)
           .put(Domain.SNP_INDEL_VARIANT, (short) 29)
+          .put(Domain.WEAR_CONSENT, (short) 30)
           .build();
 
   // A mapping from our Domain enum to OMOP domain ID values.
@@ -254,6 +255,7 @@ public final class DbStorageEnums {
           .put(Domain.CONCEPT_SET, "Concept Set")
           .put(Domain.CONCEPT_QUICK_ADD, "Concept Quick Add")
           .put(Domain.SNP_INDEL_VARIANT, "SNP/Indel Variants")
+          .put(Domain.WEAR_CONSENT, "Wear Consent")
           .build();
 
   public static Domain domainFromStorage(Short domain) {

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6492,6 +6492,7 @@ components:
       - ARRAY_DATA
       - CONCEPT_SET
       - CONCEPT_QUICK_ADD
+      - WEAR_CONSENT
     Surveys:
       type: string
       description: a survey for concepts


### PR DESCRIPTION
adding has_wear_consent flag to CB menu and query engine.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
