### PR TITLE
[risk=low][RW-9065] Enable app machine config for Staging and Preprod

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -113,7 +113,7 @@
     "ccSupportWhenAdminLocking": true,
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
-    "enableGKEAppMachineTypeChoice": false,
+    "enableGKEAppMachineTypeChoice": true,
     "enableVariantSelectAll": true
   },
   "actionAudit": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -114,7 +114,7 @@
     "ccSupportWhenAdminLocking": false,
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
-    "enableGKEAppMachineTypeChoice": false,
+    "enableGKEAppMachineTypeChoice": true,
     "enableVariantSelectAll": true
   },
   "actionAudit": {


### PR DESCRIPTION
Bring the new app machine config ability to Staging and Preprod.  Not Prod or Stable yet.

DONE ~Waiting on the resolution of a UI bug: when machine config is active, we only show the CPUs and RAM, not the disk size.  #8558 displays the disk size elsewhere, so one solution would be to merge that as well as removing the disk information from non-configurable machine config.~

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
