### PR TITLE
[risk=low][RW-13149] Update Workspace publish/unpublish email content and logic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -71,7 +71,18 @@ public interface MailService {
   void sendFileLengthsEgressRemediationEmail(DbUser dbUser, EgressRemediationAction action)
       throws MessagingException;
 
-  void sendPublishUnpublishWorkspaceEmail(
+  /**
+   * Sends emails to workspace owners notifying them that a workspace has been published or
+   * unpublished. Note that it sends one email per owner, in order to address them in text
+   * individually.
+   *
+   * @param workspace the workspace being modified
+   * @param owners the workspace's owners
+   * @param publish whether the workspace is being published or unpublished
+   * @param publishCategory the category the workspace is being published to, if applicable
+   * @throws MessagingException
+   */
+  void sendPublishUnpublishWorkspaceEmails(
       DbWorkspace workspace,
       List<DbUser> owners,
       boolean publish,

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -4,12 +4,10 @@ import jakarta.annotation.Nullable;
 import jakarta.mail.MessagingException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
-import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 
 public interface MailService {
@@ -72,20 +70,25 @@ public interface MailService {
       throws MessagingException;
 
   /**
-   * Sends emails to workspace owners notifying them that a workspace has been published or
-   * unpublished. Note that it sends one email per owner, in order to address them in text
+   * Sends emails to workspace owners notifying them that a workspace has been published as a
+   * Community Workspace. Note that it sends one email per owner, in order to address them in text
    * individually.
    *
-   * @param workspace the workspace being modified
+   * @param workspace the workspace being published as a Community Workspace
    * @param owners the workspace's owners
-   * @param publish whether the workspace is being published or unpublished
-   * @param publishCategory the category the workspace is being published to, if applicable
    * @throws MessagingException
    */
-  void sendPublishUnpublishWorkspaceEmails(
-      DbWorkspace workspace,
-      List<DbUser> owners,
-      boolean publish,
-      Optional<FeaturedWorkspaceCategory> publishCategory)
+  void sendPublishCommunityWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
+      throws MessagingException;
+
+  /**
+   * Sends emails to workspace owners notifying them that a workspace has been unpublished. Note
+   * that it sends one email per owner, in order to address them in text individually.
+   *
+   * @param workspace the workspace being unpublished
+   * @param owners the workspace's owners
+   * @throws MessagingException
+   */
+  void sendAdminUnpublishWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
       throws MessagingException;
 }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 import jakarta.mail.MessagingException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
@@ -70,10 +71,10 @@ public interface MailService {
   void sendFileLengthsEgressRemediationEmail(DbUser dbUser, EgressRemediationAction action)
       throws MessagingException;
 
-  void sendPublishWorkspaceEmail(
-      final DbWorkspace workspace, List<DbUser> owners, FeaturedWorkspaceCategory publishCategory)
-      throws MessagingException;
-
-  void sendUnpublishWorkspaceByAdminEmail(final DbWorkspace workspace, List<DbUser> owners)
+  void sendPublishUnpublishWorkspaceEmail(
+      DbWorkspace workspace,
+      List<DbUser> owners,
+      boolean publish,
+      Optional<FeaturedWorkspaceCategory> publishCategory)
       throws MessagingException;
 }

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -659,6 +659,8 @@ public class MailServiceImpl implements MailService {
     return new ImmutableMap.Builder<EmailSubstitutionField, String>()
         .put(EmailSubstitutionField.HEADER_IMG, getAllOfUsLogo())
         .put(EmailSubstitutionField.ALL_OF_US, getAllOfUsItalicsText())
+        .put(EmailSubstitutionField.FIRST_NAME, user.getGivenName())
+        .put(EmailSubstitutionField.LAST_NAME, user.getFamilyName())
         .put(EmailSubstitutionField.WORKSPACE_NAME, workspace.getName())
         .put(EmailSubstitutionField.WORKSPACE_NAMESPACE, workspace.getWorkspaceNamespace())
         .put(EmailSubstitutionField.PUBLISH_CATEGORY, publishCategory)

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -96,7 +96,8 @@ public class MailServiceImpl implements MailService {
   private static final String WORKSPACE_ADMIN_LOCKING_RESOURCE =
       "emails/workspace_admin_locking/content.html";
 
-  private static final String PUBLISH_WORKSPACE_RESOURCE = "emails/publish_workspace/content.html";
+  private static final String PUBLISH_COMMUNITY_WORKSPACE_RESOURCE =
+      "emails/publish_community_workspace/content.html";
 
   private static final String UNPUBLISH_WORKSPACE_RESOURCE =
       "emails/unpublish_workspace/content.html";
@@ -391,24 +392,14 @@ public class MailServiceImpl implements MailService {
   public void sendPublishCommunityWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
       throws MessagingException {
     sendPublishUnpublishWorkspaceEmails(
-        workspace,
-        owners,
-        PUBLISH_WORKSPACE_RESOURCE,
-        "Publish",
-        "published",
-        Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
+        workspace, owners, PUBLISH_COMMUNITY_WORKSPACE_RESOURCE, "Publish", "published");
   }
 
   @Override
   public void sendAdminUnpublishWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
       throws MessagingException {
     sendPublishUnpublishWorkspaceEmails(
-        workspace,
-        owners,
-        UNPUBLISH_WORKSPACE_RESOURCE,
-        "Unpublish",
-        "unpublished",
-        Optional.empty());
+        workspace, owners, UNPUBLISH_WORKSPACE_RESOURCE, "Unpublish", "unpublished");
   }
 
   private void sendPublishUnpublishWorkspaceEmails(
@@ -416,8 +407,7 @@ public class MailServiceImpl implements MailService {
       List<DbUser> owners,
       String emailResource,
       String presentTenseCapitalized,
-      String pastTense,
-      Optional<FeaturedWorkspaceCategory> publishCategory)
+      String pastTense)
       throws MessagingException {
     final String supportEmail = workbenchConfigProvider.get().mandrill.fromEmail;
 
@@ -434,8 +424,7 @@ public class MailServiceImpl implements MailService {
               owner.getContactEmail()),
           buildHtml(
               emailResource,
-              publishUnpublishWorkspaceSubstitutionMap(
-                  workspace, owner, publishCategory, supportEmail)));
+              publishUnpublishWorkspaceSubstitutionMap(workspace, owner, supportEmail)));
     }
   }
 
@@ -667,26 +656,16 @@ public class MailServiceImpl implements MailService {
   }
 
   private Map<EmailSubstitutionField, String> publishUnpublishWorkspaceSubstitutionMap(
-      DbWorkspace workspace,
-      DbUser user,
-      Optional<FeaturedWorkspaceCategory> publishCategory,
-      String supportEmail) {
-    var builder =
-        new ImmutableMap.Builder<EmailSubstitutionField, String>()
-            .put(EmailSubstitutionField.HEADER_IMG, getAllOfUsLogo())
-            .put(EmailSubstitutionField.ALL_OF_US, getAllOfUsItalicsText())
-            .put(EmailSubstitutionField.FIRST_NAME, user.getGivenName())
-            .put(EmailSubstitutionField.LAST_NAME, user.getFamilyName())
-            .put(EmailSubstitutionField.WORKSPACE_NAME, workspace.getName())
-            .put(EmailSubstitutionField.WORKSPACE_NAMESPACE, workspace.getWorkspaceNamespace())
-            .put(EmailSubstitutionField.SUPPORT_EMAIL, supportEmail);
-
-    publishCategory.ifPresent(
-        category ->
-            builder.put(
-                EmailSubstitutionField.PUBLISH_CATEGORY,
-                featuredWorkspaceCategoryAsDisplayString(category)));
-    return builder.build();
+      DbWorkspace workspace, DbUser user, String supportEmail) {
+    return new ImmutableMap.Builder<EmailSubstitutionField, String>()
+        .put(EmailSubstitutionField.HEADER_IMG, getAllOfUsLogo())
+        .put(EmailSubstitutionField.ALL_OF_US, getAllOfUsItalicsText())
+        .put(EmailSubstitutionField.FIRST_NAME, user.getGivenName())
+        .put(EmailSubstitutionField.LAST_NAME, user.getFamilyName())
+        .put(EmailSubstitutionField.WORKSPACE_NAME, workspace.getName())
+        .put(EmailSubstitutionField.WORKSPACE_NAMESPACE, workspace.getWorkspaceNamespace())
+        .put(EmailSubstitutionField.SUPPORT_EMAIL, supportEmail)
+        .build();
   }
 
   private String buildHtml(

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -392,24 +392,22 @@ public class MailServiceImpl implements MailService {
   public void sendPublishCommunityWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
       throws MessagingException {
     sendPublishUnpublishWorkspaceEmails(
-        workspace, owners, PUBLISH_COMMUNITY_WORKSPACE_RESOURCE, "Publish", "published");
+        workspace, owners, PUBLISH_COMMUNITY_WORKSPACE_RESOURCE, "publish");
   }
 
   @Override
   public void sendAdminUnpublishWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
       throws MessagingException {
     sendPublishUnpublishWorkspaceEmails(
-        workspace, owners, UNPUBLISH_WORKSPACE_RESOURCE, "Unpublish", "unpublished");
+        workspace, owners, UNPUBLISH_WORKSPACE_RESOURCE, "unpublish");
   }
 
   private void sendPublishUnpublishWorkspaceEmails(
-      DbWorkspace workspace,
-      List<DbUser> owners,
-      String emailResource,
-      String presentTenseCapitalized,
-      String pastTense)
+      DbWorkspace workspace, List<DbUser> owners, String emailResource, String actionPresentTense)
       throws MessagingException {
     final String supportEmail = workbenchConfigProvider.get().mandrill.fromEmail;
+    final String presentTenseCapitalized = StringUtils.capitalize(actionPresentTense);
+    final String pastTense = actionPresentTense.toLowerCase() + "ed";
 
     for (DbUser owner : owners) {
       sendWithRetries(

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -394,19 +394,22 @@ public class MailServiceImpl implements MailService {
 
     String supportEmail = workbenchConfigProvider.get().mandrill.fromEmail;
 
-    sendWithRetries(
-        ownersEmailList(owners),
-        Collections.singletonList(supportEmail),
-        "Your AoU Researcher Workbench workspace has been published",
-        String.format(
-            "Publish workspace email for workspace '%s' (%s) sent to owners %s",
-            workspace.getName(), workspace.getWorkspaceNamespace(), ownersForLogging(owners)),
-        buildHtml(
-            PUBLISH_WORKSPACE_RESOURCE,
-            publishUnpublishWorkspaceSubstitutionMap(
-                workspace,
-                featuredWorkspaceCategoryAsDisplayString(publishCategory),
-                supportEmail)));
+    for (DbUser owner : owners) {
+      sendWithRetries(
+          List.of(owner.getContactEmail()),
+          Collections.singletonList(supportEmail),
+          "Your AoU Researcher Workbench workspace has been published",
+          String.format(
+              "Publish workspace email for workspace '%s' (%s) sent to owners %s",
+              workspace.getName(), workspace.getWorkspaceNamespace(), ownersForLogging(owners)),
+          buildHtml(
+              PUBLISH_WORKSPACE_RESOURCE,
+              publishUnpublishWorkspaceSubstitutionMap(
+                  workspace,
+                  owner,
+                  featuredWorkspaceCategoryAsDisplayString(publishCategory),
+                  supportEmail)));
+    }
   }
 
   @Override
@@ -415,16 +418,18 @@ public class MailServiceImpl implements MailService {
 
     String supportEmail = workbenchConfigProvider.get().mandrill.fromEmail;
 
-    sendWithRetries(
-        ownersEmailList(owners),
-        Collections.singletonList(supportEmail),
-        "Your AoU Researcher Workbench workspace has been Unpublished",
-        String.format(
-            "Unpublish workspace by admin email for workspace '%s' (%s) sent to owners %s",
-            workspace.getName(), workspace.getWorkspaceNamespace(), ownersForLogging(owners)),
-        buildHtml(
-            UNPUBLISH_WORKSPACE_RESOURCE,
-            publishUnpublishWorkspaceSubstitutionMap(workspace, "", supportEmail)));
+    for (DbUser owner : owners) {
+      sendWithRetries(
+          List.of(owner.getContactEmail()),
+          Collections.singletonList(supportEmail),
+          "Your AoU Researcher Workbench workspace has been Unpublished",
+          String.format(
+              "Unpublish workspace by admin email for workspace '%s' (%s) sent to owners %s",
+              workspace.getName(), workspace.getWorkspaceNamespace(), ownersForLogging(owners)),
+          buildHtml(
+              UNPUBLISH_WORKSPACE_RESOURCE,
+              publishUnpublishWorkspaceSubstitutionMap(workspace, owner, "", supportEmail)));
+    }
   }
 
   private String featuredWorkspaceCategoryAsDisplayString(
@@ -655,7 +660,7 @@ public class MailServiceImpl implements MailService {
   }
 
   private Map<EmailSubstitutionField, String> publishUnpublishWorkspaceSubstitutionMap(
-      DbWorkspace workspace, String publishCategory, String supportEmail) {
+      DbWorkspace workspace, DbUser user, String publishCategory, String supportEmail) {
     return new ImmutableMap.Builder<EmailSubstitutionField, String>()
         .put(EmailSubstitutionField.HEADER_IMG, getAllOfUsLogo())
         .put(EmailSubstitutionField.ALL_OF_US, getAllOfUsItalicsText())

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -388,7 +388,7 @@ public class MailServiceImpl implements MailService {
   }
 
   @Override
-  public void sendPublishUnpublishWorkspaceEmail(
+  public void sendPublishUnpublishWorkspaceEmails(
       DbWorkspace workspace,
       List<DbUser> owners,
       boolean publish,

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -388,17 +388,38 @@ public class MailServiceImpl implements MailService {
   }
 
   @Override
-  public void sendPublishUnpublishWorkspaceEmails(
+  public void sendPublishCommunityWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
+      throws MessagingException {
+    sendPublishUnpublishWorkspaceEmails(
+        workspace,
+        owners,
+        PUBLISH_WORKSPACE_RESOURCE,
+        "Publish",
+        "published",
+        Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
+  }
+
+  @Override
+  public void sendAdminUnpublishWorkspaceEmails(DbWorkspace workspace, List<DbUser> owners)
+      throws MessagingException {
+    sendPublishUnpublishWorkspaceEmails(
+        workspace,
+        owners,
+        UNPUBLISH_WORKSPACE_RESOURCE,
+        "Unpublish",
+        "unpublished",
+        Optional.empty());
+  }
+
+  private void sendPublishUnpublishWorkspaceEmails(
       DbWorkspace workspace,
       List<DbUser> owners,
-      boolean publish,
+      String emailResource,
+      String presentTenseCapitalized,
+      String pastTense,
       Optional<FeaturedWorkspaceCategory> publishCategory)
       throws MessagingException {
     final String supportEmail = workbenchConfigProvider.get().mandrill.fromEmail;
-
-    final String resource = publish ? PUBLISH_WORKSPACE_RESOURCE : UNPUBLISH_WORKSPACE_RESOURCE;
-    final String presentTenseCapitalized = publish ? "Publish" : "Unpublish";
-    final String pastTense = publish ? "published" : "unpublished";
 
     for (DbUser owner : owners) {
       sendWithRetries(
@@ -412,7 +433,7 @@ public class MailServiceImpl implements MailService {
               workspace.getWorkspaceNamespace(),
               owner.getContactEmail()),
           buildHtml(
-              resource,
+              emailResource,
               publishUnpublishWorkspaceSubstitutionMap(
                   workspace, owner, publishCategory, supportEmail)));
     }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -526,11 +526,11 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       DbWorkspace dbWorkspace, boolean published, FeaturedWorkspaceCategory category) {
     final List<DbUser> owners = workspaceService.getWorkspaceOwnerList(dbWorkspace);
     try {
-      if (published) {
-        mailService.sendPublishWorkspaceEmail(dbWorkspace, owners, category);
-      } else {
-        mailService.sendUnpublishWorkspaceByAdminEmail(dbWorkspace, owners);
-      }
+      mailService.sendPublishUnpublishWorkspaceEmail(
+          dbWorkspace,
+          owners,
+          published,
+          published ? Optional.ofNullable(category) : Optional.empty());
     } catch (final MessagingException e) {
       log.log(Level.WARNING, e.getMessage());
     }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -526,7 +526,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       DbWorkspace dbWorkspace, boolean published, FeaturedWorkspaceCategory category) {
     final List<DbUser> owners = workspaceService.getWorkspaceOwnerList(dbWorkspace);
     try {
-      mailService.sendPublishUnpublishWorkspaceEmail(
+      mailService.sendPublishUnpublishWorkspaceEmails(
           dbWorkspace,
           owners,
           published,

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -526,11 +526,15 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       DbWorkspace dbWorkspace, boolean published, FeaturedWorkspaceCategory category) {
     final List<DbUser> owners = workspaceService.getWorkspaceOwnerList(dbWorkspace);
     try {
-      mailService.sendPublishUnpublishWorkspaceEmails(
-          dbWorkspace,
-          owners,
-          published,
-          published ? Optional.ofNullable(category) : Optional.empty());
+      if(published && category.equals(FeaturedWorkspaceCategory.COMMUNITY)) {
+        mailService.sendPublishCommunityWorkspaceEmails(
+            dbWorkspace,
+            owners);
+      } else if (!published) {
+        mailService.sendAdminUnpublishWorkspaceEmails(
+            dbWorkspace,
+            owners);
+      }
     } catch (final MessagingException e) {
       log.log(Level.WARNING, e.getMessage());
     }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -432,7 +432,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     featuredWorkspaceDao
         .findByWorkspace(dbWorkspace)
         .ifPresentOrElse(
-            (dbFeaturedWorkspace) -> {
+            dbFeaturedWorkspace -> {
               // Check if category in database is same as requested: If true do nothing, else update
               // database
               DbFeaturedCategory requestedCategory =
@@ -485,8 +485,18 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         String.format(
             "Workspace %s has been published by Admin", dbWorkspace.getWorkspaceNamespace()));
 
-    // Send Email to all workspace owners to let them know Workspace has been published
-    sendEmailToWorkspaceOwners(dbWorkspace, true, requestedCategory);
+    // send an email to all workspace owners to let them know that the workspace has been
+    // published, but only if it's a newly published Community Workspace
+
+    if (requestedCategory.equals(FeaturedWorkspaceCategory.COMMUNITY)
+        && prevCategoryIfAny == null) {
+      try {
+        mailService.sendPublishCommunityWorkspaceEmails(
+            dbWorkspace, workspaceService.getWorkspaceOwnerList(dbWorkspace));
+      } catch (final MessagingException e) {
+        log.log(Level.WARNING, e.getMessage());
+      }
+    }
   }
 
   @Override
@@ -502,7 +512,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         featuredWorkspaceDao.findByWorkspace(dbWorkspace);
 
     dbFeaturedWorkspaceOptional.ifPresentOrElse(
-        (dbFeaturedWorkspace) -> {
+        dbFeaturedWorkspace -> {
           String featuredCategory = dbFeaturedWorkspace.getCategory().toString();
 
           fireCloudService.updateWorkspaceAclForPublishing(
@@ -513,31 +523,17 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
           log.info(String.format("Workspace %s has been Unpublished by Admin", workspaceNamespace));
 
           // Send email to all workspace owners to let them know workspace has been unpublished
-          sendEmailToWorkspaceOwners(dbWorkspace, false, null);
+          try {
+            mailService.sendAdminUnpublishWorkspaceEmails(
+                dbWorkspace, workspaceService.getWorkspaceOwnerList(dbWorkspace));
+          } catch (final MessagingException e) {
+            log.log(Level.WARNING, e.getMessage());
+          }
         },
-        () -> {
-          // If there is no entry in featuredWorkspace table i.e workspace has been unpublished do
-          // nothing
-          log.warning(String.format("Workspace %s is already Unpublished", workspaceNamespace));
-        });
-  }
-
-  private void sendEmailToWorkspaceOwners(
-      DbWorkspace dbWorkspace, boolean published, FeaturedWorkspaceCategory category) {
-    final List<DbUser> owners = workspaceService.getWorkspaceOwnerList(dbWorkspace);
-    try {
-      if(published && category.equals(FeaturedWorkspaceCategory.COMMUNITY)) {
-        mailService.sendPublishCommunityWorkspaceEmails(
-            dbWorkspace,
-            owners);
-      } else if (!published) {
-        mailService.sendAdminUnpublishWorkspaceEmails(
-            dbWorkspace,
-            owners);
-      }
-    } catch (final MessagingException e) {
-      log.log(Level.WARNING, e.getMessage());
-    }
+        () ->
+            // If there is no entry in featuredWorkspace table i.e workspace has been unpublished do
+            // nothing
+            log.warning(String.format("Workspace %s is already Unpublished", workspaceNamespace)));
   }
 
   // NOTE: may be an undercount since we only retrieve the first Page of Storage List results

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -527,10 +527,11 @@ public class WorkspaceServiceImpl implements WorkspaceService {
               featuredWorkspaceDao.save(dbFeaturedWorkspaceToSave);
 
               try {
-                mailService.sendPublishUnpublishWorkspaceEmail(
+                boolean publish = true;
+                mailService.sendPublishUnpublishWorkspaceEmails(
                     dbWorkspace,
                     getWorkspaceOwnerList(dbWorkspace),
-                    true,
+                    publish,
                     Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
               } catch (MessagingException e) {
                 log.log(Level.WARNING, e.getMessage());

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -513,7 +513,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     featuredWorkspaceDao
         .findByWorkspace(dbWorkspace)
         .ifPresentOrElse(
-            (dbFeaturedWorkspace) -> {
+            dbFeaturedWorkspace -> {
               // Throw exception if workspace is already Published
               throw new BadRequestException("Workspace is already published");
             },
@@ -527,10 +527,11 @@ public class WorkspaceServiceImpl implements WorkspaceService {
               featuredWorkspaceDao.save(dbFeaturedWorkspaceToSave);
 
               try {
-                mailService.sendPublishWorkspaceEmail(
+                mailService.sendPublishUnpublishWorkspaceEmail(
                     dbWorkspace,
                     getWorkspaceOwnerList(dbWorkspace),
-                    FeaturedWorkspaceCategory.COMMUNITY);
+                    true,
+                    Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
               } catch (MessagingException e) {
                 log.log(Level.WARNING, e.getMessage());
               }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -527,7 +527,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
               featuredWorkspaceDao.save(dbFeaturedWorkspaceToSave);
 
               try {
-                mailService.sendPublishCommunityWorkspaceEmails(dbWorkspace, getWorkspaceOwnerList(dbWorkspace));
+                mailService.sendPublishCommunityWorkspaceEmails(
+                    dbWorkspace, getWorkspaceOwnerList(dbWorkspace));
               } catch (MessagingException e) {
                 log.log(Level.WARNING, e.getMessage());
               }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -527,12 +527,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
               featuredWorkspaceDao.save(dbFeaturedWorkspaceToSave);
 
               try {
-                boolean publish = true;
-                mailService.sendPublishUnpublishWorkspaceEmails(
-                    dbWorkspace,
-                    getWorkspaceOwnerList(dbWorkspace),
-                    publish,
-                    Optional.of(FeaturedWorkspaceCategory.COMMUNITY));
+                mailService.sendPublishCommunityWorkspaceEmails(dbWorkspace, getWorkspaceOwnerList(dbWorkspace));
               } catch (MessagingException e) {
                 log.log(Level.WARNING, e.getMessage());
               }

--- a/api/src/main/resources/emails/publish_community_workspace/content.html
+++ b/api/src/main/resources/emails/publish_community_workspace/content.html
@@ -15,16 +15,21 @@
     div {
       margin-bottom: 1rem;
     }
+    .workspace {
+      font-weight: bold;
+    }
   </style>
 </head>
 <body>
 <div><img src="${HEADER_IMG}"></div>
 <div>Hello ${FIRST_NAME} ${LAST_NAME},</div>
-<div>This is a notification that your workspace '${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE}) is now
+<div>This is a notification that your workspace
+  <span class="workspace">'${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE})</span> is now
   published as a Community Workspace.</div>
 <div>Please visit the ‘Community Workspaces’ section in the ${ALL_OF_US} Researcher
   Workbench to see your workspace included among others from the Workbench community.</div>
 <div>Questions? Contact our support team by using the Help Desk widget in the Workbench or by
   emailing ${SUPPORT_EMAIL}.</div>
-<div>The ${ALL_OF_US} Researcher Workbench support Team </div>
+<div>Best,</div>
+<div>The ${ALL_OF_US} Researcher Workbench Support Team</div>
 </body>

--- a/api/src/main/resources/emails/publish_community_workspace/content.html
+++ b/api/src/main/resources/emails/publish_community_workspace/content.html
@@ -21,8 +21,8 @@
 <div><img src="${HEADER_IMG}"></div>
 <div>Hello ${FIRST_NAME} ${LAST_NAME},</div>
 <div>This is a notification that your workspace '${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE}) is now
-  published as a ${PUBLISH_CATEGORY} workspace.</div>
-<div>Please visit the ‘${PUBLISH_CATEGORY} Workspaces’ section in the ${ALL_OF_US} Researcher
+  published as a Community Workspace.</div>
+<div>Please visit the ‘Community Workspaces’ section in the ${ALL_OF_US} Researcher
   Workbench to see your workspace included among others from the Workbench community.</div>
 <div>Questions? Contact our support team by using the Help Desk widget in the Workbench or by
   emailing ${SUPPORT_EMAIL}.</div>

--- a/api/src/main/resources/emails/publish_workspace/content.html
+++ b/api/src/main/resources/emails/publish_workspace/content.html
@@ -29,9 +29,10 @@
 <div>We are writing to you on behalf of the ${ALL_OF_US} Research Program’s Researcher Workbench
   Support team. A workspace you own titled
   <span class="workspace">'${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE})</span> has been
-  published  by ${ALL_OF_US} support team under ${PUBLISH_CATEGORY} category</div>
+  published by the ${ALL_OF_US} support team under the ${PUBLISH_CATEGORY} category.</div>
 
-<div>If you have any questions or want to Un-publish your workspace, please contact the ${ALL_OF_US} ${SUPPORT_EMAIL}.</div>
+<div>If you have any questions or want to Un-publish your workspace, please contact the ${ALL_OF_US}
+  Support team at ${SUPPORT_EMAIL}.</div>
 <div>Best,</div>
 <div>The ${ALL_OF_US} Researcher Workbench Support Team </div>
 </body>

--- a/api/src/main/resources/emails/publish_workspace/content.html
+++ b/api/src/main/resources/emails/publish_workspace/content.html
@@ -15,24 +15,16 @@
     div {
       margin-bottom: 1rem;
     }
-    .workspace {
-      font-weight: bold;
-    }
-    .CTA {
-      font-weight: bold;
-    }
   </style>
 </head>
 <body>
 <div><img src="${HEADER_IMG}"></div>
-<div>Hello,</div>
-<div>We are writing to you on behalf of the ${ALL_OF_US} Research Program’s Researcher Workbench
-  Support team. A workspace you own titled
-  <span class="workspace">'${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE})</span> has been
-  published by the ${ALL_OF_US} support team under the ${PUBLISH_CATEGORY} category.</div>
-
-<div>If you have any questions or want to Un-publish your workspace, please contact the ${ALL_OF_US}
-  Support team at ${SUPPORT_EMAIL}.</div>
-<div>Best,</div>
-<div>The ${ALL_OF_US} Researcher Workbench Support Team </div>
+<div>Hello ${FIRST_NAME} ${LAST_NAME},</div>
+<div>This is a notification that your workspace '${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE}) is now
+  published as a ${PUBLISH_CATEGORY} workspace.</div>
+<div>Please visit the ‘${PUBLISH_CATEGORY} Workspaces’ section in the ${ALL_OF_US} Researcher
+  Workbench to see your workspace included among others from the Workbench community.</div>
+<div>Questions? Contact our support team by using the Help Desk widget in the Workbench or by
+  emailing ${SUPPORT_EMAIL}.</div>
+<div>The ${ALL_OF_US} Researcher Workbench support Team </div>
 </body>

--- a/api/src/main/resources/emails/unpublish_workspace/content.html
+++ b/api/src/main/resources/emails/unpublish_workspace/content.html
@@ -29,7 +29,7 @@
 <div>We are writing to you on behalf of the ${ALL_OF_US} Research Program’s Researcher Workbench
   Support team. A workspace you own titled
   <span class="workspace">'${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE})</span> has been
-  un-published  by ${ALL_OF_US} Support team</div>
+  un-published by the ${ALL_OF_US} Support team.</div>
 
 <div>If you have any questions or want to publish your workspace again, please contact the ${ALL_OF_US}
   Support team at ${SUPPORT_EMAIL}.</div>

--- a/api/src/main/resources/emails/unpublish_workspace/content.html
+++ b/api/src/main/resources/emails/unpublish_workspace/content.html
@@ -18,14 +18,11 @@
     .workspace {
       font-weight: bold;
     }
-    .CTA {
-      font-weight: bold;
-    }
   </style>
 </head>
 <body>
 <div><img src="${HEADER_IMG}"></div>
-<div>Hello,</div>
+<div>Hello ${FIRST_NAME} ${LAST_NAME},</div>
 <div>We are writing to you on behalf of the ${ALL_OF_US} Research Program’s Researcher Workbench
   Support team. A workspace you own titled
   <span class="workspace">'${WORKSPACE_NAME}' (${WORKSPACE_NAMESPACE})</span> has been

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -574,14 +574,12 @@ public class WorkspaceAdminServiceTest {
     DbWorkspace mockDbWorkspace = workspaceDao.save(stubWorkspace("ns", "n"));
 
     DbFeaturedWorkspace mockFeaturedWorkspace =
-        new DbFeaturedWorkspace()
-            .setWorkspace(mockDbWorkspace)
-            .setCategory(dbCategory);
+        new DbFeaturedWorkspace().setWorkspace(mockDbWorkspace).setCategory(dbCategory);
 
     when(mockFeaturedWorkspaceDao.save(any())).thenReturn(mockFeaturedWorkspace);
 
     when(mockFeaturedWorkspaceMapper.toDbFeaturedWorkspace(
-        any(PublishWorkspaceRequest.class), any(DbWorkspace.class)))
+            any(PublishWorkspaceRequest.class), any(DbWorkspace.class)))
         .thenReturn(mockFeaturedWorkspace);
 
     // Act
@@ -593,10 +591,7 @@ public class WorkspaceAdminServiceTest {
     // Assert
     verify(mockFeaturedWorkspaceDao).save(any());
     verify(mockAdminAuditor)
-        .firePublishWorkspaceAction(
-            mockDbWorkspace.getWorkspaceId(),
-            category.toString(),
-            null);
+        .firePublishWorkspaceAction(mockDbWorkspace.getWorkspaceId(), category.toString(), null);
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -586,8 +586,7 @@ public class WorkspaceAdminServiceTest {
             mockDbWorkspace.getWorkspaceId(),
             FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES.toString(),
             null);
-    boolean publish = true;
-    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
+    verify(mailService, never()).sendPublishCommunityWorkspaceEmails(any(), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 
@@ -633,8 +632,7 @@ public class WorkspaceAdminServiceTest {
             mockDbWorkspace.getWorkspaceId(),
             dbFeaturedWorkspaceToSave.getCategory().toString(),
             existingDbFeaturedWorkspace.getCategory().toString());
-    boolean publish = true;
-    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
+    verify(mailService, never()).sendPublishCommunityWorkspaceEmails(any(), any());
 
     // We should not update the ACL as we are just updating the category and the workspace is
     // already published
@@ -675,9 +673,7 @@ public class WorkspaceAdminServiceTest {
     verify(mockAdminAuditor, never())
         .firePublishWorkspaceAction(
             workspace.getWorkspaceId(), request.getCategory().toString(), "");
-    boolean publish = true;
-    verify(mailService, never())
-        .sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
+    verify(mailService, never()).sendPublishCommunityWorkspaceEmails(any(), any());
   }
 
   @Test
@@ -701,8 +697,7 @@ public class WorkspaceAdminServiceTest {
     verify(mockFeaturedWorkspaceDao).delete(any());
     verify(mockAdminAuditor)
         .fireUnpublishWorkspaceAction(mockDbWorkspace.getWorkspaceId(), "TUTORIAL_WORKSPACES");
-    boolean publish = false;
-    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
+    verify(mailService).sendAdminUnpublishWorkspaceEmails(any(), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -594,7 +594,7 @@ public class WorkspaceAdminServiceTest {
             FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES.toString(),
             null);
     boolean publish = true;
-    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
+    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 
@@ -643,7 +643,7 @@ public class WorkspaceAdminServiceTest {
             dbFeaturedWorkspaceToSave.getCategory().toString(),
             existingDbFeaturedWorkspace.getCategory().toString());
     boolean publish = true;
-    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
+    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
 
     // We should not update the ACL as we are just updating the category and the workspace is
     // already published
@@ -687,7 +687,7 @@ public class WorkspaceAdminServiceTest {
             workspace.getWorkspaceId(), request.getCategory().toString(), "");
     boolean publish = true;
     verify(mailService, never())
-        .sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
+        .sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
   }
 
   @Test
@@ -714,7 +714,7 @@ public class WorkspaceAdminServiceTest {
     verify(mockAdminAuditor)
         .fireUnpublishWorkspaceAction(mockDbWorkspace.getWorkspaceId(), "TUTORIAL_WORKSPACES");
     boolean publish = false;
-    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
+    verify(mailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -592,7 +593,8 @@ public class WorkspaceAdminServiceTest {
             mockDbWorkspace.getWorkspaceId(),
             FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES.toString(),
             null);
-    verify(mailService).sendPublishWorkspaceEmail(any(), any(), any());
+    boolean publish = true;
+    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 
@@ -640,7 +642,8 @@ public class WorkspaceAdminServiceTest {
             mockDbWorkspace.getWorkspaceId(),
             dbFeaturedWorkspaceToSave.getCategory().toString(),
             existingDbFeaturedWorkspace.getCategory().toString());
-    verify(mailService).sendPublishWorkspaceEmail(any(), any(), any());
+    boolean publish = true;
+    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
 
     // We should not update the ACL as we are just updating the category and the workspace is
     // already published
@@ -682,7 +685,9 @@ public class WorkspaceAdminServiceTest {
     verify(mockAdminAuditor, never())
         .firePublishWorkspaceAction(
             workspace.getWorkspaceId(), request.getCategory().toString(), "");
-    verify(mailService, never()).sendPublishWorkspaceEmail(any(), any(), any());
+    boolean publish = true;
+    verify(mailService, never())
+        .sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
   }
 
   @Test
@@ -708,7 +713,8 @@ public class WorkspaceAdminServiceTest {
     verify(mockFeaturedWorkspaceDao).delete(any());
     verify(mockAdminAuditor)
         .fireUnpublishWorkspaceAction(mockDbWorkspace.getWorkspaceId(), "TUTORIAL_WORKSPACES");
-    verify(mailService).sendUnpublishWorkspaceByAdminEmail(any(), any());
+    boolean publish = false;
+    verify(mailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
 
     // verify that the ACL update was performed as the RWB system, not as the admin user
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -755,7 +755,7 @@ public class WorkspaceServiceTest {
     // Assert
     verify(mockFeaturedWorkspaceDao).save(any());
     boolean publish = true;
-    verify(mockMailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
+    verify(mockMailService).sendPublishCommunityWorkspaceEmails(any(), any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -755,7 +755,7 @@ public class WorkspaceServiceTest {
     // Assert
     verify(mockFeaturedWorkspaceDao).save(any());
     boolean publish = true;
-    verify(mockMailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
+    verify(mockMailService).sendPublishUnpublishWorkspaceEmails(any(), any(), eq(publish), any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -754,7 +754,8 @@ public class WorkspaceServiceTest {
 
     // Assert
     verify(mockFeaturedWorkspaceDao).save(any());
-    verify(mockMailService).sendPublishWorkspaceEmail(any(), any(), any());
+    boolean publish = true;
+    verify(mockMailService).sendPublishUnpublishWorkspaceEmail(any(), any(), eq(publish), any());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -754,7 +754,6 @@ public class WorkspaceServiceTest {
 
     // Assert
     verify(mockFeaturedWorkspaceDao).save(any());
-    boolean publish = true;
     verify(mockMailService).sendPublishCommunityWorkspaceEmails(any(), any());
   }
 


### PR DESCRIPTION
Update emails with text and logic as described in the Jira ticket.  Tested locally.

Publish Community Workspace
<img width="1145" alt="cw published" src="https://github.com/user-attachments/assets/4d861e5e-acfa-4e60-b9e0-ca751f057ff4">




Unpublish (any) kind of Featured Workspace
<img width="1149" alt="fw published" src="https://github.com/user-attachments/assets/a44b8564-fd61-423d-9cde-16ac04d948bf">


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
