### PR TITLE
[risk=low][RW-13148] Small changes to Workspace Publish

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/FeaturedWorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/FeaturedWorkspaceDao.java
@@ -6,8 +6,5 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.springframework.data.repository.CrudRepository;
 
 public interface FeaturedWorkspaceDao extends CrudRepository<DbFeaturedWorkspace, Long> {
-
-  public Optional<DbFeaturedWorkspace> findByWorkspace(DbWorkspace workspace);
-
-  public boolean existsByWorkspace(DbWorkspace workspace);
+  Optional<DbFeaturedWorkspace> findByWorkspace(DbWorkspace workspace);
 }

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.featuredworkspace;
 
+import java.util.Optional;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 
@@ -7,5 +8,5 @@ public interface FeaturedWorkspaceService {
 
   boolean isFeaturedWorkspace(DbWorkspace dbWorkspace);
 
-  FeaturedWorkspaceCategory getFeaturedCategory(DbWorkspace dbWorkspace);
+  Optional<FeaturedWorkspaceCategory> getFeaturedCategory(DbWorkspace dbWorkspace);
 }

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
@@ -5,9 +5,5 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 
 public interface FeaturedWorkspaceService {
-
-  // TODO: not sure if we need this, if we have the other
-  boolean isFeaturedWorkspace(DbWorkspace dbWorkspace);
-
   Optional<FeaturedWorkspaceCategory> getFeaturedCategory(DbWorkspace dbWorkspace);
 }

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceService.java
@@ -6,6 +6,7 @@ import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 
 public interface FeaturedWorkspaceService {
 
+  // TODO: not sure if we need this, if we have the other
   boolean isFeaturedWorkspace(DbWorkspace dbWorkspace);
 
   Optional<FeaturedWorkspaceCategory> getFeaturedCategory(DbWorkspace dbWorkspace);

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
@@ -21,11 +21,6 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
   }
 
   @Override
-  public boolean isFeaturedWorkspace(DbWorkspace dbWorkspace) {
-    return featuredWorkspaceDao.existsByWorkspace(dbWorkspace);
-  }
-
-  @Override
   public Optional<FeaturedWorkspaceCategory> getFeaturedCategory(DbWorkspace dbWorkspace) {
     return featuredWorkspaceDao
         .findByWorkspace(dbWorkspace)

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
@@ -1,7 +1,7 @@
 package org.pmiops.workbench.featuredworkspace;
 
+import java.util.Optional;
 import org.pmiops.workbench.db.dao.FeaturedWorkspaceDao;
-import org.pmiops.workbench.db.model.DbFeaturedWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.utils.mappers.FeaturedWorkspaceMapper;
@@ -26,9 +26,12 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
   }
 
   @Override
