### PR TITLE
[DT-820][DT-768][risk=no] Variant select all updates

### DIFF
--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -114,7 +114,7 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": false,
-    "enableVariantSelectAll": false
+    "enableVariantSelectAll": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -651,8 +651,8 @@ export const VariantSearch = fp.flow(
               paginatorTemplate='PrevPageLink CurrentPageReport NextPageLink'
               rows={pageSize}
               scrollable
-              scrollHeight='26rem'
-              style={{ fontSize: '12px', minHeight: '22rem' }}
+              scrollHeight='80%'
+              style={{ fontSize: '12px', height: '100%', minHeight: '22rem' }}
               totalRecords={totalCount}
               value={displayResults}
             >

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -161,7 +161,8 @@ const searchTooltip = (
 );
 const resultsTooltip = (
   <div style={{ marginLeft: '0.5rem' }}>
-    Number of results must be between 100 and 10,000 to Select All Results
+    Number of results must be between {pageSize} and 10,000 to Select All
+    Results. For results less than {pageSize}, selections must be made manually.
   </div>
 );
 const duplicateFilterTooltip = (
@@ -481,7 +482,7 @@ export const VariantSearch = fp.flow(
     };
 
     const disableSelectAll =
-      totalCount < 100 ||
+      totalCount < pageSize ||
       totalCount > 10000 ||
       criteria.some((crit) => crit.parameterId === getFilterParamId());
     const disableSelectAllSave =
@@ -602,7 +603,7 @@ export const VariantSearch = fp.flow(
                 <TooltipTrigger
                   side='top'
                   content={
-                    totalCount < 100 || totalCount > 10000
+                    totalCount < pageSize || totalCount > 10000
                       ? resultsTooltip
                       : duplicateFilterTooltip
                   }

--- a/ui/src/app/pages/data/criteria-search.tsx
+++ b/ui/src/app/pages/data/criteria-search.tsx
@@ -413,7 +413,7 @@ export const CriteriaSearch = fp.flow(
         toastVisible,
       } = this.state;
       return (
-        <div id='criteria-search-container'>
+        <div id='criteria-search-container' style={{ height: '100%' }}>
           {loadingSubtree && <SpinnerOverlay />}
           <Toast
             ref={(el) => (this.toast = el)}


### PR DESCRIPTION
- Set lower select all limit to the result page size (25) and add more info to tooltip
- Fix height for results table to adjust for large screens
- Enable `enableVariantSelectAll` config flag for prod