### PR TITLE
[risk=low][no ticker] More WorkspaceMapper refactoring

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -36,6 +36,7 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exceptions.TooManyRequestsException;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.iam.IamService;
 import org.pmiops.workbench.model.ArchivalStatus;
@@ -79,6 +80,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   private final CdrVersionDao cdrVersionDao;
   private final Clock clock;
+  private final FeaturedWorkspaceService featuredWorkspaceService;
   private final FireCloudService fireCloudService;
   private final FreeTierBillingService freeTierBillingService;
   private final IamService iamService;
@@ -99,6 +101,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   public WorkspacesController(
       CdrVersionDao cdrVersionDao,
       Clock clock,
+      FeaturedWorkspaceService featuredWorkspaceService,
       FireCloudService fireCloudService,
       FreeTierBillingService freeTierBillingService,
       IamService iamService,
@@ -116,6 +119,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       WorkspaceService workspaceService) {
     this.cdrVersionDao = cdrVersionDao;
     this.clock = clock;
+    this.featuredWorkspaceService = featuredWorkspaceService;
     this.fireCloudService = fireCloudService;
     this.freeTierBillingService = freeTierBillingService;
     this.iamService = iamService;
@@ -192,7 +196,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
           dbWorkspace, workbenchConfigProvider.get().billing.freeTierBillingAccountName());
       throw e;
     }
-    final Workspace createdWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    final Workspace createdWorkspace =
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
     workspaceAuditor.fireCreateAction(createdWorkspace, dbWorkspace.getWorkspaceId());
 
     if (cdrVersion.getTanagraEnabled()) {
@@ -279,7 +284,11 @@ public class WorkspacesController implements WorkspacesApiDelegate {
                 ResponseEntity.ok()
                     .body(
                         workspaceOperationMapper.toModelWithWorkspace(
-                            op, workspaceDao, fireCloudService, workspaceMapper)))
+                            op,
+                            workspaceDao,
+                            fireCloudService,
+                            workspaceMapper,
+                            featuredWorkspaceService)))
         .orElse(ResponseEntity.notFound().build());
   }
 
@@ -491,7 +500,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       throw new BadRequestException("Missing required update field 'etag'");
     }
 
-    final Workspace originalWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    final Workspace originalWorkspace =
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
 
     int version = Etags.toVersion(workspace.getEtag());
     if (dbWorkspace.getVersion() != version) {
@@ -540,11 +550,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       throw e;
     }
 
-    final Workspace editedWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    final Workspace editedWorkspace =
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
 
     workspaceAuditor.fireEditAction(
         originalWorkspace, editedWorkspace, dbWorkspace.getWorkspaceId());
-    return ResponseEntity.ok(workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace));
+    return ResponseEntity.ok(
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService));
   }
 
   @Override
@@ -639,7 +651,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     dbWorkspace = dbWorkspace.setPublished(false);
 
     dbWorkspace = workspaceDao.saveWithLastModified(dbWorkspace, user);
