### PR TITLE
[DT-827][risk=no] Clear error for valid variant searches

### DIFF
--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -310,6 +310,7 @@ export const VariantSearch = fp.flow(
           if (newInputErrors.length > 0) {
             setInputErrors(newInputErrors);
           } else {
+            setInputErrors([]);
             setLoading(true);
             setSearching(true);
             clearFilters(false);

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -335,6 +335,7 @@ export const VariantSearch = fp.flow(
     };
 
     const clearSearch = () => {
+      setInputErrors([]);
       setSearching(false);
       setSearchTerms('');
       setSearchResults([]);


### PR DESCRIPTION
Fix issue where the minimum length error still displays after a valid search or the search is cleared.