### PR TITLE
[risk=low][no ticket] Fix Cloud Environments nav bug: use terra name instead of aou name

### DIFF
--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -103,8 +103,6 @@ const css =
         display: none !important
     }`;
 
-const stringToSlug = (s) => s.toLowerCase().replace(/\s+/g, '');
-
 interface RuntimesListProps
   extends WithSpinnerOverlayProps,
     NavigationProps,
@@ -139,8 +137,8 @@ export const RuntimesList = fp.flow(
                 nav: {
                   // called from, for example:
                   // https://github.com/DataBiosphere/terra-ui/blob/4333c7b94d6ce10a6fe079361e98c2b6cc71f83a/src/pages/Environments.js#L420
-                  getLink: (_, { namespace, name }) =>
-                    analysisTabPath(namespace, stringToSlug(name)),
+                  getLink: (_, { namespace, id }) =>
+                    analysisTabPath(namespace, id),
                 },
               }}
             />

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -138,6 +138,7 @@ export const RuntimesList = fp.flow(
                   // called from, for example:
                   // https://github.com/DataBiosphere/terra-ui/blob/4333c7b94d6ce10a6fe079361e98c2b6cc71f83a/src/pages/Environments.js#L420
                   getLink: (_, { namespace, id }) =>
+                    // note that "id" here is the terra name of the workspace.
                     analysisTabPath(namespace, id),
                 },
               }}

--- a/ui/src/app/pages/runtimes-list.tsx
+++ b/ui/src/app/pages/runtimes-list.tsx
@@ -137,9 +137,11 @@ export const RuntimesList = fp.flow(
                 nav: {
                   // called from, for example:
                   // https://github.com/DataBiosphere/terra-ui/blob/4333c7b94d6ce10a6fe079361e98c2b6cc71f83a/src/pages/Environments.js#L420
-                  getLink: (_, { namespace, id }) =>
-                    // note that "id" here is the terra name of the workspace.
-                    analysisTabPath(namespace, id),
+                  getLink: (
+                    _,
+                    // TODO: rename all instances of the incorrect Workspace field name "id" to "terraName"
+                    { namespace, id: terraName }
+                  ) => analysisTabPath(namespace, terraName),
                 },
               }}
             />


### PR DESCRIPTION
We were not setting the correct URL for navigation to workspaces from Cloud Environments in some cases.

To reproduce:
* rename a workspace (to whatever)
* start a runtime or app
* go to Cloud Environments
* click the link for that workspace

Old behavior: infinite spinner, does not show workspace info

New behavior: successful navigation to workspace

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
