### PR TITLE
[risk=low][RW-11636] Update workspace out of credits notification

### DIFF
--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -3,13 +3,13 @@ import * as fp from 'lodash';
 
 import { Profile } from 'generated/fetch';
 
-import { Button } from 'app/components/buttons';
+import { Button, LinkButton } from 'app/components/buttons';
 import { ToastBanner, ToastType } from 'app/components/toast-banner';
 import { withCurrentWorkspace, withUserProfile } from 'app/utils';
 import { NavigationProps } from 'app/utils/navigation';
 import { withNavigation } from 'app/utils/with-navigation-hoc';
 import { WorkspaceData } from 'app/utils/workspace-data';
-import { openZendeskWidget } from 'app/utils/zendesk';
+import { supportUrls } from 'app/utils/zendesk';
 
 interface Props extends NavigationProps {
   workspace: WorkspaceData;
@@ -23,51 +23,34 @@ export const InvalidBillingBanner = fp.flow(
   withCurrentWorkspace(),
   withUserProfile(),
   withNavigation
-)((props: Props) => {
-  const userAction =
-    'Please provide a valid billing account or contact support to extend initial credits.';
-  const footer = (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <Button
-        style={{ height: '38px', width: '70%', fontWeight: 400 }}
-        onClick={() => {
-          openZendeskWidget(
-            props.profileState.profile.givenName,
-            props.profileState.profile.familyName,
-            props.profileState.profile.username,
-            props.profileState.profile.contactEmail
-          );
-        }}
+)(({ onClose, navigate, workspace }: Props) => {
+  const message = (
+    <div>
+      'The initial credits for the creator of this workspace have run out.
+      Please provide a valid billing account.'
+      <LinkButton
+        onClick={() => window.open(supportUrls.createBillingAccount, '_blank')}
       >
-        Request Extension
-      </Button>
-      <a
-        style={{ marginTop: '.75rem', marginLeft: '.3rem' }}
-        onClick={() => {
-          props.navigate([
-            'workspaces',
-            props.workspace.namespace,
-            props.workspace.id,
-            'edit',
-          ]);
-        }}
-      >
-        Provide billing account
-      </a>
+        Learn how to link a billing account.
+      </LinkButton>
     </div>
   );
-
+  const footer = (
+    <Button
+      style={{ height: '38px', width: '70%', fontWeight: 400 }}
+      onClick={() =>
+        navigate(['workspaces', workspace.namespace, workspace.id, 'edit'])
+      }
+    >
+      Edit Workspace
+    </Button>
+  );
   return (
     <ToastBanner
-      title={'This workspace has run out of initial credits'}
-      message={
-        'The initial credits for the creator of this workspace have run out. ' +
-        userAction
-      }
-      onClose={() => props.onClose()}
+      {...{ message, footer, onClose }}
+      title='This workspace has run out of initial credits'
       toastType={ToastType.WARNING}
       zIndex={500}
-      footer={footer}
     />
   );
 });

--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -38,9 +38,14 @@ export const InvalidBillingBanner = fp.flow(
   const footer = (
     <Button
       style={{ height: '38px', width: '70%', fontWeight: 400 }}
-      onClick={() =>
-        navigate(['workspaces', workspace.namespace, workspace.id, 'edit'])
-      }
+      onClick={() => {
+        onClose();
+        navigate(['workspaces', workspace.namespace, workspace.id, 'edit'], {
+          queryParams: {
+            highlightBilling: true,
+          },
+        });
+      }}
     >
       Edit Workspace
     </Button>

--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -26,8 +26,8 @@ export const InvalidBillingBanner = fp.flow(
 )(({ onClose, navigate, workspace }: Props) => {
   const message = (
     <div>
-      'The initial credits for the creator of this workspace have run out.
-      Please provide a valid billing account.'
+      The initial credits for the creator of this workspace have run out. Please
+      provide a valid billing account.
       <LinkButton
         onClick={() => window.open(supportUrls.createBillingAccount, '_blank')}
       >

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { MemoryRouter } from 'react-router';
 import * as fp from 'lodash/fp';
 import { mockNavigate } from 'setupTests';
 
@@ -14,6 +15,7 @@ import {
 
 import {
   getDefaultNormalizer,
+  render,
   screen,
   waitFor,
   within,
@@ -23,7 +25,9 @@ import {
   WorkspaceEdit,
   WorkspaceEditMode,
 } from 'app/pages/workspace/workspace-edit';
+import { workspacePath } from 'app/routing/utils';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import colors from 'app/styles/colors';
 import { AccessTierShortNames } from 'app/utils/access-tiers';
 import * as Authentication from 'app/utils/authentication';
 import { currentWorkspaceStore } from 'app/utils/navigation';
@@ -38,7 +42,6 @@ import defaultServerConfig from 'testing/default-server-config';
 import {
   expectButtonElementDisabled,
   expectButtonElementEnabled,
-  renderWithRouter,
 } from 'testing/react-test-helpers';
 import {
   altCdrVersion,
@@ -76,21 +79,27 @@ const OTHER_DISSEMINATION_REGEX = new RegExp(
   'i'
 );
 
-describe('WorkspaceEdit', () => {
+describe(WorkspaceEdit.name, () => {
   let workspacesApi: WorkspacesApiStub;
   let userApi: UserApiStub;
   let workspace: WorkspaceData;
   let workspaceEditMode: WorkspaceEditMode;
   let user: UserEvent;
 
-  const renderComponent = () => {
-    return renderWithRouter(
-      <WorkspaceEdit
-        cancel={() => {}}
-        hideSpinner={() => {}}
-        showSpinner={() => {}}
-        workspaceEditMode={workspaceEditMode}
-      />
+  const renderComponent = (queryParam?: string) => {
+    return render(
+      <MemoryRouter
+        initialEntries={[
+          workspacePath('foo', 'bar') + queryParam ? `?${queryParam}` : '',
+        ]}
+      >
+        <WorkspaceEdit
+          cancel={() => {}}
+          hideSpinner={() => {}}
+          showSpinner={() => {}}
+          workspaceEditMode={workspaceEditMode}
+        />
+      </MemoryRouter>
     );
   };
 
@@ -1104,5 +1113,21 @@ describe('WorkspaceEdit', () => {
         normalizer: getDefaultNormalizer({ trim: false }),
       })
     ).toBeInTheDocument();
+  });
+
+  it('should not highlight the billing dropdown by default', async () => {
+    renderComponent();
+    const billingDropdown = screen.getByTestId('billing-dropdown');
+    expect(billingDropdown).not.toHaveStyle(
+      `background-color: ${colors.highlight}`
+    );
+  });
+
+  it('should highlight the billing dropdown when specified by query param', async () => {
+    renderComponent('highlightBilling=anyvalue');
+    const billingDropdown = screen.getByTestId('billing-dropdown');
+    expect(billingDropdown).toHaveStyle(
+      `background-color: ${colors.highlight}`
+    );
   });
 });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -1115,16 +1115,16 @@ describe(WorkspaceEdit.name, () => {
 
   it('should not highlight the billing dropdown by default', async () => {
     renderComponent();
-    const billingDropdown = screen.getByTestId('billing-dropdown');
-    expect(billingDropdown).not.toHaveStyle(
+
+    expect(screen.getByTestId('billing-dropdown')).not.toHaveStyle(
       `background-color: ${colors.highlight}`
     );
   });
 
   it('should highlight the billing dropdown when specified by query param', async () => {
     renderComponent('highlightBilling=anyvalue');
-    const billingDropdown = screen.getByTestId('billing-dropdown');
-    expect(billingDropdown).toHaveStyle(
+
+    expect(screen.getByTestId('billing-dropdown')).toHaveStyle(
       `background-color: ${colors.highlight}`
     );
   });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -86,12 +86,10 @@ describe(WorkspaceEdit.name, () => {
   let workspaceEditMode: WorkspaceEditMode;
   let user: UserEvent;
 
-  const renderComponent = (queryParam?: string) => {
+  const renderComponent = (search?: string) => {
     return render(
       <MemoryRouter
-        initialEntries={[
-          workspacePath('foo', 'bar') + queryParam ? `?${queryParam}` : '',
-        ]}
+        initialEntries={[{ pathname: workspacePath('foo', 'bar'), search }]}
       >
         <WorkspaceEdit
           cancel={() => {}}

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
 import * as fp from 'lodash/fp';
 import { Dropdown } from 'primereact/dropdown';
 import validate from 'validate.js';
@@ -19,6 +20,7 @@ import {
   WorkspaceOperationStatus,
 } from 'generated/fetch';
 
+import { parseQueryParams } from 'app/components/app-router';
 import { Button, LinkButton, StyledExternalLink } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
@@ -297,7 +299,8 @@ const CdrVersionUpgrade = (props: UpgradeProps) => {
 
 export interface WorkspaceEditProps
   extends WithSpinnerOverlayProps,
-    NavigationProps {
+    NavigationProps,
+    RouteComponentProps {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
   workspace: WorkspaceData;
   cancel: Function;
@@ -334,7 +337,8 @@ export const WorkspaceEdit = fp.flow(
   withCurrentWorkspace(),
   withCdrVersions(),
   withUserProfile(),
-  withNavigation
+  withNavigation,
+  withRouter
 )(
   class WorkspaceEditCmp extends React.Component<
     WorkspaceEditProps,
@@ -1402,6 +1406,9 @@ export const WorkspaceEdit = fp.flow(
     }
 
     render() {
+      const params = parseQueryParams(this.props.location.search);
+      const highlightBilling = !!params.get('highlightBilling');
+
       const {
         workspace: {
           name,
@@ -1644,7 +1651,14 @@ export const WorkspaceEdit = fp.flow(
                           <Dropdown
                             data-test-id='billing-dropdown'
                             disabled={this.state.fetchBillingAccountError}
-                            style={{ width: '30rem' }}
+                            style={
+                              highlightBilling
+                                ? {
+                                    backgroundColor: colors.highlight,
+                                    width: '30rem',
+                                  }
+                                : { width: '30rem' }
+                            }
                             value={billingAccountName}
                             options={this.buildBillingAccountOptions()}
                             onChange={(e) => {


### PR DESCRIPTION
Update "initial credits expired" workspace banner text, and change the button to Edit Workspace.  This navigation will also cause the billing account dropdown to be highlighted.

Tested locally.

<img width="320" alt="expired" src="https://github.com/all-of-us/workbench/assets/2701406/c2b5c8c2-9f2e-46d6-ae75-79f3a09ebf39">

![highlight_billing](https://github.com/all-of-us/workbench/assets/2701406/93ec4381-73e3-4dcf-8c59-80a9e7843237)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
