### PR TITLE
[risk=no][no-ticket] Fix transaction not found issue and concurrent modification exception

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
@@ -53,10 +53,13 @@ public class OfflineBillingController implements OfflineBillingApiDelegate {
     // Clear table googleproject_cost and then insert all entries from BQ
     googleProjectPerCostDao.deleteAll();
     googleProjectPerCostDao.batchInsertProjectPerCost(googleProjectCostList);
+    log.info("Inserted all workspace costs to googleproject_cost table");
 
     List<Long> allUserIds = userService.getAllUserIds();
 
     taskQueueService.groupAndPushFreeTierBilling(allUserIds);
+    log.info("Pushed all users to Cloud Task for Free Tier Billing");
+
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -27,8 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 /** Methods relating to Free Tier credit usage and limits */
 @Service
@@ -73,10 +71,7 @@ public class FreeTierBillingService {
 
   /**
    * Check whether users have incurred sufficient cost in their workspaces to trigger alerts due to
-   * passing thresholds or exceeding limits. RW-6280 - REQUIRES_NEW transactional mode was added to
-   * make the call to this method create a new transaction with each set of users. In order to
-   * commit the transaction after the call. However, if the user has many workspaces, this method
-   * may still timeout.
+   * passing thresholds or exceeding limits.
    */
   public void checkFreeTierBillingUsageForUsers(
       Set<DbUser> users, final Map<String, Double> liveCostsInBQ) {

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -8,13 +8,8 @@ import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
@@ -83,7 +78,6 @@ public class FreeTierBillingService {
    * commit the transaction after the call. However, if the user has many workspaces, this method
    * may still timeout.
    */
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void checkFreeTierBillingUsageForUsers(
       Set<DbUser> users, final Map<String, Double> liveCostsInBQ) {
     String userIdsAsString =
@@ -132,7 +126,7 @@ public class FreeTierBillingService {
   private Set<DbUser> filterUsersHigherThanTheLowestThreshold(
       Set<DbUser> users, final Map<Long, Double> liveCostByCreator) {
     final List<Double> costThresholdsInDescOrder =
-        workbenchConfigProvider.get().billing.freeTierCostAlertThresholds;
+        new ArrayList<>(workbenchConfigProvider.get().billing.freeTierCostAlertThresholds);
     costThresholdsInDescOrder.sort(Comparator.reverseOrder());
     final double lowestThreshold =
         costThresholdsInDescOrder.get(costThresholdsInDescOrder.size() - 1);


### PR DESCRIPTION
found in prod logs a couple of exception that may cause the cloud task to fail. This PR will make the cloud tasks less flaky, and also added logs to identify why the cron job reports 500.
```
ErrorId e965b379-180f-4ed3-aac0-83104dbe9247: org.springframework.transaction.CannotCreateTransactionException
org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction
	at org.springframework.orm.jpa.JpaTransactionManager.doBegin(JpaTransactionManager.java:466)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.startTransaction(AbstractPlatformTransactionManager.java:531)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.handleExistingTransaction(AbstractPlatformTransactionManager.java:452)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(AbstractPlatformTransactionManager.java:384)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.createTransactionIfNecessary(TransactionAspectSupport.java:617)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:386)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:717)
	at org.pmiops.workbench.billing.WorkspaceFreeTierUsageService$$SpringCGLIB$$0.updateWorkspaceFreeTierUsageInDB(<generated>)
	at org.pmiops.workbench.billing.FreeTierBillingService.updateFreeTierUsageInDb(FreeTierBillingService.java:371)
	at org.pmiops.workbench.billing.FreeTierBillingService.checkFreeTierBillingUsageForUsers(FreeTierBillingService.java:97)
	at jdk.internal.reflect.GeneratedMethodAccessor1059.invoke(Unknown Source)
```


and 

```
ErrorId 464c28b6-51a2-42fb-b57e-7964055bb0af: java.util.ConcurrentModificationException
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList.sort(ArrayList.java:1723)
	at org.pmiops.workbench.billing.FreeTierBillingService.filterUsersHigherThanTheLowestThreshold(FreeTierBillingService.java:131)
	at org.pmiops.workbench.billing.FreeTierBillingService.checkFreeTierBillingUsageForUsers(FreeTierBillingService.java:107)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