-  public FeaturedWorkspaceCategory getFeaturedCategory(DbWorkspace dbWorkspace) {
-    DbFeaturedWorkspace dbFeaturedWorkspace =
-        featuredWorkspaceDao.findByWorkspace(dbWorkspace).orElseThrow();
-    return featuredWorkspaceMapper.toFeaturedWorkspaceCategory(dbFeaturedWorkspace.getCategory());
+  public Optional<FeaturedWorkspaceCategory> getFeaturedCategory(DbWorkspace dbWorkspace) {
+    return featuredWorkspaceDao
+        .findByWorkspace(dbWorkspace)
+        .map(
+            dbFeaturedWorkspace ->
+                featuredWorkspaceMapper.toFeaturedWorkspaceCategory(
+                    dbFeaturedWorkspace.getCategory()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -57,9 +57,7 @@ public interface WorkspaceMapper {
       DbWorkspace dbWorkspace,
       FeaturedWorkspaceService featuredWorkspaceService) {
     workspace.setFeaturedCategory(
-        featuredWorkspaceService.isFeaturedWorkspace(dbWorkspace)
-            ? featuredWorkspaceService.getFeaturedCategory(dbWorkspace).orElse(null)
-            : null);
+        featuredWorkspaceService.getFeaturedCategory(dbWorkspace).orElse(null));
   }
 
   @Mapping(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -58,7 +58,7 @@ public interface WorkspaceMapper {
       FeaturedWorkspaceService featuredWorkspaceService) {
     workspace.setFeaturedCategory(
         featuredWorkspaceService.isFeaturedWorkspace(dbWorkspace)
-            ? featuredWorkspaceService.getFeaturedCategory(dbWorkspace)
+            ? featuredWorkspaceService.getFeaturedCategory(dbWorkspace).orElse(null)
             : null);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -431,7 +431,13 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   @Override
   public void publishWorkspaceViaDB(
       String workspaceNamespace, PublishWorkspaceRequest publishWorkspaceRequest) {
-    final DbWorkspace dbWorkspace = workspaceDao.getByNamespace(workspaceNamespace).orElseThrow();
+    final DbWorkspace dbWorkspace =
+        workspaceDao
+            .getByNamespace(workspaceNamespace)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        String.format("Workspace Namespace %s was not found", workspaceNamespace)));
 
     featuredWorkspaceDao
         .findByWorkspace(dbWorkspace)
@@ -495,7 +501,13 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
   @Override
   public void unpublishWorkspaceViaDB(String workspaceNamespace) {
-    final DbWorkspace dbWorkspace = workspaceDao.getByNamespace(workspaceNamespace).orElseThrow();
+    final DbWorkspace dbWorkspace =
+        workspaceDao
+            .getByNamespace(workspaceNamespace)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        String.format("Workspace Namespace %s was not found", workspaceNamespace)));
     Optional<DbFeaturedWorkspace> dbFeaturedWorkspaceOptional =
         featuredWorkspaceDao.findByWorkspace(dbWorkspace);
 

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.featuredworkspace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -91,6 +92,6 @@ public class FeaturedWorkspaceTest {
     when(mockFeaturedWorkspaceDao.findByWorkspace(dbWorkspace))
         .thenReturn(Optional.of(dbFeaturedWorkspace));
     assertThat(featuredWorkspaceService.getFeaturedCategory(dbWorkspace))
-        .isEqualTo(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES);
+        .hasValue(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -2,10 +2,8 @@ package org.pmiops.workbench.featuredworkspace;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,13 +71,8 @@ public class FeaturedWorkspaceTest {
   }
 
   @Test
-  public void testFeaturedCategory_ThrowExceptionIfWorkspaceDoesntExist() {
-    NoSuchElementException exception =
-        assertThrows(
-            NoSuchElementException.class,
-            () -> featuredWorkspaceService.getFeaturedCategory(dbWorkspace));
-
-    assertThat(exception.getMessage()).isEqualTo("No value present");
+  public void testFeaturedCategory_EmptyIfWorkspaceDoesntExist() {
+    assertThat(featuredWorkspaceService.getFeaturedCategory(dbWorkspace)).isEmpty();
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -59,18 +59,6 @@ public class FeaturedWorkspaceTest {
   }
 
   @Test
-  public void testIsFeaturedWorkspace_workspaceExist() {
-    when(mockFeaturedWorkspaceDao.existsByWorkspace(dbWorkspace)).thenReturn(true);
-    assertThat(featuredWorkspaceService.isFeaturedWorkspace(dbWorkspace)).isTrue();
-  }
-
-  @Test
-  public void testIsFeaturedWorkspace_workspaceDoesNotExist() {
-    when(mockFeaturedWorkspaceDao.existsByWorkspace(dbWorkspace)).thenReturn(false);
-    assertThat(featuredWorkspaceService.isFeaturedWorkspace(dbWorkspace)).isFalse();
-  }
-
-  @Test
   public void testFeaturedCategory_EmptyIfWorkspaceDoesntExist() {
     assertThat(featuredWorkspaceService.getFeaturedCategory(dbWorkspace)).isEmpty();
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -1,10 +1,12 @@
 package org.pmiops.workbench.utils.mappers;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.model.BillingStatus;
+import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
@@ -171,6 +174,18 @@ public class WorkspaceMapperTest {
 
     assertThat(ws.getCreationTime()).isEqualTo(DB_CREATION_TIMESTAMP.toInstant().toEpochMilli());
     assertThat(ws.isPublished()).isEqualTo(sourceDbWorkspace.getPublished());
+    assertThat(ws.getFeaturedCategory()).isNull();
+  }
+
+  @Test
+  public void testConvertsFeaturedWorkspace() {
+    when(mockFeaturedWorkspaceService.getFeaturedCategory(sourceDbWorkspace))
+        .thenReturn(Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
+
+    final Workspace ws =
+        workspaceMapper.toApiWorkspace(
+            sourceDbWorkspace, sourceFirecloudWorkspace, mockFeaturedWorkspaceService);
+    assertThat(ws.getFeaturedCategory()).isEqualTo(FeaturedWorkspaceCategory.COMMUNITY);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -333,7 +333,6 @@ public class WorkspaceAdminServiceTest {
 
   @Test
   public void testGetWorkspaceAdminView_featuredCategory() {
-    when(mockFeatureService.isFeaturedWorkspace(dbWorkspace)).thenReturn(true);
     when(mockFeatureService.getFeaturedCategory(dbWorkspace))
         .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
     WorkspaceAdminView workspaceDetailsResponse =

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -335,7 +335,7 @@ public class WorkspaceAdminServiceTest {
   public void testGetWorkspaceAdminView_featuredCategory() {
     when(mockFeatureService.isFeaturedWorkspace(dbWorkspace)).thenReturn(true);
     when(mockFeatureService.getFeaturedCategory(dbWorkspace))
-        .thenReturn(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES.TUTORIAL_WORKSPACES);
+        .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
     WorkspaceAdminView workspaceDetailsResponse =
         workspaceAdminService.getWorkspaceAdminView(WORKSPACE_NAMESPACE);
     assertThat(workspaceDetailsResponse.getWorkspace().getNamespace())

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
@@ -665,7 +666,7 @@ public class WorkspaceServiceTest {
         .thenReturn(Collections.singletonList(AccessTierService.CONTROLLED_TIER_SHORT_NAME));
     when(mockFeaturedWorkspaceService.isFeaturedWorkspace(any())).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(any()))
-        .thenReturn(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES);
+        .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
 
     // Act
     WorkspaceResponse response =
@@ -686,7 +687,7 @@ public class WorkspaceServiceTest {
     // set all workspaces as featured
     when(mockFeaturedWorkspaceService.isFeaturedWorkspace(any())).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(any()))
-        .thenReturn(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES);
+        .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
 
     var result = workspaceService.getFeaturedWorkspaces();
     assertThat(result).hasSize(dbWorkspaces.size());
@@ -699,7 +700,7 @@ public class WorkspaceServiceTest {
 
     when(mockFeaturedWorkspaceService.isFeaturedWorkspace(testWorkspace)).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(testWorkspace))
-        .thenReturn(FeaturedWorkspaceCategory.DEMO_PROJECTS);
+        .thenReturn(Optional.of(FeaturedWorkspaceCategory.DEMO_PROJECTS));
 
     var result = workspaceService.getFeaturedWorkspaces();
     assertThat(result).hasSize(1);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -664,7 +664,6 @@ public class WorkspaceServiceTest {
 
     when(accessTierService.getAccessTierShortNamesForUser(dbWorkspace.getCreator()))
         .thenReturn(Collections.singletonList(AccessTierService.CONTROLLED_TIER_SHORT_NAME));
-    when(mockFeaturedWorkspaceService.isFeaturedWorkspace(any())).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(any()))
         .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
 
@@ -685,7 +684,6 @@ public class WorkspaceServiceTest {
     assertThat(before).isEmpty();
 
     // set all workspaces as featured
-    when(mockFeaturedWorkspaceService.isFeaturedWorkspace(any())).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(any()))
         .thenReturn(Optional.of(FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES));
 
@@ -698,7 +696,6 @@ public class WorkspaceServiceTest {
     // arbitrary choice from dbWorkspaces
     var testWorkspace = dbWorkspaces.get(2);
 
-    when(mockFeaturedWorkspaceService.isFeaturedWorkspace(testWorkspace)).thenReturn(true);
     when(mockFeaturedWorkspaceService.getFeaturedCategory(testWorkspace))
         .thenReturn(Optional.of(FeaturedWorkspaceCategory.DEMO_PROJECTS));
 


### PR DESCRIPTION
Does not resolve RW-13148.  Some fixes for small problems I noticed.

Change 500s to 404s
Optional<FeaturedWorkspaceCategory> getFeaturedCategory

Tested locally by calling endpoints and interacting with workspaces in the UI

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
