### PR TITLE
[risk=low][RW-11850] Fix staging e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,6 +923,7 @@ jobs:
           name: "Create a file contains test names"
           working_directory: ~/workbench/e2e
           command: yarn jest --listTests | grep -o 'tests/.*.ts$' > e2e_tests.txt
+      - gcloud-auth-login-stored-credentials: # needed to run project.rb generate-impersonated-user-tokens as part of "yarn test:ci"
       - run:
           name: "Running Puppeteer e2e tests"
           working_directory: ~/workbench/e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,7 +923,7 @@ jobs:
           name: "Create a file contains test names"
           working_directory: ~/workbench/e2e
           command: yarn jest --listTests | grep -o 'tests/.*.ts$' > e2e_tests.txt
-      - gcloud-auth-login-stored-credentials: # needed to run project.rb generate-impersonated-user-tokens as part of "yarn test:ci"
+      - gcloud-auth-login-stored-credentials  # needed to run project.rb generate-impersonated-user-tokens as part of "yarn test:ci"
       - run:
           name: "Running Puppeteer e2e tests"
           working_directory: ~/workbench/e2e


### PR DESCRIPTION
Another problem caused by #8598 which requires a fix similar to #8599

The staging e2e test run failed because it wasn't logged in: https://app.circleci.com/pipelines/github/all-of-us/workbench/33055/workflows/50af3484-8074-4f43-9bf9-7dce519235f3/jobs/359035

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
