### PR TITLE
[risk=low][no ticket] Add displayName and terraName to Workspace API entity, and deprecate id and name

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -35,11 +35,17 @@ import org.pmiops.workbench.workspaces.resources.WorkspaceResourceMapper;
       WorkspaceResourceMapper.class,
     })
 public interface WorkspaceMapper {
+
+  // DEPRECATED and subject to deletion.  Use terraName instead.
+  @Mapping(target = "id", source = "fcWorkspace.name")
+  // DEPRECATED and subject to deletion.
+  // Make an explicit choice to use either displayName for UI or terraName for Terra calls.
+  @Mapping(target = "name", source = "dbWorkspace.name")
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
   @Mapping(target = "etag", source = "dbWorkspace.version", qualifiedByName = "versionToEtag")
-  @Mapping(target = "name", source = "dbWorkspace.name")
   @Mapping(target = "namespace", source = "dbWorkspace.workspaceNamespace")
-  @Mapping(target = "id", source = "fcWorkspace.name")
+  @Mapping(target = "displayName", source = "dbWorkspace.name")
+  @Mapping(target = "terraName", source = "fcWorkspace.name")
   @Mapping(target = "googleBucketName", source = "fcWorkspace.bucketName")
   @Mapping(target = "creator", source = "dbWorkspace.creator.username")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
@@ -100,6 +106,8 @@ public interface WorkspaceMapper {
   @Mapping(target = "otherDisseminateResearchFindings", source = "disseminateResearchOther")
   ResearchPurpose workspaceToResearchPurpose(DbWorkspace dbWorkspace);
 
+  // DEPRECATED and subject to deletion.  Use terraName instead.
+  @Mapping(target = "id", source = "firecloudName")
   @Mapping(target = "cdrVersionId", source = "cdrVersion")
   @Mapping(target = "creator", source = "creator.username")
   @Mapping(target = "etag", source = "version", qualifiedByName = "versionToEtag")
@@ -107,7 +115,8 @@ public interface WorkspaceMapper {
       target = "googleBucketName",
       ignore = true) // available via toApiWorkspace(DbWorkspace dbWorkspace, RawlsWorkspaceDetails
   // fcWorkspace)
-  @Mapping(target = "id", source = "firecloudName")
+  @Mapping(target = "displayName", source = "name")
+  @Mapping(target = "terraName", source = "firecloudName")
   @Mapping(target = "namespace", source = "workspaceNamespace")
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
   @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7148,6 +7148,9 @@ components:
       properties:
         id:
           type: string
+          description: DEPRECATED. This "id" refers to the name of the workspace in Terra.
+           Terra does not refer to this as an "id" and we should stop doing this.
+           Renamed to the more accurate "terraName" - use this instead.
         etag:
           type: string
           description: Entity tag for optimistic concurrency control. To be set during
@@ -7155,8 +7158,25 @@ components:
             a changed resource.
         name:
           type: string
+          description: DEPRECATED. A workspace has both an AoU UI name (displayName) and a
+           terraName.  Use one of these to be explicit about which is desired.
+        displayName:
+          type: string
+          description: The name of the workspace as displayed in the UI.  This name is not known to
+           Terra, so it's necessary to use `terraName` and/or `namespace` for Terra calls.
+           Formerly known simply as "name".
         namespace:
           type: string
+        terraName:
+          type: string
+          description: >
+           The name of this workspace as stored in Terra.  This is also part of the
+           workspace component of the URL, and is therefore user-visible.
+           Formerly known as "id" in some contexts, but this was confusing because this does not
+           refer to the AoU or Terra database IDs corresponding to the workspace.
+           When a workspace is initially created, this is equal to the "slugified" version of
+           displayName (example: "My Workspace" becomes "myworkspace"). However, when the
+           workspace is renamed (in the AoU RWB UI) the terraName does not change.
         cdrVersionId:
           type: string
         creator:

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
@@ -1090,6 +1089,7 @@ public class WorkspacesControllerTest {
         .updateBillingAccount(ws.getNamespace(), ws.getBillingAccountName());
 
     ws.setName("updated-name");
+    ws.setDisplayName("updated-name");
     UpdateWorkspaceRequest request = new UpdateWorkspaceRequest();
     ws.setBillingAccountName("update-billing-account");
     request.setWorkspace(ws);
@@ -1098,13 +1098,11 @@ public class WorkspacesControllerTest {
     ws.setEtag(updated.getEtag());
     assertThat(updated).isEqualTo(ws);
 
-    ArgumentCaptor<String> projectCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<ProjectBillingInfo> billingCaptor =
-        ArgumentCaptor.forClass(ProjectBillingInfo.class);
     verify(fireCloudService, times(1))
         .updateBillingAccount(ws.getNamespace(), "update-billing-account");
 
     ws.setName("updated-name2");
+    ws.setDisplayName("updated-name2");
     updated =
         workspacesController.updateWorkspace(ws.getNamespace(), ws.getId(), request).getBody();
     ws.setEtag(updated.getEtag());


### PR DESCRIPTION
This is part of my long-running "Don't use `ID` to refer to Terra Names" campaign.  There will be many other changes following this one.

No observable changes in the UI, as expected.  The API returns the new `terraName` and `displayName` fields, as expected:
```
"workspace": {
        "id": "ctjun13",
        "etag": "\"1\"",
        "name": "CT Jun 13",
        "displayName": "CT Jun 13",
        "namespace": "aou-rw-local1-c5c09753",
        "terraName": "ctjun13",
        "cdrVersionId": "8",
      ...
```
---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
