### PR TITLE
[risk=low][no ticket] Check the Java version before loading plugins

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,6 +3,20 @@ import org.pmiops.workbench.tooling.GenerateAPIListingTask
 // Runs before all tasks. Sets up properties and dependencies for the build
 // process itself.
 buildscript {
+    // keep in sync with:
+    // the runtime field in api/src/main/webapp/WEB-INF/appengine-web.xml.template
+    // the Docker image in ci/Dockerfile.circle_build
+    // the Docker image in deploy/Dockerfile
+    // in this file:
+    // * sourceCompatibility
+    // * targetCompatibility
+    if (JavaVersion.current() != JavaVersion.VERSION_17) {
+        throw new GradleException(
+                "This build must be run with Java 17. " +
+                        "See developer-system-initialization.md. " +
+                        "The java version used was ${JavaVersion.current()}.")
+    }
+
     // External properties on the default project. Values declared in ext blocks
     // outside of the buildscript block aren't usable here.
     ext {
@@ -53,20 +67,6 @@ plugins {
     id 'org.owasp.dependencycheck' version '8.4.2'
     id 'org.springframework.boot' version '3.2.4'
     id 'jacoco'
-}
-
-// keep in sync with:
-// the runtime field in api/src/main/webapp/WEB-INF/appengine-web.xml.template
-// the Docker image in ci/Dockerfile.circle_build
-// the Docker image in deploy/Dockerfile
-// in this file:
-// * sourceCompatibility
-// * targetCompatibility
-if (JavaVersion.current() != JavaVersion.VERSION_17) {
-     throw new GradleException(
-            "This build must be run with Java 17. " +
-                    "See developer-system-initialization.md. " +
-                    "The java version used was ${JavaVersion.current()}.")
 }
 
 if (System.getenv("ADD_XLINT_DEPRECATION")) {


### PR DESCRIPTION
Building our Java project produces an ugly error message when the wrong Java version is used, because we load plugins which are incompatible with older version of Java.

Moving the check earlier restores the friendly behavior.
```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/thibault/src/aou/api/build.gradle' line: 17

* What went wrong:
A problem occurred evaluating root project 'api'.
> This build must be run with Java 17. See developer-system-initialization.md. The java version used was 11.
```

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