-    final Workspace savedWorkspace = workspaceMapper.toApiWorkspace(dbWorkspace, toFcWorkspace);
+    final Workspace savedWorkspace =
+        workspaceMapper.toApiWorkspace(dbWorkspace, toFcWorkspace, featuredWorkspaceService);
 
     workspaceAuditor.fireDuplicateAction(
         fromWorkspace.getWorkspaceId(), dbWorkspace.getWorkspaceId(), savedWorkspace);

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -47,7 +47,6 @@ public class DbWorkspace {
   private Set<DbConceptSet> conceptSets = new HashSet<>();
   private Set<DbDataset> dataSets = new HashSet<>();
   private Short activeStatus;
-  private boolean published;
 
   private boolean diseaseFocusedResearch;
   private String diseaseOfFocus;
@@ -82,6 +81,23 @@ public class DbWorkspace {
   private String googleProject;
   private boolean adminLocked;
   private String adminLockedReason;
+
+  /*
+  We are in the process of changing how Published/Featured workspaces work.
+
+  Old Style:
+  This field "published" indicates that the workspace has been shared with the Registered Tier
+  Auth Domain as Reader (thus making it readable to all RT and CT users).  We use
+  FeaturedWorkspacesConfig to indicate that a workspace is "featured".  The UI only displays
+  workspaces which are both Published and Featured on the Featured Workspaces page.
+
+  New Style:
+  Going forward, Publishing and Featuring will happen in a single step, and we will indicate that
+  a workspace has been published/featured by adding a row to DbFeaturedWorkspace.  See also the
+  new FeaturedWorkspaceService.
+  */
+  @Deprecated(since = "July 2024", forRemoval = true)
+  private boolean published;
 
   public DbWorkspace() {
     setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -198,11 +214,15 @@ public class DbWorkspace {
     return this;
   }
 
+  // see note above, at the field definition
+  @Deprecated(since = "July 2024", forRemoval = true)
   @Column(name = "published")
   public boolean getPublished() {
     return published;
   }
 
+  // see note above, at the field definition
+  @Deprecated(since = "July 2024", forRemoval = true)
   public DbWorkspace setPublished(boolean published) {
     this.published = published;
     return this;

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
@@ -36,8 +37,9 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
       Logger.getLogger(ImpersonatedWorkspaceServiceImpl.class.getName());
 
   private final BillingProjectAuditor billingProjectAuditor;
-  private final FirecloudMapper firecloudMapper;
+  private final FeaturedWorkspaceService featuredWorkspaceService;
   private final FireCloudService firecloudService;
+  private final FirecloudMapper firecloudMapper;
   private final ImpersonatedFirecloudService impersonatedFirecloudService;
   private final UserDao userDao;
   private final WorkspaceDao workspaceDao;
@@ -46,13 +48,15 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
   @Autowired
   public ImpersonatedWorkspaceServiceImpl(
       BillingProjectAuditor billingProjectAuditor,
-      FirecloudMapper firecloudMapper,
+      FeaturedWorkspaceService featuredWorkspaceService,
       FireCloudService firecloudService,
+      FirecloudMapper firecloudMapper,
       ImpersonatedFirecloudService impersonatedFirecloudService,
       UserDao userDao,
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper) {
     this.billingProjectAuditor = billingProjectAuditor;
+    this.featuredWorkspaceService = featuredWorkspaceService;
     this.firecloudMapper = firecloudMapper;
     this.firecloudService = firecloudService;
     this.impersonatedFirecloudService = impersonatedFirecloudService;
@@ -72,7 +76,9 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
     try {
       return workspaceMapper
           .toApiWorkspaceResponseList(
-              workspaceDao, impersonatedFirecloudService.getWorkspaces(dbUser))
+              workspaceDao,
+              impersonatedFirecloudService.getWorkspaces(dbUser),
+              featuredWorkspaceService)
           .stream()
           .filter(response -> response.getAccessLevel() == WorkspaceAccessLevel.OWNER)
           .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -250,14 +250,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             .getWorkspaceAsService(workspaceNamespace, workspaceFirecloudName)
             .getWorkspace();
 
-    boolean featureFlagForPublish =
-        workspaceConfigProvider.get().featureFlags.enablePublishedWorkspacesViaDb;
-
     Workspace workspace =
-        featureFlagForPublish
-            ? workspaceMapper.toApiWorkspace(
-                dbWorkspace, firecloudWorkspace, featuredWorkspaceService)
-            : workspaceMapper.toApiWorkspace(dbWorkspace, firecloudWorkspace);
+        workspaceMapper.toApiWorkspace(dbWorkspace, firecloudWorkspace, featuredWorkspaceService);
 
     return new WorkspaceAdminView()
         .workspace(workspace)
@@ -269,7 +263,9 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
   private WorkspaceAdminView getDeletedWorkspaceAdminView(DbWorkspace dbWorkspace) {
     return new WorkspaceAdminView()
-        .workspace(workspaceMapper.toApiWorkspace(dbWorkspace, new RawlsWorkspaceDetails()))
+        .workspace(
+            workspaceMapper.toApiWorkspace(
+                dbWorkspace, new RawlsWorkspaceDetails(), featuredWorkspaceService))
         .workspaceDatabaseId(dbWorkspace.getWorkspaceId())
         .activeStatus(dbWorkspace.getWorkspaceActiveStatusEnum());
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspaceOperation;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceOperation;
@@ -21,14 +22,20 @@ public interface WorkspaceOperationMapper {
       DbWorkspaceOperation source,
       WorkspaceDao workspaceDao,
       FireCloudService fireCloudService,
-      WorkspaceMapper workspaceMapper) {
+      WorkspaceMapper workspaceMapper,
+      FeaturedWorkspaceService featuredWorkspaceService) {
 
     WorkspaceOperation modelOperation = toModelWithoutWorkspace(source);
     // set the operation's workspace, if possible
     Optional.ofNullable(source.getWorkspaceId())
         .flatMap(
             workspaceId ->
-                getWorkspaceMaybe(workspaceId, workspaceDao, fireCloudService, workspaceMapper))
+                getWorkspaceMaybe(
+                    workspaceId,
+                    workspaceDao,
+                    fireCloudService,
+                    workspaceMapper,
+                    featuredWorkspaceService))
         .ifPresent(modelOperation::workspace);
 
     return modelOperation;
@@ -50,7 +57,8 @@ public interface WorkspaceOperationMapper {
       long workspaceId,
       WorkspaceDao workspaceDao,
       FireCloudService fireCloudService,
-      WorkspaceMapper workspaceMapper) {
+      WorkspaceMapper workspaceMapper,
+      FeaturedWorkspaceService featuredWorkspaceService) {
     return workspaceDao
         .findActiveByWorkspaceId(workspaceId)
         .flatMap(
@@ -61,6 +69,8 @@ public interface WorkspaceOperationMapper {
                     .map(
                         fcWorkspaceResponse ->
                             workspaceMapper.toApiWorkspace(
-                                dbWorkspace, fcWorkspaceResponse.getWorkspace())));
+                                dbWorkspace,
+                                fcWorkspaceResponse.getWorkspace(),
+                                featuredWorkspaceService)));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -141,7 +141,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public List<WorkspaceResponse> getWorkspaces() {
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspaces())
+        .toApiWorkspaceResponseList(
+            workspaceDao, fireCloudService.getWorkspaces(), featuredWorkspaceService)
         .stream()
         .filter(WorkspaceServiceImpl::filterToNonPublished)
         .toList();
@@ -156,7 +157,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public List<WorkspaceResponse> getPublishedWorkspaces() {
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspaces())
+        .toApiWorkspaceResponseList(
+            workspaceDao, fireCloudService.getWorkspaces(), featuredWorkspaceService)
         .stream()
         .filter(workspaceResponse -> workspaceResponse.getWorkspace().isPublished())
         .toList();
@@ -197,9 +199,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     workspaceResponse.setAccessLevel(
         firecloudMapper.fcToApiWorkspaceAccessLevel(fcResponse.getAccessLevel()));
     Workspace workspace =
-        workbenchConfigProvider.get().featureFlags.enablePublishedWorkspacesViaDb
-            ? workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService)
-            : workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
     workspaceResponse.setWorkspace(workspace);
 
     return workspaceResponse;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7164,6 +7164,10 @@ components:
         published:
           type: boolean
           default: false
+          description: indicates whether the workspace has been shared as READER to all Registered
+            Tier users.  Used in conjunction with FeaturedWorkspacesConfig to show Featured
+            Workspaces in the UI.  DEPRECATED in favor of featuredCategory when the Feature Flag
+            enablePublishedWorkspacesViaDb is set.
         featuredCategory:
           $ref: '#/components/schemas/FeaturedWorkspaceCategory'
           description: The name of the category in which the workspace is published

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -95,6 +95,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ConflictException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClient;
@@ -296,6 +297,7 @@ public class CohortReviewControllerTest {
     CloudStorageClient.class,
     DataSetService.class,
     DirectoryService.class,
+    FeaturedWorkspaceService.class,
     FireCloudService.class,
     FreeTierBillingService.class,
     IamService.class,

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -22,6 +22,7 @@ import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
 import org.pmiops.workbench.model.ResearchPurpose;
@@ -65,6 +66,8 @@ public class WorkspaceMapperTest {
   private RawlsWorkspaceDetails sourceFirecloudWorkspace;
 
   @Autowired private WorkspaceMapper workspaceMapper;
+
+  @MockBean private FeaturedWorkspaceService mockFeaturedWorkspaceService;
 
   @TestConfiguration
   @Import({
@@ -150,7 +153,8 @@ public class WorkspaceMapperTest {
   public void testConvertsDbToApiWorkspace() {
 
     final Workspace ws =
-        workspaceMapper.toApiWorkspace(sourceDbWorkspace, sourceFirecloudWorkspace);
+        workspaceMapper.toApiWorkspace(
+            sourceDbWorkspace, sourceFirecloudWorkspace, mockFeaturedWorkspaceService);
     assertThat(ws.getId()).isEqualTo(WORKSPACE_FIRECLOUD_NAME);
     assertThat(ws.getEtag()).isEqualTo(Etags.fromVersion(WORKSPACE_VERSION));
     assertThat(ws.getName()).isEqualTo(WORKSPACE_AOU_NAME);
@@ -173,7 +177,8 @@ public class WorkspaceMapperTest {
   public void testConvertsFirecloudResponseToApiResponse() {
     final WorkspaceResponse resp =
         workspaceMapper.toApiWorkspaceResponse(
-            workspaceMapper.toApiWorkspace(sourceDbWorkspace, sourceFirecloudWorkspace),
+            workspaceMapper.toApiWorkspace(
+                sourceDbWorkspace, sourceFirecloudWorkspace, mockFeaturedWorkspaceService),
             RawlsWorkspaceAccessLevel.PROJECT_OWNER);
 
     assertThat(resp.getAccessLevel()).isEqualTo(WorkspaceAccessLevel.OWNER);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
@@ -41,7 +41,7 @@ public class WorkspaceOperationMapperTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   @MockBean private FireCloudService mockFirecloudService;
-  @MockBean private FeaturedWorkspaceService featuredWorkspaceService;
+  @MockBean private FeaturedWorkspaceService mockFeaturedWorkspaceService;
 
   @TestConfiguration
   @Import({
@@ -112,7 +112,7 @@ public class WorkspaceOperationMapperTest {
                 workspaceDao,
                 mockFirecloudService,
                 workspaceMapper,
-                featuredWorkspaceService))
+                mockFeaturedWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -138,7 +138,7 @@ public class WorkspaceOperationMapperTest {
                 workspaceDao,
                 mockFirecloudService,
                 workspaceMapper,
-                featuredWorkspaceService))
+                mockFeaturedWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -165,7 +165,7 @@ public class WorkspaceOperationMapperTest {
                 workspaceDao,
                 mockFirecloudService,
                 workspaceMapper,
-                featuredWorkspaceService))
+                mockFeaturedWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -182,7 +182,7 @@ public class WorkspaceOperationMapperTest {
             workspaceDao,
             mockFirecloudService,
             workspaceMapper,
-            featuredWorkspaceService);
+            mockFeaturedWorkspaceService);
 
     assertThat(maybeWorkspace).hasValue(expectedWorkspace);
   }
@@ -191,7 +191,11 @@ public class WorkspaceOperationMapperTest {
   public void test_getWorkspaceMaybe_not_found() {
     assertThat(
             workspaceOperationMapper.getWorkspaceMaybe(
-                -1L, workspaceDao, mockFirecloudService, workspaceMapper, featuredWorkspaceService))
+                -1L,
+                workspaceDao,
+                mockFirecloudService,
+                workspaceMapper,
+                mockFeaturedWorkspaceService))
         .isEmpty();
   }
 
@@ -203,6 +207,6 @@ public class WorkspaceOperationMapperTest {
 
     when(mockFirecloudService.getWorkspace(namespace, fcName))
         .thenReturn(new RawlsWorkspaceResponse().workspace(fcWorkspace));
-    return workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
+    return workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, mockFeaturedWorkspaceService);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
@@ -13,6 +13,7 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceOperation;
 import org.pmiops.workbench.db.model.DbWorkspaceOperation.DbWorkspaceOperationStatus;
+import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
@@ -40,6 +41,7 @@ public class WorkspaceOperationMapperTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   @MockBean private FireCloudService mockFirecloudService;
+  @MockBean private FeaturedWorkspaceService featuredWorkspaceService;
 
   @TestConfiguration
   @Import({
@@ -106,7 +108,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                workspaceMapper,
+                featuredWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -128,7 +134,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                workspaceMapper,
+                featuredWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -151,7 +161,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                workspaceMapper,
+                featuredWorkspaceService))
         .isEqualTo(expectedOperation);
   }
 
@@ -164,7 +178,11 @@ public class WorkspaceOperationMapperTest {
 
     Optional<Workspace> maybeWorkspace =
         workspaceOperationMapper.getWorkspaceMaybe(
-            dbWorkspace.getWorkspaceId(), workspaceDao, mockFirecloudService, workspaceMapper);
+            dbWorkspace.getWorkspaceId(),
+            workspaceDao,
+            mockFirecloudService,
+            workspaceMapper,
+            featuredWorkspaceService);
 
     assertThat(maybeWorkspace).hasValue(expectedWorkspace);
   }
@@ -173,7 +191,7 @@ public class WorkspaceOperationMapperTest {
   public void test_getWorkspaceMaybe_not_found() {
     assertThat(
             workspaceOperationMapper.getWorkspaceMaybe(
-                -1L, workspaceDao, mockFirecloudService, workspaceMapper))
+                -1L, workspaceDao, mockFirecloudService, workspaceMapper, featuredWorkspaceService))
         .isEmpty();
   }
 
@@ -185,6 +203,6 @@ public class WorkspaceOperationMapperTest {
 
     when(mockFirecloudService.getWorkspace(namespace, fcName))
         .thenReturn(new RawlsWorkspaceResponse().workspace(fcWorkspace));
-    return workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    return workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, featuredWorkspaceService);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -646,7 +646,7 @@ public class WorkspaceServiceTest {
   }
 
   @Test
-  public void testGetWorkspace_PublishInformationFromDbFeaturedWorkspace() {
+  public void testGetWorkspace_featuredCategory() {
     // Arrange
     DbWorkspace dbWorkspace =
         buildDbWorkspace(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -648,7 +648,6 @@ public class WorkspaceServiceTest {
   @Test
   public void testGetWorkspace_PublishInformationFromDbFeaturedWorkspace() {
     // Arrange
-    workbenchConfig.featureFlags.enablePublishedWorkspacesViaDb = true;
     DbWorkspace dbWorkspace =
         buildDbWorkspace(
             workspaceIdIncrementer.getAndIncrement(),
@@ -673,14 +672,8 @@ public class WorkspaceServiceTest {
         workspaceService.getWorkspace(DEFAULT_WORKSPACE_NAMESPACE, dbWorkspace.getFirecloudName());
 
     // Assert
-    assertThat(response.getWorkspace().isPublished()).isTrue();
+    assertThat(response.getWorkspace().isPublished()).isFalse();
     assertThat(response.getWorkspace().getFeaturedCategory())
         .isEqualTo(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES);
-
-    workbenchConfig.featureFlags.enablePublishedWorkspacesViaDb = false;
-    response =
-        workspaceService.getWorkspace(DEFAULT_WORKSPACE_NAMESPACE, dbWorkspace.getFirecloudName());
-    assertThat(response.getWorkspace().isPublished()).isFalse();
-    assertThat(response.getWorkspace().getFeaturedCategory()).isNull();
   }
 }


### PR DESCRIPTION
Make the WorkspaceMapper work for both cases of the Feature Flag `enablePublishedWorkspacesViaDb` by separating the logic of the two cases with respect to Workspace: one uses `published` and the other uses `featuredCategory`.

Also deprecate `published`.

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
