### PR TITLE
[risk=low][RW-13148] Enable publish/unpublish of featured workspaces when not owner

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -96,6 +96,9 @@ public interface FireCloudService {
   RawlsWorkspaceACLUpdateResponseList updateWorkspaceACL(
       String workspaceNamespace, String firecloudName, List<RawlsWorkspaceACLUpdate> aclUpdates);
 
+  RawlsWorkspaceACLUpdateResponseList updateWorkspaceACLAsService(
+      String workspaceNamespace, String firecloudName, List<RawlsWorkspaceACLUpdate> aclUpdates);
+
   RawlsWorkspaceResponse getWorkspaceAsService(String workspaceNamespace, String firecloudName);
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -379,6 +379,14 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
+  public RawlsWorkspaceACL getWorkspaceAclAsService(
+      String workspaceNamespace, String firecloudName) {
+    WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
+    return rawlsRetryHandler.run(
+        (context) -> workspacesApi.getACL(workspaceNamespace, firecloudName));
+  }
+
+  @Override
   public RawlsWorkspaceACLUpdateResponseList updateWorkspaceACL(
       String workspaceNamespace, String firecloudName, List<RawlsWorkspaceACLUpdate> aclUpdates) {
     WorkspacesApi workspacesApi = endUserWorkspacesApiProvider.get();
@@ -387,11 +395,11 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
-  public RawlsWorkspaceACL getWorkspaceAclAsService(
-      String workspaceNamespace, String firecloudName) {
+  public RawlsWorkspaceACLUpdateResponseList updateWorkspaceACLAsService(
+      String workspaceNamespace, String firecloudName, List<RawlsWorkspaceACLUpdate> aclUpdates) {
     WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
     return rawlsRetryHandler.run(
-        (context) -> workspacesApi.getACL(workspaceNamespace, firecloudName));
+        (context) -> workspacesApi.updateACL(aclUpdates, workspaceNamespace, firecloudName, false));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -554,7 +554,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     var aclUpdate =
         FirecloudTransforms.buildAclUpdate(
             workspaceService.getPublishedWorkspacesGroupEmail(), accessLevel);
-    fireCloudService.updateWorkspaceACL(workspaceNamespace, firecloudName, List.of(aclUpdate));
+    fireCloudService.updateWorkspaceACLAsService(
+        workspaceNamespace, firecloudName, List.of(aclUpdate));
   }
 
   private List<DbUser> getWorkspaceOwnerList(DbWorkspace dbWorkspace) {


### PR DESCRIPTION
Publish/unpublish did not work when the workspace was not owned by the admin user.  We require Owner to publish old-style featured workspaces, but we do not want to require this in the new process.

Instead of calling "update Terra ACL" as the admin user, call it as the RWB system itself, which will always have the appropriate access to do this.

Tested locally by publishing/unpublishing workspaces which are owned by my user and not owned by my user.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
