### PR TITLE
[RW-12855][risk=low] Support mount GCS bucket in SAS and RStudio

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -114,7 +114,8 @@
     "enableDataExplorer": true,
     "enableGKEAppPausing": true,
     "enableGKEAppMachineTypeChoice": true,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -114,7 +114,8 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": true,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -114,7 +114,8 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": false,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -114,7 +114,8 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": false,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -115,7 +115,8 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": true,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -115,7 +115,7 @@
     "enableGKEAppPausing": true,
     "enableGKEAppMachineTypeChoice": true,
     "enableVariantSelectAll": true,
-    "enableGcsFuseOnGke": false
+    "enableGcsFuseOnGke": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -114,7 +114,8 @@
     "enableDataExplorer": false,
     "enableGKEAppPausing": true,
     "enableGKEAppMachineTypeChoice": true,
-    "enableVariantSelectAll": true
+    "enableVariantSelectAll": true,
+    "enableGcsFuseOnGke": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -318,6 +318,8 @@ public class WorkbenchConfig {
     public boolean enableGKEAppMachineTypeChoice;
     // If true, enable variant select all
     public boolean enableVariantSelectAll;
+    // If true, enable mounting GCS buckets on GKE apps
+    public boolean enableGcsFuseOnGke;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -26,6 +26,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
+import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.FireCloudService;
@@ -65,6 +66,7 @@ import org.pmiops.workbench.notebooks.api.ProxyApi;
 import org.pmiops.workbench.notebooks.model.LocalizationEntry;
 import org.pmiops.workbench.notebooks.model.Localize;
 import org.pmiops.workbench.notebooks.model.StorageLink;
+import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -242,9 +244,13 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     DbUser user = userProvider.get();
     DbWorkspace workspace = workspaceDao.getRequired(workspaceNamespace, workspaceFirecloudName);
 
+    RawlsWorkspaceResponse fcWorkspaceResponse =
+        fireCloudService
+            .getWorkspace(workspace)
+            .orElseThrow(() -> new NotFoundException("workspace not found"));
     Map<String, String> customEnvironmentVariables =
         LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
-            workspace, fireCloudService, workbenchConfigProvider.get());
+            workspace, fcWorkspaceResponse, workbenchConfigProvider.get());
 
     // See RW-7107
     customEnvironmentVariables.put("PYSPARK_PYTHON", "/usr/local/bin/python3");
@@ -610,9 +616,14 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
       diskRequest.setName(userProvider.get().generatePDNameForUserApps(appType));
     }
 
+    RawlsWorkspaceResponse fcWorkspaceResponse =
+        fireCloudService
+            .getWorkspace(dbWorkspace)
+            .orElseThrow(() -> new NotFoundException("workspace not found"));
+
     Map<String, String> appCustomEnvVars =
         LeonardoCustomEnvVarUtils.getBaseEnvironmentVariables(
-            dbWorkspace, fireCloudService, workbenchConfigProvider.get());
+            dbWorkspace, fcWorkspaceResponse, workbenchConfigProvider.get());
     // Required by Leo to validate one App per user per workspace (namespace with workspace name)
     appCustomEnvVars.put(WORKSPACE_NAME_ENV_KEY, dbWorkspace.getFirecloudName());
 
@@ -631,6 +642,12 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
         .labels(appLabels)
         .autodeleteEnabled(createAppRequest.isAutodeleteEnabled())
         .autodeleteThreshold(createAppRequest.getAutodeleteThreshold());
+
+    if (workbenchConfigProvider.get().featureFlags.enableGcsFuseOnGke
+        && (appType.equals(AppType.RSTUDIO) || appType.equals(AppType.SAS))) {
+      leonardoCreateAppRequest.bucketNameToMount(
+          fcWorkspaceResponse.getWorkspace().getBucketName());
+    }
 
     leonardoRetryHandler.run(
         (context) -> {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoCustomEnvVarUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoCustomEnvVarUtils.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
 
@@ -177,12 +175,10 @@ public class LeonardoCustomEnvVarUtils {
 
   /** The general environment variables that can be used in all Apps. */
   public static Map<String, String> getBaseEnvironmentVariables(
-      DbWorkspace workspace, FireCloudService fireCloudService, WorkbenchConfig workbenchConfig) {
+      DbWorkspace workspace,
+      RawlsWorkspaceResponse fcWorkspaceResponse,
+      WorkbenchConfig workbenchConfig) {
     Map<String, String> customEnvironmentVariables = new HashMap<>();
-    RawlsWorkspaceResponse fcWorkspaceResponse =
-        fireCloudService
-            .getWorkspace(workspace)
-            .orElseThrow(() -> new NotFoundException("workspace not found"));
     customEnvironmentVariables.put(WORKSPACE_NAMESPACE_KEY, workspace.getWorkspaceNamespace());
     // This variable is already made available by Leonardo, but it's only exported in certain
     // notebooks contexts; this ensures it is always exported. See RW-7096.

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -2542,6 +2542,12 @@ components:
         autodeleteEnabled:
           type: boolean
           description: Whether to turn on autodelete
+        autopilot:
+          $ref: '#/components/schemas/Autopilot'
+        bucketNameToMount:
+          type: string
+          description: >
+            The GCS bucket name (without gs://) that will be mounted in the app if present. 
 
     GetAppResponse:
       description: the configuration of an app
@@ -2644,6 +2650,20 @@ components:
         cloudResource:
           type: string
           description: Cloud resource name. Google project if cloud provider is GCP OR Azure's tenantId/subscriptionId/managedResourceGroupId if in Azure
+
+    Autopilot:
+      description: Defines app's Autopilot configuration
+      type: object
+      properties:
+        cpuInMillicores:
+          type: integer
+          description: Number of CPUs in autopilot mode measured in millicores. For example, 500m refers to half a core of computing processing time. 2000m is 2 cores.
+        memoryInGb:
+          type: integer
+          description: memory in GB.
+        ephemeralStorageInGb:
+          type: integer
+          description: ephemeral storage size in GB.
 
     KubernetesRuntimeConfig:
       description: configuration for a kubernetes app runtime


### PR DESCRIPTION
Currently this is protected by feature flag. If ff is on, we will pass workspace bucket to Leo. 
In the future, mounting or not might be passed from UI depends on the UX research

This is blocked by https://github.com/DataBiosphere/leonardo/pull/4628

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
