### PR TITLE
[risk=low][RW-3890] Change UI uses of workspace.id to workspace.terraName

### DIFF
--- a/api-proxy/handlers/|v1|workspaces.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces.get.mjs
@@ -9,8 +9,10 @@ const body = JSON.stringify(
     {
       workspace: {
         id: 'mohstest',
+        terraName: 'mohstest',
         etag: '"4"',
         name: 'Mohs Test',
+        displayName: 'Mohs Test',
         namespace: 'aou-rw-test-53ff4756',
         cdrVersionId: '3',
         creator: 'dmohs@fake-research-aou.org',

--- a/api-proxy/handlers/|v1|workspaces|aou-rw-test-53ff4756|mohstest.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces|aou-rw-test-53ff4756|mohstest.get.mjs
@@ -5,10 +5,12 @@ const matchReq = req =>
 const body = JSON.stringify(
   {
     workspace:{
-      id:"testspace",
-      etag:"\"10\"",
-      name:"TestSpace",
       namespace:"aou-rw-local1-a312fa3d",
+      name:"TestSpace",
+      displayName:"TestSpace",
+      id:"testspace",
+      terraName:"testspace",
+      etag:"\"10\"",
       cdrVersionId:"3",
       creator:"evrii-local@fake-research-aou.org",
       billingAccountName:"billingAccounts/013713-75CFF6-1751E5",

--- a/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|testwsshare202207311932.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|testwsshare202207311932.get.mjs
@@ -7,8 +7,10 @@ const body = JSON.stringify(
 {
   workspace: {
     id: 'testwsshare202207311932',
+    terraName: 'testwsshare202207311932',
     etag: '"1"',
     name: 'test-ws-share-202207311932',
+    displayName: 'test-ws-share-202207311932',
     namespace: 'aou-rw-test-ca61ee0f',
     cdrVersionId: '3',
     creator: 'puppeteer-tester-7@fake-research-aou.org',

--- a/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|testwsshare202207311932|user-recent-workspaces|update.post.mjs
+++ b/api-proxy/handlers/|v1|workspaces|aou-rw-test-ca61ee0f|testwsshare202207311932|user-recent-workspaces|update.post.mjs
@@ -8,8 +8,10 @@ const body = JSON.stringify(
   {
     workspace: {
       id: 'testwsshare202207311932',
+      terraName: 'testwsshare202207311932',
       etag: '"1"',
       name: 'test-ws-share-202207311932',
+      displayName: 'test-ws-share-202207311932',
       namespace: 'aou-rw-test-ca61ee0f',
       cdrVersionId: '3',
       creator: 'puppeteer-tester-7@fake-research-aou.org',

--- a/api-proxy/handlers/|v1|workspaces|operations|25168.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces|operations|25168.get.mjs
@@ -9,8 +9,10 @@ const body = JSON.stringify(
   status: 'SUCCESS',
   workspace: {
     id: 'testwsshare202207311932',
+    terraName: 'testwsshare202207311932',
     etag: '"1"',
     name: 'test-ws-share-202207311932',
+    displayName: 'test-ws-share-202207311932',
     namespace: 'aou-rw-test-ca61ee0f',
     cdrVersionId: '3',
     creator: 'puppeteer-tester-7@fake-research-aou.org',

--- a/api-proxy/handlers/|v1|workspaces|user-recent-workspaces.get.mjs
+++ b/api-proxy/handlers/|v1|workspaces|user-recent-workspaces.get.mjs
@@ -8,8 +8,10 @@ const body = JSON.stringify(
   {
     workspace: {
       id: 'mohstest',
+      terraName: 'mohstest',
       etag: '"4"',
       name: 'Mohs Test',
+      displayName: 'Mohs Test',
       namespace: 'aou-rw-test-53ff4756',
       cdrVersionId: '3',
       creator: 'dmohs@fake-research-aou.org',

--- a/ui/src/app/components/apps-panel/expanded-app.spec.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.spec.tsx
@@ -406,7 +406,7 @@ describe('ExpandedApp', () => {
           expect(mockNavigate).toHaveBeenCalledWith([
             appDisplayPath(
               WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-              WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+              WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
               appType
             ),
           ]);

--- a/ui/src/app/components/apps-panel/expanded-app.tsx
+++ b/ui/src/app/components/apps-panel/expanded-app.tsx
@@ -176,9 +176,9 @@ const RStudioButtonRow = (props: {
 }) => {
   const { userApp, billingAccountDisabled } = props;
   const [navigate] = useNavigation();
-  const { namespace, id } = currentWorkspaceStore.getValue();
+  const { namespace, terraName } = currentWorkspaceStore.getValue();
   const onClickLaunch = async () => {
-    openAppInIframe(namespace, id, userApp, navigate);
+    openAppInIframe(namespace, terraName, userApp, navigate);
     sidebarActiveIconStore.next(null);
   };
   const launchButtonDisabled =
@@ -217,10 +217,10 @@ const SASButtonRow = (props: {
 }) => {
   const { userApp } = props;
   const [navigate] = useNavigation();
-  const { namespace, id } = currentWorkspaceStore.getValue();
+  const { namespace, terraName } = currentWorkspaceStore.getValue();
 
   const onClickLaunch = async () => {
-    openAppInIframe(namespace, id, userApp, navigate);
+    openAppInIframe(namespace, terraName, userApp, navigate);
     sidebarActiveIconStore.next(null);
   };
 

--- a/ui/src/app/components/apps-panel/new-jupyter-notebook-button.tsx
+++ b/ui/src/app/components/apps-panel/new-jupyter-notebook-button.tsx
@@ -18,7 +18,7 @@ export const NewJupyterNotebookButton = (props: { workspace: Workspace }) => {
 
   useEffect(() => {
     notebooksApi()
-      .getNoteBookList(workspace.namespace, workspace.id)
+      .getNoteBookList(workspace.namespace, workspace.terraName)
       .then((nbl) =>
         setNotebookNameList(
           nbl.map((fd) => dropJupyterNotebookFileSuffix(fd.name))

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -40,7 +40,7 @@ export const ConfigurationPanel = fp.flow(
     workspace: WorkspaceData;
     profileState: ProfileStore;
   }) => {
-    const { namespace, id } = workspace;
+    const { namespace, terraName } = workspace;
     const [creatorFreeCreditsRemaining, setCreatorFreeCreditsRemaining] =
       useState(null);
 
@@ -50,7 +50,7 @@ export const ConfigurationPanel = fp.flow(
         const { freeCreditsRemaining } =
           await workspacesApi().getWorkspaceCreatorFreeCreditsRemaining(
             namespace,
-            id,
+            terraName,
             { signal: aborter.signal }
           );
         setCreatorFreeCreditsRemaining(freeCreditsRemaining);

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -38,7 +38,7 @@ import { CopyModal, CopyModalProps } from './copy-modal';
 interface TestWorkspace {
   namespace: string;
   name: string;
-  id: string;
+  terraName: string;
   cdrVersionId: string;
   accessTierShortName: string;
 }
@@ -92,42 +92,42 @@ describe(CopyModal.name, () => {
     {
       namespace: defaultNamespace,
       name: 'Freerider',
-      id: 'freerider',
+      terraName: 'freerider',
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Registered,
     },
     {
       namespace: defaultNamespace,
       name: 'Dawn Wall',
-      id: 'dawn wall',
+      terraName: 'dawn wall',
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Registered,
     },
     {
       namespace: defaultNamespace,
       name: 'Zodiac',
-      id: 'zodiac',
+      terraName: 'zodiac',
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Registered,
     },
     {
       namespace: defaultNamespace,
       name: 'The Nose',
-      id: 'the nose',
+      terraName: 'the nose',
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Registered,
     },
     {
       namespace: altNamespace,
       name: 'Sesame Street',
-      id: 'sesame-street',
+      terraName: 'sesame-street',
       cdrVersionId: CdrVersionsStubVariables.ALT_WORKSPACE_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Registered,
     },
     {
       namespace: controlledNamespace,
       name: 'A tightly controlled workspace',
-      id: 'controlled-ws-1',
+      terraName: 'controlled-ws-1',
       cdrVersionId: CdrVersionsStubVariables.CONTROLLED_TIER_CDR_VERSION_ID,
       accessTierShortName: AccessTierShortNames.Controlled,
     },
@@ -141,7 +141,7 @@ describe(CopyModal.name, () => {
   const controlledCdrWorkspace = workspaces[5];
 
   const fromWorkspaceNamespace = ownerWorkspace.namespace;
-  const fromWorkspaceFirecloudName = ownerWorkspace.id;
+  const fromWorkspaceFirecloudName = ownerWorkspace.terraName;
   const fromCdrVersionId = ownerWorkspace.cdrVersionId;
   const fromAccessTierShortName = ownerWorkspace.accessTierShortName;
   const fromResourceName = 'notebook';
@@ -185,27 +185,27 @@ describe(CopyModal.name, () => {
       saveFunction: notebookSaveFunction,
     };
     wsApiStub.workspaceAccess.set(
-      ownerWorkspace.id,
+      ownerWorkspace.terraName,
       WorkspaceAccessLevel.OWNER
     );
     wsApiStub.workspaceAccess.set(
-      readerWorkspace.id,
+      readerWorkspace.terraName,
       WorkspaceAccessLevel.READER
     );
     wsApiStub.workspaceAccess.set(
-      writerWorkspace.id,
+      writerWorkspace.terraName,
       WorkspaceAccessLevel.WRITER
     );
     wsApiStub.workspaceAccess.set(
-      noAccessWorkspace.id,
+      noAccessWorkspace.terraName,
       WorkspaceAccessLevel.NO_ACCESS
     );
     wsApiStub.workspaceAccess.set(
-      altCdrWorkspace.id,
+      altCdrWorkspace.terraName,
       WorkspaceAccessLevel.WRITER
     );
     wsApiStub.workspaceAccess.set(
-      controlledCdrWorkspace.id,
+      controlledCdrWorkspace.terraName,
       WorkspaceAccessLevel.OWNER
     );
 
@@ -242,7 +242,7 @@ describe(CopyModal.name, () => {
   it('should list workspaces with the same CDR version first', async () => {
     // choose a workspace with an alternative CDR version instead of the default
     props.fromWorkspaceNamespace = altCdrWorkspace.namespace;
-    props.fromWorkspaceFirecloudName = altCdrWorkspace.id;
+    props.fromWorkspaceFirecloudName = altCdrWorkspace.terraName;
     props.fromCdrVersionId = altCdrWorkspace.cdrVersionId;
 
     component();
@@ -296,7 +296,7 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceFirecloudName,
       props.fromResourceName,
       {
-        toWorkspaceName: writerWorkspace.id,
+        toWorkspaceName: writerWorkspace.terraName,
         toWorkspaceNamespace: writerWorkspace.namespace,
         newName,
       }
@@ -335,7 +335,7 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceFirecloudName,
       props.fromResourceName,
       {
-        toWorkspaceName: altCdrWorkspace.id,
+        toWorkspaceName: altCdrWorkspace.terraName,
         toWorkspaceNamespace: altCdrWorkspace.namespace,
         newName,
       }
@@ -398,7 +398,7 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceFirecloudName,
       props.fromResourceName,
       {
-        toWorkspaceName: writerWorkspace.id,
+        toWorkspaceName: writerWorkspace.terraName,
         toWorkspaceNamespace: writerWorkspace.namespace,
         newName,
       }

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -141,14 +141,14 @@ describe(CopyModal.name, () => {
   const controlledCdrWorkspace = workspaces[5];
 
   const fromWorkspaceNamespace = ownerWorkspace.namespace;
-  const fromWorkspaceFirecloudName = ownerWorkspace.terraName;
+  const fromWorkspaceTerraName = ownerWorkspace.terraName;
   const fromCdrVersionId = ownerWorkspace.cdrVersionId;
   const fromAccessTierShortName = ownerWorkspace.accessTierShortName;
   const fromResourceName = 'notebook';
   const notebookSaveFunction = (copyRequest) => {
     return notebooksApi().copyNotebook(
       fromWorkspaceNamespace,
-      fromWorkspaceFirecloudName,
+      fromWorkspaceTerraName,
       dropJupyterNotebookFileSuffix(fromResourceName),
       copyRequest
     );
@@ -160,7 +160,7 @@ describe(CopyModal.name, () => {
     props.saveFunction = (copyRequest) => {
       return conceptSetsApi().copyConceptSet(
         props.fromWorkspaceNamespace,
-        props.fromWorkspaceFirecloudName,
+        props.fromWorkspaceTerraName,
         props.fromResourceName,
         copyRequest
       );
@@ -174,11 +174,11 @@ describe(CopyModal.name, () => {
     registerApiClient(ConceptSetsApi, new ConceptSetsApiStub());
 
     props = {
-      fromWorkspaceNamespace: fromWorkspaceNamespace,
-      fromWorkspaceFirecloudName: fromWorkspaceFirecloudName,
-      fromResourceName: fromResourceName,
-      fromCdrVersionId: fromCdrVersionId,
-      fromAccessTierShortName: fromAccessTierShortName,
+      fromWorkspaceNamespace,
+      fromWorkspaceTerraName,
+      fromResourceName,
+      fromCdrVersionId,
+      fromAccessTierShortName,
       resourceType: ResourceType.NOTEBOOK,
       onClose: () => {},
       onCopy: () => {},
@@ -242,7 +242,7 @@ describe(CopyModal.name, () => {
   it('should list workspaces with the same CDR version first', async () => {
     // choose a workspace with an alternative CDR version instead of the default
     props.fromWorkspaceNamespace = altCdrWorkspace.namespace;
-    props.fromWorkspaceFirecloudName = altCdrWorkspace.terraName;
+    props.fromWorkspaceTerraName = altCdrWorkspace.terraName;
     props.fromCdrVersionId = altCdrWorkspace.cdrVersionId;
 
     component();
@@ -293,7 +293,7 @@ describe(CopyModal.name, () => {
 
     expect(spy).toHaveBeenCalledWith(
       props.fromWorkspaceNamespace,
-      props.fromWorkspaceFirecloudName,
+      props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
         toWorkspaceName: writerWorkspace.terraName,
@@ -332,7 +332,7 @@ describe(CopyModal.name, () => {
 
     expect(spy).toHaveBeenCalledWith(
       props.fromWorkspaceNamespace,
-      props.fromWorkspaceFirecloudName,
+      props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
         toWorkspaceName: altCdrWorkspace.terraName,
@@ -395,7 +395,7 @@ describe(CopyModal.name, () => {
 
     expect(spy).toHaveBeenCalledWith(
       props.fromWorkspaceNamespace,
-      props.fromWorkspaceFirecloudName,
+      props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
         toWorkspaceName: writerWorkspace.terraName,

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -176,7 +176,7 @@ const CopyModal = withCdrVersions()(
     isDestinationSameWorkspace(workspace: Workspace): boolean {
       const { fromWorkspaceFirecloudName, fromWorkspaceNamespace } = this.props;
       return (
-        workspace.id === fromWorkspaceFirecloudName &&
+        workspace.terraName === fromWorkspaceFirecloudName &&
         workspace.namespace === fromWorkspaceNamespace
       );
     }
@@ -255,7 +255,7 @@ const CopyModal = withCdrVersions()(
       const { saveFunction, resourceType } = this.props;
 
       saveFunction({
-        toWorkspaceName: this.state.destination.id,
+        toWorkspaceName: this.state.destination.terraName,
         toWorkspaceNamespace: this.state.destination.namespace,
         newName: this.state.newName,
       })
@@ -344,13 +344,13 @@ const CopyModal = withCdrVersions()(
           </Button>
         );
       } else if (this.state.requestState === RequestState.SUCCESS) {
-        const { namespace, id } = this.state.destination;
+        const { namespace, terraName } = this.state.destination;
         return (
           <Button
             path={
               resourceType === ResourceType.NOTEBOOK
-                ? analysisTabPath(namespace, id)
-                : dataTabPath(namespace, id)
+                ? analysisTabPath(namespace, terraName)
+                : dataTabPath(namespace, terraName)
             }
             style={{ marginLeft: '0.75rem' }}
           >

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -41,7 +41,7 @@ enum RequestState {
 
 export interface CopyModalProps {
   fromWorkspaceNamespace: string;
-  fromWorkspaceFirecloudName: string;
+  fromWorkspaceTerraName: string;
   fromResourceName: string;
   fromCdrVersionId: string;
   fromAccessTierShortName: string;
@@ -174,9 +174,9 @@ const CopyModal = withCdrVersions()(
     }
 
     isDestinationSameWorkspace(workspace: Workspace): boolean {
-      const { fromWorkspaceFirecloudName, fromWorkspaceNamespace } = this.props;
+      const { fromWorkspaceTerraName, fromWorkspaceNamespace } = this.props;
       return (
-        workspace.terraName === fromWorkspaceFirecloudName &&
+        workspace.terraName === fromWorkspaceTerraName &&
         workspace.namespace === fromWorkspaceNamespace
       );
     }

--- a/ui/src/app/components/genomics-extraction-menu.spec.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.spec.tsx
@@ -185,7 +185,7 @@ describe(GenomicsExtractionMenu.name, () => {
       expect(abortSpy).toHaveBeenCalledTimes(1);
       expect(abortSpy).toHaveBeenCalledWith(
         WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-        WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+        WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
         genomicExtractionJobId.toString()
       );
     });

--- a/ui/src/app/components/genomics-extraction-menu.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.tsx
@@ -89,7 +89,7 @@ export const GenomicsExtractionMenu = ({
               onClick={async () => {
                 await dataSetApi().abortGenomicExtractionJob(
                   workspace.namespace,
-                  workspace.id,
+                  workspace.terraName,
                   job.genomicExtractionJobId.toString()
                 );
                 onMutate();

--- a/ui/src/app/components/genomics-extraction-table.tsx
+++ b/ui/src/app/components/genomics-extraction-table.tsx
@@ -212,7 +212,7 @@ export const GenomicsExtractionTable = fp.flow(withCurrentWorkspace())(
       data: jobs,
       error,
       mutate,
-    } = useGenomicExtractionJobs(workspace.namespace, workspace.id);
+    } = useGenomicExtractionJobs(workspace.namespace, workspace.terraName);
 
     return (
       <div

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.spec.tsx
@@ -83,7 +83,7 @@ describe(OpenGkeAppButton.name, () => {
         expect(mockNavigate).toHaveBeenCalledWith([
           appDisplayPath(
             WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-            WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+            WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
             appType
           ),
         ]);

--- a/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/open-gke-app-button.tsx
@@ -18,7 +18,7 @@ export interface OpenGkeAppButtonProps {
 export function OpenGkeAppButton({
   userApp,
   billingStatus,
-  workspace: { namespace, id },
+  workspace: { namespace, terraName },
   onClose,
   style,
 }: OpenGkeAppButtonProps) {
@@ -39,7 +39,7 @@ export function OpenGkeAppButton({
           id={`${appTypeString}-cloud-environment-open-button`}
           aria-label={`${appTypeString} cloud environment open button`}
           onClick={() => {
-            openAppInIframe(namespace, id, userApp, navigate);
+            openAppInIframe(namespace, terraName, userApp, navigate);
             onClose();
           }}
           disabled={!openEnabled}

--- a/ui/src/app/components/help-sidebar-icons.tsx
+++ b/ui/src/app/components/help-sidebar-icons.tsx
@@ -448,7 +448,10 @@ const DisplayIcon = (props: DisplayIconProps) => {
       'terminal',
       () => (
         <RouteLink
-          path={`${workspacePath(workspace.namespace, workspace.id)}/terminals`}
+          path={`${workspacePath(
+            workspace.namespace,
+            workspace.terraName
+          )}/terminals`}
         >
           <FontAwesomeIcon
             data-test-id={'help-sidebar-icon-' + icon.id}

--- a/ui/src/app/components/help-sidebar.tsx
+++ b/ui/src/app/components/help-sidebar.tsx
@@ -312,7 +312,7 @@ export const HelpSidebar = fp.flow(
         AnalyticsTracker.Workspaces.Delete();
         await workspacesApi().deleteWorkspace(
           this.props.workspace.namespace,
-          this.props.workspace.id
+          this.props.workspace.terraName
         );
         this.props.navigate(['workspaces']);
       }
@@ -728,7 +728,7 @@ export const HelpSidebar = fp.flow(
       } = this.state;
       const {
         workspace,
-        workspace: { namespace, id },
+        workspace: { namespace, terraName },
         pageKey,
         criteria,
       } = this.props;
@@ -771,7 +771,7 @@ export const HelpSidebar = fp.flow(
                         this.props.navigate([
                           'workspaces',
                           namespace,
-                          id,
+                          terraName,
                           'duplicate',
                         ]);
                       }}
@@ -780,7 +780,7 @@ export const HelpSidebar = fp.flow(
                         this.props.navigate([
                           'workspaces',
                           namespace,
-                          id,
+                          terraName,
                           'edit',
                         ]);
                       }}

--- a/ui/src/app/components/notebook-size-warning-modal.spec.tsx
+++ b/ui/src/app/components/notebook-size-warning-modal.spec.tsx
@@ -33,7 +33,7 @@ describe('Notebook Size Warning Modal', () => {
   const defaultProps: NotebookSizeWarningModalProps = {
     handleClose: () => {},
     namespace: 'mockNamespace',
-    firecloudName: 'mockfirecloudName',
+    terraName: 'mockTerraName',
     notebookName: 'mockNotebookName',
   };
 
@@ -76,7 +76,7 @@ describe('Notebook Size Warning Modal', () => {
     const expectedNavigation = [
       'workspaces',
       defaultProps.namespace,
-      defaultProps.firecloudName,
+      defaultProps.terraName,
       analysisTabName,
       defaultProps.notebookName,
     ];
@@ -91,7 +91,7 @@ describe('Notebook Size Warning Modal', () => {
     const expectedNavigation = [
       'workspaces',
       defaultProps.namespace,
-      defaultProps.firecloudName,
+      defaultProps.terraName,
       analysisTabName,
       defaultProps.notebookName,
     ];

--- a/ui/src/app/components/notebook-size-warning-modal.tsx
+++ b/ui/src/app/components/notebook-size-warning-modal.tsx
@@ -18,7 +18,7 @@ import { Spinner } from './spinners';
 export interface NotebookSizeWarningModalProps {
   handleClose: () => void;
   namespace: string;
-  firecloudName: string;
+  terraName: string;
   notebookName: string;
 }
 
@@ -27,14 +27,14 @@ const article =
 export const NotebookSizeWarningModal = ({
   handleClose,
   namespace,
-  firecloudName,
+  terraName,
   notebookName,
 }: NotebookSizeWarningModalProps) => {
   const [navigate] = useNavigation();
   const navigationPath = [
     'workspaces',
     namespace,
-    firecloudName,
+    terraName,
     analysisTabName,
     notebookName,
   ];

--- a/ui/src/app/components/resources/concept-set-action-menu.tsx
+++ b/ui/src/app/components/resources/concept-set-action-menu.tsx
@@ -175,7 +175,7 @@ export const ConceptSetActionMenu = fp.flow(
           {this.state.showCopyModal && (
             <CopyModal
               fromWorkspaceNamespace={resource.workspaceNamespace}
-              fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
+              fromWorkspaceTerraName={resource.workspaceFirecloudName}
               fromResourceName={resource.conceptSet.name}
               fromCdrVersionId={resource.cdrVersionId}
               fromAccessTierShortName={resource.accessTierShortName}

--- a/ui/src/app/components/resources/dataset-action-menu.tsx
+++ b/ui/src/app/components/resources/dataset-action-menu.tsx
@@ -200,7 +200,7 @@ export const DatasetActionMenu = fp.flow(
             <GenomicExtractionModal
               dataSet={resource.dataSet}
               workspaceNamespace={resource.workspaceNamespace}
-              workspaceFirecloudName={resource.workspaceFirecloudName}
+              workspaceTerraName={resource.workspaceFirecloudName}
               closeFunction={() =>
                 this.setState({ showGenomicExtractionModal: false })
               }

--- a/ui/src/app/components/resources/resource-list.tsx
+++ b/ui/src/app/components/resources/resource-list.tsx
@@ -67,13 +67,13 @@ interface NavProps {
 
 const WorkspaceNavigation = (props: NavProps) => {
   const {
-    workspace: { name, namespace, id },
+    workspace: { name, namespace, terraName },
     resource,
     style,
   } = props;
   const url = isNotebook(resource)
-    ? analysisTabPath(namespace, id)
-    : dataTabPath(namespace, id);
+    ? analysisTabPath(namespace, terraName)
+    : dataTabPath(namespace, terraName);
   return (
     <Clickable>
       <Link to={url} style={style} data-test-id='workspace-navigation'>

--- a/ui/src/app/components/runtime-configuration-panel/spark-console-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/spark-console-panel.tsx
@@ -41,7 +41,7 @@ const sparkLinkConfigs: {
   },
 ];
 
-export const SparkConsolePanel = ({ namespace, id }: WorkspaceData) => {
+export const SparkConsolePanel = ({ namespace, terraName }: WorkspaceData) => {
   return (
     <FlexColumn style={{ gap: '24px', paddingBottom: '10px' }}>
       <h3 style={{ ...styles.baseHeader, ...styles.bold }}>Spark Console</h3>
@@ -54,7 +54,7 @@ export const SparkConsolePanel = ({ namespace, id }: WorkspaceData) => {
           <div>{description}</div>
           <div>
             <RouteLink
-              path={`${workspacePath(namespace, id)}/spark/${path}`}
+              path={`${workspacePath(namespace, terraName)}/spark/${path}`}
               style={styles.sparkConsoleLaunchButton}
             >
               Launch

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -32,7 +32,7 @@ export const BasicInformation = ({
           {workspace.name}
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Terra Name (often incorrectly called "id")'>
-          {workspace.id}
+          {workspace.terraName}
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Workspace Namespace'>
           {workspace.namespace}

--- a/ui/src/app/pages/analysis/gke-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/gke-app-launcher.spec.tsx
@@ -53,7 +53,11 @@ const currentWorkspace = workspaceStubs[0];
 const createRoute = (appType: string) => (
   <MemoryRouter
     initialEntries={[
-      appDisplayPath(currentWorkspace.namespace, currentWorkspace.id, appType),
+      appDisplayPath(
+        currentWorkspace.namespace,
+        currentWorkspace.terraName,
+        appType
+      ),
     ]}
   >
     <Route path='/workspaces/:ns/:terraName/analysis/userApp/:appType'>
@@ -64,7 +68,7 @@ const createRoute = (appType: string) => (
 
 const pathToCurrentWSAnalysisTab = analysisTabPath(
   currentWorkspace.namespace,
-  currentWorkspace.id
+  currentWorkspace.terraName
 );
 
 const setup = (queryParam, userApps: UserAppEnvironment[] = defaultApps()) => {

--- a/ui/src/app/pages/analysis/gke-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/gke-app-launcher.tsx
@@ -31,8 +31,8 @@ export const GKEAppLauncher = fp.flow(withRouter)((props: Props) => {
     props.hideSpinner();
     // In case app is deleted redirect user to the analysis tab.
     if (!!userApp && userApp.status === AppStatus.DELETING) {
-      const { namespace, id } = currentWorkspaceStore.getValue();
-      navigate([analysisTabPath(namespace, id)]);
+      const { namespace, terraName } = currentWorkspaceStore.getValue();
+      navigate([analysisTabPath(namespace, terraName)]);
     }
   }, [userApp]);
 

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.spec.tsx
@@ -52,7 +52,10 @@ import { LeoRuntimesApiStub } from 'testing/stubs/leo-runtimes-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import { ProxyApiStub } from 'testing/stubs/proxy-api-stub';
 import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
-import { workspaceStubs } from 'testing/stubs/workspaces';
+import {
+  workspaceStubs,
+  WorkspaceStubVariables,
+} from 'testing/stubs/workspaces';
 
 function currentCardText() {
   return screen.getByTestId('current-progress-card').textContent;
@@ -517,8 +520,8 @@ describe('TerminalLauncher', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith([
         'workspaces',
-        'defaultNamespace',
-        '1',
+        WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
+        WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
         analysisTabName,
       ]);
     });

--- a/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
+++ b/ui/src/app/pages/analysis/leonardo-app-launcher.tsx
@@ -507,7 +507,7 @@ export const LeonardoAppLauncher = fp.flow(
         this.props.navigate([
           'workspaces',
           workspace.namespace,
-          workspace.id,
+          workspace.terraName,
           // navigate will encode the notebook name automatically
           analysisTabName,
           ...(this.props.leoAppType === LeoApplicationType.JupyterNotebook
@@ -570,7 +570,7 @@ export const LeonardoAppLauncher = fp.flow(
     }
 
     private async connectToRunningRuntime(runtime: Runtime) {
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       this.incrementProgress(Progress.Authenticating);
 
       const leoAppLocation = await this.getLeoAppPathAndLocalize(runtime);
@@ -578,7 +578,7 @@ export const LeonardoAppLauncher = fp.flow(
         window.history.replaceState(
           {},
           'Notebook',
-          `${analysisTabPath(namespace, id)}/${encodeURIComponent(
+          `${analysisTabPath(namespace, terraName)}/${encodeURIComponent(
             this.getFullJupyterNotebookName()
           )}`
         );

--- a/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
+++ b/ui/src/app/pages/analysis/new-jupyter-notebook-modal.tsx
@@ -63,14 +63,18 @@ export const NewJupyterNotebookModal = (props: Props) => {
   };
 
   const create = () => {
-    userMetricsApi().updateRecentResource(workspace.namespace, workspace.id, {
-      notebookName: appendJupyterNotebookFileSuffix(name),
-    });
+    userMetricsApi().updateRecentResource(
+      workspace.namespace,
+      workspace.terraName,
+      {
+        notebookName: appendJupyterNotebookFileSuffix(name),
+      }
+    );
     navigate(
       [
         'workspaces',
         workspace.namespace,
-        workspace.id,
+        workspace.terraName,
         analysisTabName,
         encodeURIComponent(name),
       ],

--- a/ui/src/app/pages/analysis/notebook-action-menu.tsx
+++ b/ui/src/app/pages/analysis/notebook-action-menu.tsx
@@ -186,7 +186,7 @@ export const NotebookActionMenu = fp.flow(
           {this.state.showCopyNotebookModal && (
             <CopyModal
               fromWorkspaceNamespace={resource.workspaceNamespace}
-              fromWorkspaceFirecloudName={resource.workspaceFirecloudName}
+              fromWorkspaceTerraName={resource.workspaceFirecloudName}
               fromResourceName={getDisplayName(resource)}
               fromCdrVersionId={resource.cdrVersionId}
               fromAccessTierShortName={resource.accessTierShortName}

--- a/ui/src/app/pages/analysis/util.ts
+++ b/ui/src/app/pages/analysis/util.ts
@@ -108,8 +108,8 @@ export const getAppInfoFromFileName = (name: string) => {
 };
 
 export const listNotebooks = (workspace: Workspace): Promise<FileDetail[]> => {
-  const { namespace, id } = workspace;
-  return notebooksApi().getNoteBookList(namespace, id);
+  const { namespace, terraName } = workspace;
+  return notebooksApi().getNoteBookList(namespace, terraName);
 };
 
 export const getExistingJupyterNotebookNames = async (

--- a/ui/src/app/pages/appAnalysis/app-files-list.spec.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.spec.tsx
@@ -113,7 +113,7 @@ describe(AppFilesList.name, () => {
 
     expect(notebookLink).toHaveAttribute(
       'href',
-      `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.id}/analysis/preview/${firstNotebook.name}`
+      `/workspaces/${workspaceDataStub.namespace}/${workspaceDataStub.terraName}/analysis/preview/${firstNotebook.name}`
     );
   });
 

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -273,7 +273,7 @@ export const AppFilesList = withCurrentWorkspace()(
         {showNotebookSizeWarningModal && (
           <NotebookSizeWarningModal
             namespace={workspace.namespace}
-            firecloudName={workspace.terraName}
+            terraName={workspace.terraName}
             notebookName={activeNotebookName}
             handleClose={() => {
               setShowNotebookSizeWarningModal(false);

--- a/ui/src/app/pages/appAnalysis/app-files-list.tsx
+++ b/ui/src/app/pages/appAnalysis/app-files-list.tsx
@@ -110,7 +110,7 @@ export const AppFilesList = withCurrentWorkspace()(
       },
       () =>
         workspacesApi()
-          .notebookTransferComplete(workspace.namespace, workspace.id)
+          .notebookTransferComplete(workspace.namespace, workspace.terraName)
           .then((isComplete) => {
             setIsTransferComplete(isComplete);
 
@@ -166,10 +166,10 @@ export const AppFilesList = withCurrentWorkspace()(
 
     const displayName = (row: FileDetail) => {
       const {
-        workspace: { namespace, id },
+        workspace: { namespace, terraName },
       } = props;
       const { name } = row;
-      const url = `${analysisTabPath(namespace, id)}/preview/${name}`;
+      const url = `${analysisTabPath(namespace, terraName)}/preview/${name}`;
       return row.sizeInBytes <= notebookSizeThreshold ? (
         <StyledRouterLink path={url} data-test-id='notebook-navigation'>
           {row.name}
@@ -273,7 +273,7 @@ export const AppFilesList = withCurrentWorkspace()(
         {showNotebookSizeWarningModal && (
           <NotebookSizeWarningModal
             namespace={workspace.namespace}
-            firecloudName={workspace.id}
+            firecloudName={workspace.terraName}
             notebookName={activeNotebookName}
             handleClose={() => {
               setShowNotebookSizeWarningModal(false);

--- a/ui/src/app/pages/appAnalysis/app-selector.tsx
+++ b/ui/src/app/pages/appAnalysis/app-selector.tsx
@@ -63,7 +63,7 @@ export const AppSelector = (props: AppSelectorProps) => {
         setVisibleModal(VisibleModal.None);
         openAppOrConfigPanel(
           workspace.namespace,
-          workspace.id,
+          workspace.terraName,
           userApps,
           selectedApp,
           navigate

--- a/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/annotation-definition-modals.component.tsx
@@ -77,14 +77,14 @@ export const AddAnnotationDefinitionModal = withRouter(
         const {
           onCreate,
           cohortId,
-          workspace: { namespace, id },
+          workspace: { namespace, terraName },
         } = this.props;
         const { name, annotationType, enumValues } = this.state;
         this.setState({ saving: true });
         const newDef =
           await cohortAnnotationDefinitionApi().createCohortAnnotationDefinition(
             namespace,
-            id,
+            terraName,
             cohortId,
             {
               cohortId: cohortId,

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -52,7 +52,7 @@ export const DetailPage = fp.flow(
 
     async componentDidMount() {
       const {
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
         hideSpinner,
       } = this.props;
       hideSpinner();
@@ -77,7 +77,7 @@ export const DetailPage = fp.flow(
         });
       }
       if (!vocabOptions.getValue()) {
-        getVocabOptions(namespace, id);
+        getVocabOptions(namespace, terraName);
       }
       this.updateParticipantStore();
       this.subscription = participantStore.subscribe((participant) =>

--- a/ui/src/app/pages/data/cohort-review/detail-page.tsx
+++ b/ui/src/app/pages/data/cohort-review/detail-page.tsx
@@ -18,20 +18,14 @@ import {
   vocabOptions,
 } from 'app/services/review-state.service';
 import { cohortReviewApi } from 'app/services/swagger-fetch-clients';
-import {
-  hasNewValidProps,
-  withCurrentCohortReview,
-  withCurrentWorkspace,
-} from 'app/utils';
+import { hasNewValidProps, withCurrentCohortReview } from 'app/utils';
 import { currentCohortReviewStore } from 'app/utils/navigation';
 import { MatchParams } from 'app/utils/stores';
-import { WorkspaceData } from 'app/utils/workspace-data';
 
 interface Props
   extends WithSpinnerOverlayProps,
     RouteComponentProps<MatchParams> {
   cohortReview: CohortReview;
-  workspace: WorkspaceData;
 }
 
 interface State {
@@ -40,7 +34,6 @@ interface State {
 
 export const DetailPage = fp.flow(
   withCurrentCohortReview(),
-  withCurrentWorkspace(),
   withRouter
 )(
   class extends React.Component<Props, State> {
@@ -51,10 +44,7 @@ export const DetailPage = fp.flow(
     }
 
     async componentDidMount() {
-      const {
-        workspace: { namespace, terraName },
-        hideSpinner,
-      } = this.props;
+      const { hideSpinner } = this.props;
       hideSpinner();
       let { cohortReview } = this.props;
       const { ns, terraName, crid } = this.props.match.params;
@@ -77,7 +67,7 @@ export const DetailPage = fp.flow(
         });
       }
       if (!vocabOptions.getValue()) {
-        getVocabOptions(namespace, terraName);
+        getVocabOptions(ns, terraName);
       }
       this.updateParticipantStore();
       this.subscription = participantStore.subscribe((participant) =>

--- a/ui/src/app/pages/data/cohort-review/participants-charts.tsx
+++ b/ui/src/app/pages/data/cohort-review/participants-charts.tsx
@@ -149,18 +149,18 @@ export const ParticipantsCharts = withCurrentWorkspace()(
         cohortReviewId,
         domain,
         searchRequest,
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
       } = this.props;
       const chartResponse = !!cohortReviewId
         ? await cohortReviewApi().getCohortReviewChartData(
             namespace,
-            id,
+            terraName,
             cohortReviewId,
             domain
           )
         : await cohortBuilderApi().getCohortChartData(
             namespace,
-            id,
+            terraName,
             domain,
             searchRequest
           );

--- a/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
+++ b/ui/src/app/pages/data/cohort-review/sidebar-content.component.tsx
@@ -158,7 +158,7 @@ const AnnotationItem = fp.flow(
           setAnnotation,
           cohortReview: { cohortReviewId },
           definition: { annotationType, cohortAnnotationDefinitionId },
-          workspace: { namespace, id },
+          workspace: { namespace, terraName },
           participantId,
         } = this.props;
         const { timeout } = this.state;
@@ -169,7 +169,7 @@ const AnnotationItem = fp.flow(
           setAnnotation(
             await cohortReviewApi().deleteParticipantCohortAnnotation(
               namespace,
-              id,
+              terraName,
               cohortReviewId,
               participantId,
               aid
@@ -181,7 +181,7 @@ const AnnotationItem = fp.flow(
           await cohortReviewApi()
             .updateParticipantCohortAnnotation(
               namespace,
-              id,
+              terraName,
               cohortReviewId,
               participantId,
               aid,
@@ -199,7 +199,7 @@ const AnnotationItem = fp.flow(
           await cohortReviewApi()
             .createParticipantCohortAnnotation(
               namespace,
-              id,
+              terraName,
               cohortReviewId,
               participantId,
               {
@@ -389,15 +389,15 @@ export const SidebarContent = fp.flow(
         cohortReview: { cohortId, cohortReviewId },
         participant,
       } = this.props;
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       this.getAnnotations(
         namespace,
-        id,
+        terraName,
         cohortReviewId,
         participant.participantId
       );
       cohortAnnotationDefinitionApi()
-        .getCohortAnnotationDefinitions(namespace, id, cohortId)
+        .getCohortAnnotationDefinitions(namespace, terraName, cohortId)
         .then(({ items }) => {
           this.setState({ annotationDefinitions: items });
         });
@@ -408,7 +408,7 @@ export const SidebarContent = fp.flow(
         cohortReview: { cohortReviewId },
         participant,
       } = this.props;
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       if (
         participant.participantId !== prevProps.participant.participantId &&
         !isNaN(participant.participantId)
@@ -416,7 +416,7 @@ export const SidebarContent = fp.flow(
         // get values for annotations when switching participants
         this.getAnnotations(
           namespace,
-          id,
+          terraName,
           cohortReviewId,
           participant.participantId
         );
@@ -437,14 +437,14 @@ export const SidebarContent = fp.flow(
       try {
         const {
           cohortReview: { cohortReviewId },
-          workspace: { namespace, id },
+          workspace: { namespace, terraName },
           participant: { participantId },
         } = this.props;
         this.setState({ savingStatus: v });
         const participant =
           await cohortReviewApi().updateParticipantCohortStatus(
             namespace,
-            id,
+            terraName,
             cohortReviewId,
             participantId,
             { status: v }

--- a/ui/src/app/pages/data/cohort/attributes-page.tsx
+++ b/ui/src/app/pages/data/cohort/attributes-page.tsx
@@ -318,9 +318,9 @@ export const AttributesPage = fp.flow(
 
   const getAttributes = () => {
     const { conceptId } = node;
-    const { id, namespace } = workspace;
+    const { namespace, terraName } = workspace;
     cohortBuilderApi()
-      .findCriteriaAttributeByConceptId(namespace, id, conceptId)
+      .findCriteriaAttributeByConceptId(namespace, terraName, conceptId)
       .then((resp) => {
         const newAttributes = { numAttributes: [], catAttributes: [] };
         resp.items.forEach((attr) => {
@@ -359,7 +359,7 @@ export const AttributesPage = fp.flow(
 
   const getSurveyAttributes = async () => {
     const { conceptId, parentId, path, subtype, value } = node;
-    const { namespace, id } = workspace;
+    const { namespace, terraName } = workspace;
     const { cdrVersionId } = currentWorkspaceStore.getValue();
     const surveyId = path.split('.')[0];
     let surveyNode = ppiSurveys
@@ -369,7 +369,7 @@ export const AttributesPage = fp.flow(
       await cohortBuilderApi()
         .findCriteriaBy(
           namespace,
-          id,
+          terraName,
           Domain.SURVEY.toString(),
           CriteriaType.PPI.toString(),
           false,
@@ -396,7 +396,7 @@ export const AttributesPage = fp.flow(
         promises.push(
           cohortBuilderApi().findSurveyVersionByQuestionConceptId(
             namespace,
-            id,
+            terraName,
             conceptId
           )
         );
@@ -404,7 +404,7 @@ export const AttributesPage = fp.flow(
         promises.push(
           cohortBuilderApi().findSurveyVersionByQuestionConceptIdAndAnswerConceptId(
             namespace,
-            id,
+            terraName,
             ppiQuestions.getValue()[parentId].conceptId,
             +value
           )
@@ -414,7 +414,7 @@ export const AttributesPage = fp.flow(
         promises.push(
           cohortBuilderApi().findCriteriaAttributeByConceptId(
             namespace,
-            id,
+            terraName,
             conceptId
           )
         );
@@ -851,7 +851,7 @@ export const AttributesPage = fp.flow(
   };
 
   const requestPreview = () => {
-    const { id, namespace } = workspace;
+    const { namespace, terraName } = workspace;
     setCalculating(true);
     setAttributeCount(null);
     setCountError(false);
@@ -877,7 +877,7 @@ export const AttributesPage = fp.flow(
       dataFilters: [],
     };
     cohortBuilderApi()
-      .countParticipants(namespace, id, request)
+      .countParticipants(namespace, terraName, request)
       .then(
         (response) => {
           setCalculating(false);

--- a/ui/src/app/pages/data/cohort/cohort-actions.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-actions.tsx
@@ -128,9 +128,9 @@ export const CohortActions = fp.flow(
         this.setState({ cohort });
       } else {
         this.setState({ cohortLoading: true });
-        const { namespace, id } = this.props.workspace;
+        const { namespace, terraName } = this.props.workspace;
         cohortsApi()
-          .getCohort(namespace, id, +this.props.match.params.cid)
+          .getCohort(namespace, terraName, +this.props.match.params.cid)
           .then((c) => {
             if (c) {
               this.setState({ cohort: c, cohortLoading: false });
@@ -138,7 +138,7 @@ export const CohortActions = fp.flow(
               this.props.navigate([
                 'workspaces',
                 namespace,
-                id,
+                terraName,
                 'data',
                 'cohorts',
               ]);
@@ -149,8 +149,8 @@ export const CohortActions = fp.flow(
 
     getNavigationPath(action: string): string {
       const { cohort } = this.state;
-      const { namespace, id } = this.props.workspace;
-      let url = workspacePath(namespace, id) + '/';
+      const { namespace, terraName } = this.props.workspace;
+      let url = workspacePath(namespace, terraName) + '/';
       let queryParams: any = null;
 
       switch (action) {

--- a/ui/src/app/pages/data/cohort/cohort-criteria-menu.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-criteria-menu.tsx
@@ -210,9 +210,9 @@ export const CohortCriteriaMenu = withCurrentWorkspace()(
     const menuRef = useRef(null);
 
     const getDomainCounts = () => {
-      const { id, namespace } = workspace;
+      const { namespace, terraName } = workspace;
       cohortBuilderApi()
-        .findUniversalDomainCounts(namespace, id, searchTerms)
+        .findUniversalDomainCounts(namespace, terraName, searchTerms)
         .then((response) => {
           setDomainCounts(response.items);
           setDomainCountsLoading(false);

--- a/ui/src/app/pages/data/cohort/cohort-page.spec.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-page.spec.tsx
@@ -55,7 +55,7 @@ describe('CohortPage', () => {
 
   it('should render one search group for each includes/excludes item', async () => {
     const mockGetCohort = jest.spyOn(cohortsApi(), 'getCohort');
-    const { id, namespace } = workspaceDataStub;
+    const { namespace, terraName } = workspaceDataStub;
     component();
     await waitFor(() => expect(mockGetCohort).toHaveBeenCalledTimes(0));
     expect(screen.queryAllByTestId('includes-search-group').length).toBe(0);
@@ -64,7 +64,7 @@ describe('CohortPage', () => {
     // Call cohort with 2 includes groups
     history.push('?cohortId=1');
     await waitFor(() =>
-      expect(mockGetCohort).toHaveBeenCalledWith(namespace, id, 1)
+      expect(mockGetCohort).toHaveBeenCalledWith(namespace, terraName, 1)
     );
     expect(screen.getAllByTestId('includes-search-group').length).toBe(2);
     expect(screen.queryAllByTestId('excludes-search-group').length).toBe(0);
@@ -72,7 +72,7 @@ describe('CohortPage', () => {
     // Call cohort with 2 includes groups and one excludes group
     history.push('?cohortId=2');
     await waitFor(() =>
-      expect(mockGetCohort).toHaveBeenCalledWith(namespace, id, 2)
+      expect(mockGetCohort).toHaveBeenCalledWith(namespace, terraName, 2)
     );
     expect(screen.getAllByTestId('includes-search-group').length).toBe(2);
     expect(screen.getAllByTestId('excludes-search-group').length).toBe(1);

--- a/ui/src/app/pages/data/cohort/cohort-page.tsx
+++ b/ui/src/app/pages/data/cohort/cohort-page.tsx
@@ -122,7 +122,7 @@ export const CohortPage = fp.flow(
 
     componentDidMount() {
       const {
-        workspace: { id },
+        workspace: { terraName },
         hideSpinner,
       } = this.props;
       hideSpinner();
@@ -141,7 +141,7 @@ export const CohortPage = fp.flow(
           updateGroupListsCount: this.state.updateGroupListsCount + 1,
         });
         const localStorageCohort = {
-          workspaceId: id,
+          workspaceId: terraName,
           cohortId: !!cohort ? cohort.id : null,
           searchRequest,
         };
@@ -168,7 +168,7 @@ export const CohortPage = fp.flow(
 
     initCohort() {
       const {
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
       } = this.props;
       const cid = parseQueryParams(this.props.location.search).get('cohortId');
       const existingCohort = JSON.parse(
@@ -181,13 +181,13 @@ export const CohortPage = fp.flow(
       if (cid) {
         this.setState({ loading: true });
         cohortsApi()
-          .getCohort(namespace, id, +cid)
+          .getCohort(namespace, terraName, +cid)
           .then((cohort) => {
             this.setState({ cohort, loading: false });
             currentCohortStore.next(cohort);
             if (
               existingCohort &&
-              existingCohort.workspaceId === id &&
+              existingCohort.workspaceId === terraName &&
               existingCohort.cohortId === +cid
             ) {
               searchRequestStore.next(existingCohort.searchRequest);
@@ -211,7 +211,7 @@ export const CohortPage = fp.flow(
           () => {
             if (
               existingCohort &&
-              existingCohort.workspaceId === id &&
+              existingCohort.workspaceId === terraName &&
               !existingCohort.cohortId
             ) {
               searchRequestStore.next(existingCohort.searchRequest);
@@ -223,7 +223,10 @@ export const CohortPage = fp.flow(
       }
       if (existingContext) {
         const { workspaceId, cohortId, cohortContext } = existingContext;
-        if (workspaceId === id && ((!cid && !cohortId) || +cid === cohortId)) {
+        if (
+          workspaceId === terraName &&
+          ((!cid && !cohortId) || +cid === cohortId)
+        ) {
           this.setSearchContext(cohortContext);
         } else {
           localStorage.removeItem(LOCAL_STORAGE_KEY_COHORT_CONTEXT);

--- a/ui/src/app/pages/data/cohort/custom-funnel.tsx
+++ b/ui/src/app/pages/data/cohort/custom-funnel.tsx
@@ -17,7 +17,7 @@ export const CustomFunnel = withCurrentWorkspace()(
   ({
     onExit,
     totalCount,
-    workspace: { namespace, id },
+    workspace: { namespace, terraName },
   }: {
     onExit: (e: Event) => void;
     totalCount: number;
@@ -131,7 +131,7 @@ export const CustomFunnel = withCurrentWorkspace()(
             }
             return cohortBuilderApi().countParticipants(
               namespace,
-              id,
+              terraName,
               searchRequest
             );
           })

--- a/ui/src/app/pages/data/cohort/demographics.tsx
+++ b/ui/src/app/pages/data/cohort/demographics.tsx
@@ -185,11 +185,11 @@ export class Demographics extends React.Component<Props, State> {
 
   async loadNodesFromApi() {
     const { criteriaType, selections } = this.props;
-    const { id, namespace } = currentWorkspaceStore.getValue();
+    const { namespace, terraName } = currentWorkspaceStore.getValue();
     this.setState({ loading: true });
     const response = await cohortBuilderApi().findCriteriaBy(
       namespace,
-      id,
+      terraName,
       Domain.PERSON.toString(),
       criteriaType.toString()
     );
@@ -208,13 +208,16 @@ export class Demographics extends React.Component<Props, State> {
 
   async loadAgeNodesFromApi() {
     const { ageRange } = this.state;
-    const { id, namespace } = currentWorkspaceStore.getValue();
+    const { terraName, namespace } = currentWorkspaceStore.getValue();
     const initialValue = {
       [AttrName.AGE]: [],
       [AttrName.AGE_AT_CONSENT]: [],
       [AttrName.AGE_AT_CDR]: [],
     };
-    const response = await cohortBuilderApi().findAgeTypeCounts(namespace, id);
+    const response = await cohortBuilderApi().findAgeTypeCounts(
+      namespace,
+      terraName
+    );
     const ageTypeNodes = response.items.reduce((acc, item) => {
       acc[item.ageType].push(item);
       // Compare age with upper range and update if needed. Can't currently change lower range to prevent including ages < 18

--- a/ui/src/app/pages/data/cohort/list-search.tsx
+++ b/ui/src/app/pages/data/cohort/list-search.tsx
@@ -371,7 +371,7 @@ export const ListSearch = fp.flow(
         cdrVersionTiersResponse,
         searchTerms,
         searchContext: { domain, source },
-        workspace: { cdrVersionId, id, namespace },
+        workspace: { cdrVersionId, namespace, terraName },
       } = this.props;
       this.setState({
         cdrVersion: findCdrVersion(cdrVersionId, cdrVersionTiersResponse),
@@ -382,16 +382,21 @@ export const ListSearch = fp.flow(
         if (this.criteriaLookupNeeded) {
           this.setState({ loading: true });
           await cohortBuilderApi()
-            .findCriteriaForCohortEdit(namespace, id, domain.toString(), {
-              sourceConceptIds: currentCohortCriteriaStore
-                .getValue()
-                .filter((s) => !s.standard)
-                .map((s) => s.conceptId),
-              standardConceptIds: currentCohortCriteriaStore
-                .getValue()
-                .filter((s) => s.standard)
-                .map((s) => s.conceptId),
-            })
+            .findCriteriaForCohortEdit(
+              namespace,
+              terraName,
+              domain.toString(),
+              {
+                sourceConceptIds: currentCohortCriteriaStore
+                  .getValue()
+                  .filter((s) => !s.standard)
+                  .map((s) => s.conceptId),
+                standardConceptIds: currentCohortCriteriaStore
+                  .getValue()
+                  .filter((s) => s.standard)
+                  .map((s) => s.conceptId),
+              }
+            )
             .then((response) =>
               updateCriteriaSelectionStore(response.items, domain)
             );
@@ -465,7 +470,7 @@ export const ListSearch = fp.flow(
         });
         const {
           searchContext: { domain, source, selectedSurvey },
-          workspace: { id, namespace },
+          workspace: { namespace, terraName },
         } = this.props;
         const { removeDrugBrand, searchSource } = this.state;
         const request: CriteriaSearchRequest = {
@@ -477,7 +482,7 @@ export const ListSearch = fp.flow(
         };
         const resp = await cohortBuilderApi().findCriteriaByDomain(
           namespace,
-          id,
+          terraName,
           request
         );
         let data: Criteria[];
@@ -598,18 +603,18 @@ export const ListSearch = fp.flow(
           };
           this.setState({ childNodes });
           const {
-            workspace: { id, namespace },
+            workspace: { namespace, terraName },
           } = this.props;
           const childResponse =
             domainId === Domain.DRUG.toString()
               ? await cohortBuilderApi().findDrugIngredientByConceptId(
                   namespace,
-                  id,
+                  terraName,
                   conceptId
                 )
               : await cohortBuilderApi().findCriteriaBy(
                   namespace,
-                  id,
+                  terraName,
                   domainId,
                   type,
                   standard,

--- a/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
@@ -54,7 +54,7 @@ describe('ModifierPage', () => {
         initialEntries={[
           `${dataTabPath(
             workspaceDataStub.namespace,
-            workspaceDataStub.id
+            workspaceDataStub.terraName
           )}/cohorts/build`,
         ]}
       >

--- a/ui/src/app/pages/data/cohort/modifier-page.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.tsx
@@ -225,7 +225,7 @@ export const ModifierPage = fp.flow(
     closeModifiers,
     cohortContext,
     selections,
-    workspace,
+    workspace: { cdrVersionId },
   }: Props) => {
     const { ns, terraName } = useParams<MatchParams>();
     const [calculateError, setCalculateError] = useState(false);
@@ -296,7 +296,7 @@ export const ModifierPage = fp.flow(
       }
       if (cohortContext.domain === Domain.SURVEY) {
         const cdrVersion = findCdrVersion(
-          workspace.cdrVersionId,
+          cdrVersionId,
           cdrVersionTiersResponse
         );
         // Add CATI modifier for cdrs with hasSurveyConductData
@@ -514,7 +514,6 @@ export const ModifierPage = fp.flow(
 
     const calculate = async () => {
       const { domain, role } = cohortContext;
-      const { namespace, terraName } = workspace;
       AnalyticsTracker.CohortBuilder.ModifiersAction(
         `Calculate - ${domainToTitle(domain)}`
       );
@@ -539,7 +538,7 @@ export const ModifierPage = fp.flow(
           dataFilters: [],
         };
         await cohortBuilderApi()
-          .countParticipants(namespace, terraName, request)
+          .countParticipants(ns, terraName, request)
           .then((response) => {
             setCalculating(false);
             setCount(response);

--- a/ui/src/app/pages/data/cohort/modifier-page.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.tsx
@@ -514,7 +514,7 @@ export const ModifierPage = fp.flow(
 
     const calculate = async () => {
       const { domain, role } = cohortContext;
-      const { id, namespace } = workspace;
+      const { namespace, terraName } = workspace;
       AnalyticsTracker.CohortBuilder.ModifiersAction(
         `Calculate - ${domainToTitle(domain)}`
       );
@@ -539,7 +539,7 @@ export const ModifierPage = fp.flow(
           dataFilters: [],
         };
         await cohortBuilderApi()
-          .countParticipants(namespace, id, request)
+          .countParticipants(namespace, terraName, request)
           .then((response) => {
             setCalculating(false);
             setCount(response);

--- a/ui/src/app/pages/data/cohort/overview.tsx
+++ b/ui/src/app/pages/data/cohort/overview.tsx
@@ -306,11 +306,11 @@ export const ListOverview = fp.flow(
     callApi() {
       const { searchRequest } = this.props;
       const { ageType, chartType } = this.state;
-      const { id, namespace } = currentWorkspaceStore.getValue();
+      const { namespace, terraName } = currentWorkspaceStore.getValue();
       const request = mapRequest(searchRequest);
       return cohortBuilderApi().findDemoChartInfo(
         namespace,
-        id,
+        terraName,
         chartType.toString(),
         ageType.toString(),
         request,

--- a/ui/src/app/pages/data/cohort/search-bar.tsx
+++ b/ui/src/app/pages/data/cohort/search-bar.tsx
@@ -281,13 +281,13 @@ export class SearchBar extends React.Component<Props, State> {
       `${domainToTitle(domainId)} - '${searchTerms}'`
     );
     this.setState({ inputErrors: [], loading: true });
-    const { id, namespace } = currentWorkspaceStore.getValue();
+    const { namespace, terraName } = currentWorkspaceStore.getValue();
     let apiCall;
     switch (domainId) {
       case Domain.DRUG.toString():
         apiCall = cohortBuilderApi().findDrugBrandOrIngredientByValue(
           namespace,
-          id,
+          terraName,
           searchTerms
         );
         break;
@@ -300,7 +300,7 @@ export class SearchBar extends React.Component<Props, State> {
         };
         apiCall = cohortBuilderApi().findCriteriaAutoComplete(
           namespace,
-          id,
+          terraName,
           surveyRequest
         );
         break;
@@ -313,7 +313,7 @@ export class SearchBar extends React.Component<Props, State> {
         };
         apiCall = cohortBuilderApi().findCriteriaAutoComplete(
           namespace,
-          id,
+          terraName,
           request
         );
     }
@@ -352,9 +352,9 @@ export class SearchBar extends React.Component<Props, State> {
         optionSelected: true,
       });
       if (option.type === CriteriaType.BRAND.toString()) {
-        const { id, namespace } = currentWorkspaceStore.getValue();
+        const { namespace, terraName } = currentWorkspaceStore.getValue();
         cohortBuilderApi()
-          .findDrugIngredientByConceptId(namespace, id, option.conceptId)
+          .findDrugIngredientByConceptId(namespace, terraName, option.conceptId)
           .then((resp) => {
             if (resp.items.length) {
               const ingredients = resp.items.map((it) => it.name);

--- a/ui/src/app/pages/data/cohort/search-group-item.spec.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.spec.tsx
@@ -16,8 +16,8 @@ const itemStub = {
 };
 
 const workspaceStub = {
-  id: 'workspace_id',
   namespace: 'namespace',
+  terraName: 'terraName',
 };
 
 describe('SearchGroupItem', () => {

--- a/ui/src/app/pages/data/cohort/search-group-item.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-item.tsx
@@ -249,7 +249,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
     componentDidMount(): void {
       const {
         item: { count, modifiers },
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
       } = this.props;
       const { encounters } = this.state;
       if (count !== undefined) {
@@ -265,7 +265,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
         cohortBuilderApi()
           .findCriteriaBy(
             namespace,
-            id,
+            terraName,
             Domain[Domain.VISIT],
             CriteriaType[CriteriaType.VISIT]
           )
@@ -289,7 +289,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
       const { item, role, updateGroup } = this.props;
       try {
         updateGroup();
-        const { id, namespace } = currentWorkspaceStore.getValue();
+        const { namespace, terraName } = currentWorkspaceStore.getValue();
         const mappedItem = mapGroupItem(item, false);
         const request = {
           includes: [],
@@ -298,7 +298,7 @@ export const SearchGroupItem = withCurrentWorkspace()(
           [role]: [{ items: [mappedItem], temporal: false }],
         };
         await cohortBuilderApi()
-          .countParticipants(namespace, id, request)
+          .countParticipants(namespace, terraName, request)
           .then((count) => this.updateSearchRequest('count', count, false));
       } catch (error) {
         console.error(error);

--- a/ui/src/app/pages/data/cohort/search-group-list.tsx
+++ b/ui/src/app/pages/data/cohort/search-group-list.tsx
@@ -146,11 +146,11 @@ const SearchGroupList = fp.flow(withCurrentWorkspace())(
 
     getMenuOptions() {
       const {
-        workspace: { cdrVersionId, id, namespace },
+        workspace: { cdrVersionId, namespace, terraName },
       } = this.props;
       const criteriaMenuOptions = criteriaMenuOptionsStore.getValue();
       cohortBuilderApi()
-        .findCriteriaMenu(namespace, id, 0)
+        .findCriteriaMenu(namespace, terraName, 0)
         .then(async (res) => {
           const menuOptions = await Promise.all(
             res.items.map(async (item) => {
@@ -158,7 +158,7 @@ const SearchGroupList = fp.flow(withCurrentWorkspace())(
               if (option.group) {
                 const children = await cohortBuilderApi().findCriteriaMenu(
                   namespace,
-                  id,
+                  terraName,
                   option.id
                 );
                 option.children = children.items.map(mapMenuItem);

--- a/ui/src/app/pages/data/cohort/search-group.tsx
+++ b/ui/src/app/pages/data/cohort/search-group.tsx
@@ -313,7 +313,7 @@ export const SearchGroup = withCurrentWorkspace()(
         group,
         groupIndex,
         role,
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
       } = this.props;
       const mappedGroup = mapGroup(group);
       const request = {
@@ -323,7 +323,7 @@ export const SearchGroup = withCurrentWorkspace()(
         [role]: [mappedGroup],
       };
       cohortBuilderApi()
-        .countParticipants(namespace, id, request, {
+        .countParticipants(namespace, terraName, request, {
           signal: this.aborter.signal,
         })
         .then((count) => {

--- a/ui/src/app/pages/data/cohort/selection-list.tsx
+++ b/ui/src/app/pages/data/cohort/selection-list.tsx
@@ -255,12 +255,12 @@ export const SelectionInfo = withCurrentCohortSearchContext()(
     }
 
     async getVariantFilterBuckets() {
-      const { namespace, id } = currentWorkspaceStore.getValue();
+      const { namespace, terraName } = currentWorkspaceStore.getValue();
       try {
         const filterBucketResponse =
           await cohortBuilderApi().findVariantFilterInfo(
             namespace,
-            id,
+            terraName,
             this.props.selection.variantFilter
           );
         this.setState({ variantFilterInfoResponse: filterBucketResponse });

--- a/ui/src/app/pages/data/cohort/tree-node.tsx
+++ b/ui/src/app/pages/data/cohort/tree-node.tsx
@@ -196,7 +196,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
     cohortBuilderApi()
       .findCriteriaBy(
         workspace.namespace,
-        workspace.id,
+        workspace.terraName,
         domain.toString(),
         criteriaType,
         standard,
@@ -207,7 +207,7 @@ export class TreeNode extends React.Component<TreeNodeProps, TreeNodeState> {
           cohortBuilderApi()
             .findCriteriaBy(
               workspace.namespace,
-              workspace.id,
+              workspace.terraName,
               domain.toString(),
               CriteriaType[CriteriaType.RXNORM],
               standard,

--- a/ui/src/app/pages/data/cohort/tree.tsx
+++ b/ui/src/app/pages/data/cohort/tree.tsx
@@ -220,20 +220,20 @@ export const CriteriaTree = fp.flow(
           source,
         } = this.props;
         this.setState({ loading: true });
-        const { id: workspaceId, namespace } = currentWorkspaceStore.getValue();
+        const { namespace, terraName } = currentWorkspaceStore.getValue();
         const criteriaType =
           domain === Domain.DRUG ? CriteriaType.ATC.toString() : type;
         const promises = [
           this.sendOnlyCriteriaType(domain)
             ? cohortBuilderApi().findCriteriaBy(
                 namespace,
-                workspaceId,
+                terraName,
                 domain.toString(),
                 criteriaType
               )
             : cohortBuilderApi().findCriteriaBy(
                 namespace,
-                workspaceId,
+                terraName,
                 domain.toString(),
                 criteriaType,
                 standard,
@@ -242,7 +242,7 @@ export const CriteriaTree = fp.flow(
           this.criteriaLookupNeeded
             ? cohortBuilderApi().findCriteriaForCohortEdit(
                 namespace,
-                workspaceId,
+                terraName,
                 domain.toString(),
                 {
                   sourceConceptIds: currentCohortCriteriaStore
@@ -257,7 +257,7 @@ export const CriteriaTree = fp.flow(
               )
             : Promise.resolve(null),
           domain === Domain.SURVEY
-            ? cohortBuilderApi().findVersionedSurveys(namespace, workspaceId)
+            ? cohortBuilderApi().findVersionedSurveys(namespace, terraName)
             : Promise.resolve(null),
         ];
         const [criteriaResponse, criteriaLookup, versionedSurveyLookup] =
@@ -353,12 +353,12 @@ export const CriteriaTree = fp.flow(
       const {
         node: { domainId, standard, type },
       } = this.props;
-      const { id, namespace } = currentWorkspaceStore.getValue();
+      const { namespace, terraName } = currentWorkspaceStore.getValue();
       if (selectedSurveyChild && selectedSurveyChild.length > 0) {
         cohortBuilderApi()
           .findCriteriaBy(
             namespace,
-            id,
+            terraName,
             domainId,
             type,
             standard,

--- a/ui/src/app/pages/data/cohort/variant-search.tsx
+++ b/ui/src/app/pages/data/cohort/variant-search.tsx
@@ -180,7 +180,7 @@ export const VariantSearch = fp.flow(
     criteria,
     select,
     selectedIds,
-    workspace: { id, namespace },
+    workspace: { namespace, terraName },
   }) => {
     const [first, setFirst] = useState(0);
     const [inputErrors, setInputErrors] = useState([]);
@@ -216,14 +216,14 @@ export const VariantSearch = fp.flow(
       try {
         const [{ items, nextPageToken, totalSize }, filterResponse] =
           await Promise.all([
-            cohortBuilderApi().findVariants(namespace, id, {
+            cohortBuilderApi().findVariants(namespace, terraName, {
               ...selectedFilters,
               searchTerm: searchTerms.trim(),
               pageSize,
               pageToken: !!firstPage ? pageToken : null,
             }),
             newSearch
-              ? cohortBuilderApi().findVariantFilters(namespace, id, {
+              ? cohortBuilderApi().findVariantFilters(namespace, terraName, {
                   searchTerm: searchTerms.trim(),
                 })
               : null,

--- a/ui/src/app/pages/data/concept/concept-add-modal.tsx
+++ b/ui/src/app/pages/data/concept/concept-add-modal.tsx
@@ -107,11 +107,11 @@ export const ConceptAddModal = withCurrentWorkspace()(
         const {
           activeDomainTab: { domain },
           selectedConcepts,
-          workspace: { namespace, id },
+          workspace: { namespace, terraName },
         } = this.props;
         const conceptSets = await conceptSetsApi().getConceptSetsInWorkspace(
           namespace,
-          id
+          terraName
         );
         const conceptSetsInDomain = conceptSets.items.filter(
           (conceptSet) => conceptSet.domain === domain
@@ -135,7 +135,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
       const {
         activeDomainTab: { domain },
         onSave,
-        workspace: { namespace, id },
+        workspace: { namespace, terraName },
       } = this.props;
       const {
         selectedSet,
@@ -173,7 +173,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
         try {
           const conceptSet = await conceptSetsApi().updateConceptSetConcepts(
             namespace,
-            id,
+            terraName,
             selectedSet.id,
             updateConceptSetReq
           );
@@ -196,7 +196,7 @@ export const ConceptAddModal = withCurrentWorkspace()(
         try {
           const createdConceptSet = await conceptSetsApi().createConceptSet(
             namespace,
-            id,
+            terraName,
             request
           );
           this.setState({ saving: false });
@@ -230,11 +230,11 @@ export const ConceptAddModal = withCurrentWorkspace()(
     async selectConceptSet(conceptSet: ConceptSet) {
       this.setState({ loadingSelectedSet: true });
       const {
-        workspace: { namespace, id },
+        workspace: { namespace, terraName },
       } = this.props;
       const selectedSetCount = await conceptSetsApi().countConceptsInConceptSet(
         namespace,
-        id,
+        terraName,
         conceptSet.id
       );
       this.setState({

--- a/ui/src/app/pages/data/concept/concept-homepage.tsx
+++ b/ui/src/app/pages/data/concept/concept-homepage.tsx
@@ -302,7 +302,7 @@ export const ConceptHomepage = fp.flow(
 
     async loadDomainsAndSurveys() {
       const {
-        workspace: { id, namespace },
+        workspace: { namespace, terraName },
       } = this.props;
       this.setState({
         domainInfoError: false,
@@ -310,7 +310,7 @@ export const ConceptHomepage = fp.flow(
         conceptCountInfoError: false,
       });
       const getDomainCards = cohortBuilderApi()
-        .findDomainCards(namespace, id)
+        .findDomainCards(namespace, terraName)
         .then((conceptDomainCards) =>
           this.setState({ conceptDomainCards: conceptDomainCards.items })
         )
@@ -319,7 +319,7 @@ export const ConceptHomepage = fp.flow(
           console.error(e);
         });
       const getSurveyInfo = cohortBuilderApi()
-        .findSurveyModules(namespace, id)
+        .findSurveyModules(namespace, terraName)
         .then((surveysInfo) =>
           this.setState({ conceptSurveysList: surveysInfo.items })
         )
@@ -332,7 +332,7 @@ export const ConceptHomepage = fp.flow(
     }
 
     async updateCardCounts() {
-      const { id, namespace } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       const { conceptDomainCards, conceptSurveysList, currentInputString } =
         this.state;
       this.setState({
@@ -343,7 +343,7 @@ export const ConceptHomepage = fp.flow(
       });
 
       cohortBuilderApi()
-        .findConceptCounts(namespace, id, currentInputString)
+        .findConceptCounts(namespace, terraName, currentInputString)
         .then((cardList) => {
           conceptDomainCards.forEach((conceptDomainCard) => {
             const cardCount = cardList.items.find(
@@ -407,13 +407,13 @@ export const ConceptHomepage = fp.flow(
     }
 
     browseDomain(domain: Domain, surveyName?: string) {
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       currentCohortSearchContextStore.next({
         domain: domain,
         searchTerms: this.state.currentSearchString,
         surveyName,
       });
-      const url = `${dataTabPath(namespace, id)}/concepts/${domain}`;
+      const url = `${dataTabPath(namespace, terraName)}/concepts/${domain}`;
 
       this.props.navigateByUrl(
         url,

--- a/ui/src/app/pages/data/concept/concept-list.tsx
+++ b/ui/src/app/pages/data/concept/concept-list.tsx
@@ -130,7 +130,7 @@ export const ConceptListPage = fp.flow(
       const {
         concept,
         conceptSet,
-        workspace: { namespace, id },
+        workspace: { namespace, terraName },
       } = this.props;
       conceptSetUpdating.next(true);
       this.setState({ updating: true });
@@ -153,7 +153,7 @@ export const ConceptListPage = fp.flow(
         const updatedConceptSet =
           await conceptSetsApi().updateConceptSetConcepts(
             namespace,
-            id,
+            terraName,
             conceptSet.id,
             updateConceptSetReq
           );
@@ -161,7 +161,7 @@ export const ConceptListPage = fp.flow(
         this.props.navigate([
           'workspaces',
           namespace,
-          id,
+          terraName,
           'data',
           'concepts',
           'sets',
@@ -185,11 +185,11 @@ export const ConceptListPage = fp.flow(
     }
 
     afterConceptsSaved(conceptSet: ConceptSet) {
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       this.props.navigate([
         'workspaces',
         namespace,
-        id,
+        terraName,
         'data',
         'concepts',
         'sets',

--- a/ui/src/app/pages/data/concept/concept-search.spec.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.spec.tsx
@@ -48,7 +48,7 @@ describe('ConceptSearch', () => {
         initialEntries={[
           `${dataTabPath(
             workspaceDataStub.namespace,
-            workspaceDataStub.id
+            workspaceDataStub.terraName
           )}/concepts/sets/${conceptSet.id}`,
         ]}
       >

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -661,7 +661,7 @@ export const ConceptSearch = fp.flow(
           {copying && (
             <CopyModal
               fromWorkspaceNamespace={namespace}
-              fromWorkspaceFirecloudName={terraName}
+              fromWorkspaceTerraName={terraName}
               fromResourceName={conceptSet.name}
               fromCdrVersionId={cdrVersionId}
               fromAccessTierShortName={accessTierShortName}

--- a/ui/src/app/pages/data/concept/concept-search.tsx
+++ b/ui/src/app/pages/data/concept/concept-search.tsx
@@ -425,7 +425,7 @@ export const ConceptSearch = fp.flow(
         workspace: {
           accessLevel,
           cdrVersionId,
-          id,
+          terraName,
           namespace,
           accessTierShortName,
         },
@@ -617,7 +617,7 @@ export const ConceptSearch = fp.flow(
                     this.props.navigate([
                       'workspaces',
                       namespace,
-                      id,
+                      terraName,
                       'data',
                       'concepts',
                     ])
@@ -661,7 +661,7 @@ export const ConceptSearch = fp.flow(
           {copying && (
             <CopyModal
               fromWorkspaceNamespace={namespace}
-              fromWorkspaceFirecloudName={id}
+              fromWorkspaceFirecloudName={terraName}
               fromResourceName={conceptSet.name}
               fromCdrVersionId={cdrVersionId}
               fromAccessTierShortName={accessTierShortName}

--- a/ui/src/app/pages/data/concept/concept-set-actions.tsx
+++ b/ui/src/app/pages/data/concept/concept-set-actions.tsx
@@ -126,9 +126,9 @@ export const ConceptSetActions = fp.flow(
         this.setState({ conceptSet });
       } else {
         this.setState({ conceptSetLoading: true });
-        const { namespace, id } = this.props.workspace;
+        const { namespace, terraName } = this.props.workspace;
         conceptSetsApi()
-          .getConceptSet(namespace, id, +csid)
+          .getConceptSet(namespace, terraName, +csid)
           .then((cs) => {
             if (cs) {
               this.setState({ conceptSet: cs, conceptSetLoading: false });
@@ -136,7 +136,7 @@ export const ConceptSetActions = fp.flow(
               this.props.navigate([
                 'workspaces',
                 namespace,
-                id,
+                terraName,
                 'data',
                 'concepts',
               ]);
@@ -146,9 +146,9 @@ export const ConceptSetActions = fp.flow(
     }
 
     getNavigationPath(action: string): string {
-      const { namespace, id } = this.props.workspace;
+      const { namespace, terraName } = this.props.workspace;
       const { conceptSet } = this.state;
-      let url = workspacePath(namespace, id) + '/';
+      let url = workspacePath(namespace, terraName) + '/';
       switch (action) {
         case 'conceptSet':
           url += `data/concepts/sets/${conceptSet.id}`;

--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -107,7 +107,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
       setResourceList(
         await workspacesApi().getWorkspaceResourcesV2(
           workspace.namespace,
-          workspace.id,
+          workspace.terraName,
           resourceTypesToFetch
         )
       );
@@ -120,7 +120,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
 
   useEffect(() => {
     loadResources();
-  }, [workspace.namespace, workspace.id]);
+  }, [workspace.namespace, workspace.terraName]);
 
   const writePermission =
     workspace.accessLevel === WorkspaceAccessLevel.OWNER ||
@@ -158,7 +158,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
                 navigate([
                   'workspaces',
                   workspace.namespace,
-                  workspace.id,
+                  workspace.terraName,
                   'data',
                   'cohorts',
                   'build',
@@ -205,7 +205,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
                 navigate([
                   'workspaces',
                   workspace.namespace,
-                  workspace.id,
+                  workspace.terraName,
                   'data',
                   'data-sets',
                 ]);

--- a/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.spec.tsx
@@ -88,7 +88,7 @@ describe('DataSetPage', () => {
         initialEntries={[
           `${dataTabPath(
             workspaceDataStub.namespace,
-            workspaceDataStub.id
+            workspaceDataStub.terraName
           )}/data-sets/${stubDataSet().id}`,
         ]}
       >
@@ -102,7 +102,7 @@ describe('DataSetPage', () => {
             match={{
               params: {
                 ns: workspaceDataStub.namespace,
-                terraName: workspaceDataStub.id,
+                terraName: workspaceDataStub.terraName,
                 dataSetId: stubDataSet().id,
               },
             }}
@@ -331,7 +331,7 @@ describe('DataSetPage', () => {
     componentAlt();
     const pathPrefix = dataTabPath(
       workspaceDataStub.namespace,
-      workspaceDataStub.id
+      workspaceDataStub.terraName
     );
 
     // Check Cohorts "+" link

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -332,7 +332,7 @@ interface ImmutableWorkspaceCohortListItemProps {
   checked: boolean;
   cohortId: number;
   namespace: string;
-  wid: string;
+  terraName: string;
   dataTestId?: string;
 }
 const ImmutableWorkspaceCohortListItem = ({
@@ -341,7 +341,7 @@ const ImmutableWorkspaceCohortListItem = ({
   checked,
   cohortId,
   namespace,
-  wid,
+  terraName,
   dataTestId,
 }: ImmutableWorkspaceCohortListItemProps) => {
   const [showNameTooltip, setShowNameTooltip] = useState(false);
@@ -376,7 +376,7 @@ const ImmutableWorkspaceCohortListItem = ({
           <StyledRouterLink
             path={`${dataTabPath(
               namespace,
-              wid
+              terraName
             )}/cohorts/${cohortId}/reviews/cohort-description`}
             target='_blank'
           >
@@ -1755,7 +1755,7 @@ export const DatasetPage = fp.flow(
                         checked={selectedCohortIds.includes(cohort.id)}
                         cohortId={cohort.id}
                         namespace={namespace}
-                        wid={terraName}
+                        terraName={terraName}
                         onChange={() => selectCohort(cohort)}
                       />
                     ))}

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -937,7 +937,7 @@ export const DatasetPage = fp.flow(
       // TODO(RW-4426): There is a lot of complexity here around loading domain
       // values which is static data for a given CDR version. Consider
       // refactoring this page to load all schema data before rendering.
-      const { namespace, id } = workspace;
+      const { namespace, terraName } = workspace;
       const updatedCrossDomainConceptSetList = crossDomainConceptSetList;
       const updatedSelectedDomainsWithConceptSetIds =
         selectedDomainsWithConceptSetIds;
@@ -947,7 +947,7 @@ export const DatasetPage = fp.flow(
       const newLookup = new Map(domainValueSetLookup);
       const values = await dataSetApi().getValuesFromDomain(
         namespace,
-        id,
+        terraName,
         domainWithConceptSetId.domain.toString(),
         domainWithConceptSetId.conceptSetId
       );
@@ -1021,7 +1021,7 @@ export const DatasetPage = fp.flow(
       // TODO(RW-4426): There is a lot of complexity here around loading domain
       // values which is static data for a given CDR version. Consider
       // refactoring this page to load all schema data before rendering.
-      const { namespace, id } = workspace;
+      const { namespace, terraName } = workspace;
       const newCrossDomainConceptSetList = new Set();
       const domainsWithConceptSetIds =
         getDomainsWithConceptSetIdsFromDataSet(loadedDataset);
@@ -1032,7 +1032,7 @@ export const DatasetPage = fp.flow(
         ({ conceptSetId, domain }) =>
           dataSetApi().getValuesFromDomain(
             namespace,
-            id,
+            terraName,
             domain.toString(),
             conceptSetId
           )
@@ -1103,14 +1103,14 @@ export const DatasetPage = fp.flow(
 
     const loadResources = async () => {
       try {
-        const { namespace, id } = workspace;
+        const { namespace, terraName } = workspace;
         const resourceCalls: Array<Promise<any>> = [
-          conceptSetsApi().getConceptSetsInWorkspace(namespace, id),
-          cohortsApi().getCohortsInWorkspace(namespace, id),
+          conceptSetsApi().getConceptSetsInWorkspace(namespace, terraName),
+          cohortsApi().getCohortsInWorkspace(namespace, terraName),
         ];
         if (dataSetId) {
           resourceCalls.push(
-            dataSetApi().getDataSet(namespace, id, +dataSetId)
+            dataSetApi().getDataSet(namespace, terraName, +dataSetId)
           );
         }
         const [conceptSets, cohorts, dataset] = await Promise.all(
@@ -1463,7 +1463,7 @@ export const DatasetPage = fp.flow(
         );
         return;
       }
-      const { namespace, id } = workspace;
+      const { namespace, terraName } = workspace;
       const domainRequest: DataSetPreviewRequest = {
         domain: domain,
         conceptSetIds: selectedConceptSetIds,
@@ -1478,7 +1478,11 @@ export const DatasetPage = fp.flow(
       try {
         const domainPreviewResponse = await apiCallWithGatewayTimeoutRetries(
           () =>
-            dataSetApi().previewDataSetByDomain(namespace, id, domainRequest)
+            dataSetApi().previewDataSetByDomain(
+              namespace,
+              terraName,
+              domainRequest
+            )
         );
         newPreviewInformation = {
           isLoading: false,
@@ -1535,10 +1539,14 @@ export const DatasetPage = fp.flow(
 
     const createDataset = async (datasetName, desc) => {
       AnalyticsTracker.DatasetBuilder.Create();
-      const { namespace, id } = workspace;
+      const { namespace, terraName } = workspace;
 
       dataSetApi()
-        .createDataSet(namespace, id, createDatasetRequest(datasetName, desc))
+        .createDataSet(
+          namespace,
+          terraName,
+          createDatasetRequest(datasetName, desc)
+        )
         .then((dataset) => loadDataset(dataset));
     };
 
@@ -1551,11 +1559,11 @@ export const DatasetPage = fp.flow(
 
     const saveDataset = async () => {
       AnalyticsTracker.DatasetBuilder.Save();
-      const { namespace, id } = workspace;
+      const { namespace, terraName } = workspace;
 
       setSavingDataset(true);
       dataSetApi()
-        .updateDataSet(namespace, id, dataSet.id, updateDatasetRequest())
+        .updateDataSet(namespace, terraName, dataSet.id, updateDatasetRequest())
         .then((dataset) => loadDataset(dataset))
         .catch((e) => {
           console.error(e);
@@ -1680,8 +1688,8 @@ export const DatasetPage = fp.flow(
       );
     };
 
-    const { namespace, id } = workspace;
-    const pathPrefix = dataTabPath(namespace, id);
+    const { namespace, terraName } = workspace;
+    const pathPrefix = dataTabPath(namespace, terraName);
     const cohortsPath = pathPrefix + '/cohorts/build';
     const conceptSetsPath = pathPrefix + '/concepts';
     const exportError = !canWrite()
@@ -1747,7 +1755,7 @@ export const DatasetPage = fp.flow(
                         checked={selectedCohortIds.includes(cohort.id)}
                         cohortId={cohort.id}
                         namespace={namespace}
-                        wid={id}
+                        wid={terraName}
                         onChange={() => selectCohort(cohort)}
                       />
                     ))}
@@ -2153,7 +2161,7 @@ export const DatasetPage = fp.flow(
                   const resources =
                     await workspacesApi().getWorkspaceResourcesV2(
                       namespace,
-                      id,
+                      terraName,
                       [ResourceType.DATASET.toString()]
                     );
                   return resources.map((resource) => resource.dataSet.name);
@@ -2179,7 +2187,7 @@ export const DatasetPage = fp.flow(
               <GenomicExtractionModal
                 dataSet={dataSet}
                 workspaceNamespace={namespace}
-                workspaceFirecloudName={id}
+                workspaceFirecloudName={terraName}
                 title={
                   'Would you like to extract genomic variant data as VCF files?'
                 }

--- a/ui/src/app/pages/data/data-set/dataset-page.tsx
+++ b/ui/src/app/pages/data/data-set/dataset-page.tsx
@@ -2187,7 +2187,7 @@ export const DatasetPage = fp.flow(
               <GenomicExtractionModal
                 dataSet={dataSet}
                 workspaceNamespace={namespace}
-                workspaceFirecloudName={terraName}
+                workspaceTerraName={terraName}
                 title={
                   'Would you like to extract genomic variant data as VCF files?'
                 }

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.spec.tsx
@@ -145,7 +145,7 @@ describe(ExportDatasetModal.name, () => {
     await clickExportButton();
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         newNotebook: true,
@@ -174,7 +174,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         newNotebook: true,
@@ -280,7 +280,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         newNotebook: false,
@@ -319,7 +319,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         analysisLanguage: AnalysisLanguage.PYTHON,
@@ -334,7 +334,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         analysisLanguage: AnalysisLanguage.R,
@@ -440,7 +440,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(exportSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         newNotebook: true,
@@ -474,7 +474,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         analysisLanguage: AnalysisLanguage.PYTHON,
@@ -489,7 +489,7 @@ describe(ExportDatasetModal.name, () => {
 
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         analysisLanguage: AnalysisLanguage.PYTHON,
@@ -506,7 +506,7 @@ describe(ExportDatasetModal.name, () => {
     await user.click(otherRadioButton);
     expect(previewSpy).toHaveBeenCalledWith(
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       expect.objectContaining({
         dataSetRequest: expectedDatasetRequest,
         analysisLanguage: AnalysisLanguage.PYTHON,

--- a/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
+++ b/ui/src/app/pages/data/data-set/export-dataset-modal.tsx
@@ -138,11 +138,14 @@ export const ExportDatasetModal = ({
     try {
       await dataSetApi().exportToNotebook(
         workspace.namespace,
-        workspace.id,
+        workspace.terraName,
         createExportDatasetRequest(language)
       );
       const notebookUrl =
-        `${analysisTabPath(workspace.namespace, workspace.id)}/preview/` +
+        `${analysisTabPath(
+          workspace.namespace,
+          workspace.terraName
+        )}/preview/` +
         encodeURIComponentStrict(
           appendJupyterNotebookFileSuffix(notebookNameWithoutSuffix)
         );
@@ -232,7 +235,7 @@ export const ExportDatasetModal = ({
     dataSetApi()
       .previewExportToNotebook(
         workspace.namespace,
-        workspace.id,
+        workspace.terraName,
         createExportDatasetRequest(language)
       )
       .then((resp) => {
@@ -275,7 +278,7 @@ export const ExportDatasetModal = ({
       notebooksApi()
         .getNotebookKernel(
           workspace.namespace,
-          workspace.id,
+          workspace.terraName,
           appendJupyterNotebookFileSuffix(nameWithoutSuffix)
         )
         .then((resp) => {

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.spec.tsx
@@ -54,7 +54,7 @@ describe('GenomicExtractionModal', () => {
     testProps = {
       dataSet: dataset,
       workspaceNamespace: workspace.namespace,
-      workspaceFirecloudName: workspace.id,
+      workspaceFirecloudName: workspace.terraName,
       closeFunction: () => {},
       title: "Top 10 Egregious Hacks Your Tech Lead Doesn't Want You To Know",
     };

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.spec.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.spec.tsx
@@ -54,7 +54,7 @@ describe('GenomicExtractionModal', () => {
     testProps = {
       dataSet: dataset,
       workspaceNamespace: workspace.namespace,
-      workspaceFirecloudName: workspace.terraName,
+      workspaceTerraName: workspace.terraName,
       closeFunction: () => {},
       title: "Top 10 Egregious Hacks Your Tech Lead Doesn't Want You To Know",
     };

--- a/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
+++ b/ui/src/app/pages/data/data-set/genomic-extraction-modal.tsx
@@ -38,7 +38,7 @@ const TimeAgoWithVerboseTooltip = (epoch) => {
 interface Props {
   dataSet: DataSet;
   workspaceNamespace: string;
-  workspaceFirecloudName: string;
+  workspaceTerraName: string;
   closeFunction: Function;
   title?: string;
   cancelText?: string;
@@ -48,7 +48,7 @@ interface Props {
 export const GenomicExtractionModal = ({
   dataSet,
   workspaceNamespace,
-  workspaceFirecloudName,
+  workspaceTerraName,
   closeFunction,
   title,
   cancelText,
@@ -60,7 +60,7 @@ export const GenomicExtractionModal = ({
 
   const { data: jobs, mutate } = useGenomicExtractionJobs(
     workspaceNamespace,
-    workspaceFirecloudName
+    workspaceTerraName
   );
   const mostRecentExtract: GenomicExtractionJob = fp.flow(
     fp.filter(
@@ -175,7 +175,7 @@ export const GenomicExtractionModal = ({
             try {
               const job = await dataSetApi().extractGenomicData(
                 workspaceNamespace,
-                workspaceFirecloudName,
+                workspaceTerraName,
                 dataSet.id
               );
               mutate(fp.concat(jobs, job));

--- a/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/data-component-tanagra.tsx
@@ -115,7 +115,7 @@ const mapTanagraWorkspaceResource = ({
   workspace: WorkspaceData;
 }): TanagraWorkspaceResource => ({
   workspaceNamespace: workspace.namespace,
-  workspaceFirecloudName: workspace.id, // TODO verify this is the correct value to set
+  workspaceFirecloudName: workspace.terraName, // TODO verify this is the correct value to set
   workspaceBillingStatus: workspace.billingStatus,
   cdrVersionId: workspace.cdrVersionId,
   accessTierShortName: workspace.accessTierShortName,
@@ -210,7 +210,7 @@ export const DataComponentTanagra = fp.flow(
 
   useEffect(() => {
     loadResources();
-  }, [workspace.namespace, workspace.id]);
+  }, [workspace.namespace, workspace.terraName]);
 
   const writePermission =
     workspace.accessLevel === WorkspaceAccessLevel.OWNER ||
@@ -243,7 +243,7 @@ export const DataComponentTanagra = fp.flow(
     navigate([
       'workspaces',
       workspace.namespace,
-      workspace.id,
+      workspace.terraName,
       'data',
       'tanagra',
       'cohorts',
@@ -308,7 +308,7 @@ export const DataComponentTanagra = fp.flow(
                 navigate([
                   'workspaces',
                   workspace.namespace,
-                  workspace.id,
+                  workspace.terraName,
                   'data',
                   'tanagra',
                   'export',

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-container.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-container.tsx
@@ -21,7 +21,7 @@ export const TanagraContainer = fp.flow(
 )(({ cdrVersionTiersResponse, hideSpinner, workspace }) => {
   const [navigate] = useNavigation();
   const { 0: splat } = useParams<{ 0: string }>();
-  const { cdrVersionId, id, namespace } = workspace;
+  const { cdrVersionId, namespace, terraName } = workspace;
   const { bigqueryDataset } = findCdrVersion(
     cdrVersionId,
     cdrVersionTiersResponse
@@ -35,7 +35,7 @@ export const TanagraContainer = fp.flow(
 
   useExitActionListener(() => {
     // Navigate to Data tab when exiting Tanagra iframe
-    navigate(['workspaces', namespace, id, 'data']);
+    navigate(['workspaces', namespace, terraName, 'data']);
   });
 
   useExportListener((exportResourceIds) => {

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-dev.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-dev.tsx
@@ -41,13 +41,13 @@ export const TanagraDev = fp.flow(
   ({
     cdrVersionTiersResponse,
     hideSpinner,
-    workspace: { cdrVersionId, id, namespace },
+    workspace: { cdrVersionId, namespace, terraName },
   }) => {
     const [navigate] = useNavigation();
 
     useExitActionListener(() => {
       // Navigate to Data tab when exiting Tanagra iframe
-      navigate(['workspaces', namespace, id, 'data']);
+      navigate(['workspaces', namespace, terraName, 'data']);
     });
 
     const { bigqueryDataset } = findCdrVersion(

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -75,10 +75,10 @@ interface NavProps {
 
 const WorkspaceNavigation = (props: NavProps) => {
   const {
-    workspace: { name, namespace, id },
+    workspace: { name, namespace, terraName },
     style,
   } = props;
-  const url = dataTabPath(namespace, id);
+  const url = dataTabPath(namespace, terraName);
 
   return (
     <Clickable>

--- a/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
+++ b/ui/src/app/pages/data/tanagra-dev/tanagra-resource-list.tsx
@@ -225,7 +225,7 @@ export const TanagraResourceList = fp.flow(
         cohortTanagra,
         conceptSetTanagra,
         reviewTanagra,
-        workspaceFirecloudName,
+        workspaceTerraName,
         workspaceNamespace,
       },
     } = rowData;
@@ -233,7 +233,7 @@ export const TanagraResourceList = fp.flow(
     let url = '';
     const urlPrefix = `${dataTabPath(
       workspaceNamespace,
-      workspaceFirecloudName
+      workspaceTerraName
     )}/tanagra`;
     if (cohortTanagra) {
       displayName = cohortTanagra.displayName;

--- a/ui/src/app/pages/workspace/featured-workspaces.spec.tsx
+++ b/ui/src/app/pages/workspace/featured-workspaces.spec.tsx
@@ -15,6 +15,7 @@ import { profileStore } from 'app/utils/stores';
 import { renderWithRouter } from 'testing/react-test-helpers';
 import { FeaturedWorkspacesApiStub } from 'testing/stubs/featured-workspaces-service-stub';
 import { ProfileApiStub } from 'testing/stubs/profile-api-stub';
+import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
 
 import { FeaturedWorkspaces } from './featured-workspaces';
 
@@ -89,7 +90,10 @@ describe('Featured Workspace List', () => {
         expect(screen.queryAllByTestId('workspace-card').length).toBe(2);
       });
       expect(
-        screen.queryByText('defaultWorkspace' + featuredCategory[index])
+        screen.queryByText(
+          WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME +
+            featuredCategory[index]
+        )
       ).toBeInTheDocument();
     });
   });

--- a/ui/src/app/pages/workspace/invalid-billing-banner.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner.tsx
@@ -40,11 +40,14 @@ export const InvalidBillingBanner = fp.flow(
       style={{ height: '38px', width: '70%', fontWeight: 400 }}
       onClick={() => {
         onClose();
-        navigate(['workspaces', workspace.namespace, workspace.id, 'edit'], {
-          queryParams: {
-            highlightBilling: true,
-          },
-        });
+        navigate(
+          ['workspaces', workspace.namespace, workspace.terraName, 'edit'],
+          {
+            queryParams: {
+              highlightBilling: true,
+            },
+          }
+        );
       }}
     >
       Edit Workspace

--- a/ui/src/app/pages/workspace/research-purpose.tsx
+++ b/ui/src/app/pages/workspace/research-purpose.tsx
@@ -109,7 +109,12 @@ export const ResearchPurpose = fp.flow(
           }}
           data-test-id='edit-workspace'
           onClick={() =>
-            navigate(['workspaces', workspace.namespace, workspace.id, 'edit'])
+            navigate([
+              'workspaces',
+              workspace.namespace,
+              workspace.terraName,
+              'edit',
+            ])
           }
         >
           <EditComponentReact

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -34,7 +34,11 @@ import {
   ProfileStubVariables,
 } from 'testing/stubs/profile-api-stub';
 import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
-import { userRolesStub, workspaceStubs } from 'testing/stubs/workspaces';
+import {
+  userRolesStub,
+  workspaceStubs,
+  WorkspaceStubVariables,
+} from 'testing/stubs/workspaces';
 import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { WorkspaceAbout } from './workspace-about';
@@ -118,7 +122,7 @@ describe('WorkspaceAbout', () => {
         name: /share/i,
       })
     );
-    screen.getByText('Share defaultWorkspace');
+    screen.getByText('Share ' + WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME);
   });
 
   test.each([

--- a/ui/src/app/pages/workspace/workspace-about.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.tsx
@@ -205,7 +205,10 @@ export const WorkspaceAbout = fp.flow(
 
     loadInitialCreditsUsage(workspace: WorkspaceData) {
       fetchWithErrorModal(() =>
-        workspacesApi().getBillingUsage(workspace.namespace, workspace.id)
+        workspacesApi().getBillingUsage(
+          workspace.namespace,
+          workspace.terraName
+        )
       ).then((usage: WorkspaceBillingUsageResponse) =>
         this.setState({ workspaceInitialCreditsUsage: usage.cost })
       );
@@ -238,7 +241,7 @@ export const WorkspaceAbout = fp.flow(
       fetchWithErrorModal(() =>
         workspacesApi().getFirecloudWorkspaceUserRoles(
           workspace.namespace,
-          workspace.id
+          workspace.terraName
         )
       ).then((resp: WorkspaceUserRolesResponse) =>
         this.setState({

--- a/ui/src/app/pages/workspace/workspace-card.tsx
+++ b/ui/src/app/pages/workspace/workspace-card.tsx
@@ -121,7 +121,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
         AnalyticsTracker.Workspaces.Delete();
         await workspacesApi().deleteWorkspace(
           this.props.workspace.namespace,
-          this.props.workspace.id
+          this.props.workspace.terraName
         );
         await this.props.reload();
       }
@@ -154,7 +154,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
     render() {
       const {
         workspace,
-        workspace: { accessTierShortName, adminLocked, namespace, id },
+        workspace: { accessTierShortName, adminLocked, namespace, terraName },
         accessLevel,
         tierAccessDisabled,
         navigate,
@@ -183,11 +183,21 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                             : AnalyticsTracker.Workspaces.OpenDuplicatePage(
                                 'Card'
                               );
-                          navigate(['workspaces', namespace, id, 'duplicate']);
+                          navigate([
+                            'workspaces',
+                            namespace,
+                            terraName,
+                            'duplicate',
+                          ]);
                         }}
                         onEdit={() => {
                           AnalyticsTracker.Workspaces.OpenEditPage('Card');
-                          navigate(['workspaces', namespace, id, 'edit']);
+                          navigate([
+                            'workspaces',
+                            namespace,
+                            terraName,
+                            'edit',
+                          ]);
                         }}
                         onDelete={() => {
                           AnalyticsTracker.Workspaces.OpenDeleteModal('Card');
@@ -232,7 +242,7 @@ export const WorkspaceCard = fp.flow(withNavigation)(
                       analyticsFn={() => this.trackWorkspaceNavigation()}
                       data-test-id={'workspace-card-link'}
                       propagateDataTestId
-                      path={dataTabPath(namespace, id)}
+                      path={dataTabPath(namespace, terraName)}
                     >
                       <TooltipTrigger
                         content={

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1145,7 +1145,7 @@ export const WorkspaceEdit = fp.flow(
         async () =>
           await workspacesApi().duplicateWorkspaceAsync(
             this.props.workspace.namespace,
-            this.props.workspace.id,
+            this.props.workspace.terraName,
             {
               includeUserRoles: this.state.cloneUserRole,
               workspace: this.state.workspace,
@@ -1170,14 +1170,14 @@ export const WorkspaceEdit = fp.flow(
         } else {
           workspace = await workspacesApi().updateWorkspace(
             this.state.workspace.namespace,
-            this.state.workspace.id,
+            this.state.workspace.terraName,
             { workspace: this.state.workspace }
           );
           // TODO: Investigate removing this GET call, the response from Update should suffice here.
           await workspacesApi()
             .getWorkspace(
               this.state.workspace.namespace,
-              this.state.workspace.id
+              this.state.workspace.terraName
             )
             .then((ws) =>
               currentWorkspaceStore.next({
@@ -1188,20 +1188,23 @@ export const WorkspaceEdit = fp.flow(
           this.props.navigate([
             'workspaces',
             workspace.namespace,
-            workspace.id,
+            workspace.terraName,
             'data',
           ]);
           return;
         }
 
         const { workspace: updatedWorkspace, accessLevel: updatedAccessLevel } =
-          await workspacesApi().getWorkspace(workspace.namespace, workspace.id);
+          await workspacesApi().getWorkspace(
+            workspace.namespace,
+            workspace.terraName
+          );
 
         const navigateToWorkspace = () => {
           this.props.navigate([
             'workspaces',
             updatedWorkspace.namespace,
-            updatedWorkspace.id,
+            updatedWorkspace.terraName,
             'data',
           ]);
         };

--- a/ui/src/app/pages/workspace/workspace-list.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.spec.tsx
@@ -108,9 +108,9 @@ describe('WorkspaceList', () => {
       workspaceOwn,
     ];
     workspacesApiStub.workspaceAccess = new Map([
-      [workspaceRead.id, WorkspaceAccessLevel.READER],
-      [workspaceWrite.id, WorkspaceAccessLevel.WRITER],
-      [workspaceOwn.id, WorkspaceAccessLevel.OWNER],
+      [workspaceRead.terraName, WorkspaceAccessLevel.READER],
+      [workspaceWrite.terraName, WorkspaceAccessLevel.WRITER],
+      [workspaceOwn.terraName, WorkspaceAccessLevel.OWNER],
     ]);
 
     component();

--- a/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.spec.tsx
@@ -29,7 +29,7 @@ describe('WorkspaceNavBar', () => {
     return render(
       <MemoryRouter
         initialEntries={[
-          `/${workspaceDataStub.namespace}/${workspaceDataStub.id}`,
+          `/${workspaceDataStub.namespace}/${workspaceDataStub.terraName}`,
         ]}
       >
         <Route path='/:ns/:terraName'>
@@ -72,7 +72,7 @@ describe('WorkspaceNavBar', () => {
     expect(mockNavigate).toHaveBeenCalledWith([
       'workspaces',
       workspaceDataStub.namespace,
-      workspaceDataStub.id,
+      workspaceDataStub.terraName,
       analysisTabName,
     ]);
 
@@ -80,7 +80,7 @@ describe('WorkspaceNavBar', () => {
     expect(mockNavigate).toHaveBeenCalledWith([
       'workspaces',
       workspaceDataStub.namespace,
-      workspaceDataStub.id,
+      workspaceDataStub.terraName,
       'data',
     ]);
 
@@ -88,7 +88,7 @@ describe('WorkspaceNavBar', () => {
     expect(mockNavigate).toHaveBeenCalledWith([
       'workspaces',
       workspaceDataStub.namespace,
-      workspaceDataStub.id,
+      workspaceDataStub.terraName,
       'about',
     ]);
   });
@@ -106,7 +106,7 @@ describe('WorkspaceNavBar', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith([
       'workspaces',
       workspaceDataStub.namespace,
-      workspaceDataStub.id,
+      workspaceDataStub.terraName,
       'data',
     ]);
 
@@ -114,7 +114,7 @@ describe('WorkspaceNavBar', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith([
       'workspaces',
       workspaceDataStub.namespace,
-      workspaceDataStub.id,
+      workspaceDataStub.terraName,
       analysisTabName,
     ]);
   });

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -87,9 +87,9 @@ const CdrVersion = (props: {
   cdrVersionTiersResponse: CdrVersionTiersResponse;
 }) => {
   const { workspace, cdrVersionTiersResponse } = props;
-  const { namespace, id } = workspace;
+  const { namespace, terraName } = workspace;
 
-  const localStorageKey = `${namespace}-${id}-user-dismissed-cdr-version-update-alert`;
+  const localStorageKey = `${namespace}-${terraName}-user-dismissed-cdr-version-update-alert`;
 
   const dismissedInLocalStorage = () =>
     localStorage.getItem(localStorageKey) === USER_DISMISSED_ALERT_VALUE;
@@ -134,7 +134,9 @@ const CdrVersion = (props: {
             ).name
           }
           onClose={() => setShowModal(false)}
-          upgrade={() => navigate(['workspaces', namespace, id, 'duplicate'])}
+          upgrade={() =>
+            navigate(['workspaces', namespace, terraName, 'duplicate'])
+          }
         />
       )}
     </FlexRow>

--- a/ui/src/app/pages/workspace/workspace-share.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.spec.tsx
@@ -28,7 +28,7 @@ import { WorkspacesApiStub } from 'testing/stubs/workspaces-api-stub';
 
 import { WorkspaceShare, WorkspaceShareProps } from './workspace-share';
 
-describe('WorkspaceShare', () => {
+describe(WorkspaceShare.name, () => {
   let props: WorkspaceShareProps;
   let user;
 
@@ -76,13 +76,13 @@ describe('WorkspaceShare', () => {
     role: WorkspaceAccessLevel.NO_ACCESS,
   };
 
-  const tomRiddleDiary = {
+  const tomRiddleDiary: WorkspaceData = {
     namespace: 'Horcrux',
     name: 'The Diary of Tom Marvolo Riddle',
+    terraName: 'diary',
     etag: '1',
-    id: 'The Diary of Tom Marvolo Riddle',
     accessLevel: WorkspaceAccessLevel.OWNER,
-  } as WorkspaceData;
+  };
   const tomRiddleDiaryUserRoles = [harryRole, hermioneRole, ronRole];
 
   const getUserRoleDropdownLabel = (desiredUser: User) => {
@@ -264,7 +264,7 @@ describe('WorkspaceShare', () => {
     );
     expect(spy).toHaveBeenCalledWith(
       tomRiddleDiary.namespace,
-      tomRiddleDiary.name,
+      tomRiddleDiary.terraName,
       {
         workspaceEtag: tomRiddleDiary.etag,
         items: [

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -228,7 +228,7 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
       try {
         const resp = await workspacesApi().getFirecloudWorkspaceUserRoles(
           this.props.workspace.namespace,
-          this.props.workspace.id
+          this.props.workspace.terraName
         );
         this.setState({
           userRoles: fp.sortBy('familyName', resp.items),
@@ -251,7 +251,7 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
       workspacesApi()
         .shareWorkspacePatch(
           this.props.workspace.namespace,
-          this.props.workspace.id,
+          this.props.workspace.terraName,
           {
             workspaceEtag: this.props.workspace.etag,
             items: this.state.userRolesToChange,
@@ -724,7 +724,8 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
           {!this.state.workspaceFound && (
             <div>
               <h3>
-                The workspace {this.props.workspace.id} could not be found
+                The workspace {this.props.workspace.terraName} could not be
+                found
               </h3>
             </div>
           )}

--- a/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
@@ -63,7 +63,10 @@ describe(WorkspaceWrapper.name, () => {
     render(
       <MemoryRouter
         initialEntries={[
-          workspacePath(workspaceDataStub.namespace, workspaceDataStub.id),
+          workspacePath(
+            workspaceDataStub.namespace,
+            workspaceDataStub.terraName
+          ),
         ]}
       >
         <Route path='/workspaces/:ns/:terraName'>
@@ -85,7 +88,7 @@ describe(WorkspaceWrapper.name, () => {
     await createWrapperAndWaitForLoad();
     expect(spy).toHaveBeenCalledWith(
       workspaceDataStub.namespace,
-      workspaceDataStub.id
+      workspaceDataStub.terraName
     );
 
     // populated with the result of getWorkspace()
@@ -98,19 +101,19 @@ describe(WorkspaceWrapper.name, () => {
     currentWorkspaceStore.next({
       ...workspaceDataStub,
       namespace: 'something else',
-      id: 'some other ID',
+      terraName: 'some other ID',
     });
     nextWorkspaceWarmupStore.next({
       ...workspaceDataStub,
       namespace: 'another one',
-      id: 'definitely not a match',
+      terraName: 'definitely not a match',
     });
 
     const spy = jest.spyOn(workspacesApi(), 'getWorkspace');
     await createWrapperAndWaitForLoad();
     expect(spy).toHaveBeenCalledWith(
       workspaceDataStub.namespace,
-      workspaceDataStub.id
+      workspaceDataStub.terraName
     );
 
     // populated with the result of getWorkspace()
@@ -124,7 +127,7 @@ describe(WorkspaceWrapper.name, () => {
     const nextWs = {
       ...workspaceDataStub,
       namespace: 'something else',
-      id: 'some other ID',
+      terraName: 'some other ID',
     };
     nextWorkspaceWarmupStore.next(nextWs);
 
@@ -158,7 +161,7 @@ describe(WorkspaceWrapper.name, () => {
       currentWorkspaceStore.next({
         ...workspaceDataStub,
         namespace: 'something else',
-        id: 'some other ID',
+        terraName: 'some other ID',
       });
       nextWorkspaceWarmupStore.next(workspaceDataStub);
 

--- a/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.spec.tsx
@@ -101,7 +101,7 @@ describe(WorkspaceWrapper.name, () => {
     currentWorkspaceStore.next({
       ...workspaceDataStub,
       namespace: 'something else',
-      terraName: 'some other ID',
+      terraName: 'some other terraName',
     });
     nextWorkspaceWarmupStore.next({
       ...workspaceDataStub,
@@ -127,7 +127,7 @@ describe(WorkspaceWrapper.name, () => {
     const nextWs = {
       ...workspaceDataStub,
       namespace: 'something else',
-      terraName: 'some other ID',
+      terraName: 'some other terraName',
     };
     nextWorkspaceWarmupStore.next(nextWs);
 
@@ -161,7 +161,7 @@ describe(WorkspaceWrapper.name, () => {
       currentWorkspaceStore.next({
         ...workspaceDataStub,
         namespace: 'something else',
-        terraName: 'some other ID',
+        terraName: 'some other terraName',
       });
       nextWorkspaceWarmupStore.next(workspaceDataStub);
 

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -248,7 +248,7 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
       wsInCurrentStore &&
       // can't use ?. here because we don't want to match against undefined
       wsInCurrentStore.namespace === ns &&
-      wsInCurrentStore.id === terraName
+      wsInCurrentStore.terraName === terraName
     ) {
       updateRuntimeStores({
         workspaceNamespace: ns,
@@ -266,7 +266,7 @@ export const WorkspaceWrapper = ({ hideSpinner }) => {
         wsInNextStore &&
         // can't use ?. here because we don't want to match against undefined
         wsInNextStore.namespace === ns &&
-        wsInNextStore.id === terraName
+        wsInNextStore.terraName === terraName
       ) {
         currentWorkspaceStore.next(wsInNextStore);
         updateRuntimeStores({

--- a/ui/src/app/services/review-state.service.ts
+++ b/ui/src/app/services/review-state.service.ts
@@ -120,14 +120,11 @@ export const reviewPaginationStore = new BehaviorSubject<any>(
   initialPaginationState
 );
 
-export function getVocabOptions(
-  workspaceNamespace: string,
-  workspaceId: string
-) {
+export function getVocabOptions(workspaceNamespace: string, terraName: string) {
   const vocabFilters = { source: {}, standard: {} };
   try {
     cohortReviewApi()
-      .getVocabularies(workspaceNamespace, workspaceId)
+      .getVocabularies(workspaceNamespace, terraName)
       .then((response) => {
         response.items.forEach((item) => {
           const type = item.type.toLowerCase();

--- a/ui/src/app/utils/cdr-versions.spec.tsx
+++ b/ui/src/app/utils/cdr-versions.spec.tsx
@@ -17,7 +17,7 @@ import { WorkspaceStubVariables } from 'testing/stubs/workspaces';
 
 const stubWorkspace: Workspace = {
   name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
-  id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+  terraName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
   namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
 };
 

--- a/ui/src/app/utils/resources.spec.tsx
+++ b/ui/src/app/utils/resources.spec.tsx
@@ -181,15 +181,15 @@ describe('resources.tsx', () => {
   });
 
   it('should return resource URLs', () => {
-    const { DEFAULT_WORKSPACE_NS, DEFAULT_WORKSPACE_ID } =
+    const { DEFAULT_WORKSPACE_NS, DEFAULT_WORKSPACE_TERRA_NAME } =
       WorkspaceStubVariables;
     const dataTabPrefix = dataTabPath(
       DEFAULT_WORKSPACE_NS,
-      DEFAULT_WORKSPACE_ID
+      DEFAULT_WORKSPACE_TERRA_NAME
     );
     const analysisTabPrefix = analysisTabPath(
       DEFAULT_WORKSPACE_NS,
-      DEFAULT_WORKSPACE_ID
+      DEFAULT_WORKSPACE_TERRA_NAME
     );
     const EXPECTED_COHORT_URL = `${dataTabPrefix}/cohorts/build?cohortId=${COHORT_ID}`;
     const EXPECTED_COHORT_REVIEW_URL = `${dataTabPrefix}/cohorts/${COHORT_REVIEW_COHORT_ID}/reviews/${COHORT_REVIEW_ID}`;

--- a/ui/src/app/utils/resources.tsx
+++ b/ui/src/app/utils/resources.tsx
@@ -133,7 +133,7 @@ export function convertToResource(
 ): WorkspaceResource {
   const {
     namespace,
-    id,
+    terraName,
     accessLevel,
     accessTierShortName,
     adminLocked,
@@ -142,7 +142,7 @@ export function convertToResource(
   } = workspace;
   return {
     workspaceNamespace: namespace,
-    workspaceFirecloudName: id,
+    workspaceFirecloudName: terraName,
     permission: WorkspaceAccessLevel[accessLevel],
     accessTierShortName,
     cdrVersionId,

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -52,14 +52,14 @@ export const cdrVersionStore = atom<CdrVersionStore>({});
 
 export const useGenomicExtractionJobs = (
   workspaceNamespace: string,
-  workspaceId: string,
+  terraName: string,
   pollWhileNonTerminal = true
 ) =>
   useSWR(
-    `/api/workspaces/${workspaceNamespace}/${workspaceId}/genomicExtractionJobs`,
+    `/api/workspaces/${workspaceNamespace}/${terraName}/genomicExtractionJobs`,
     () =>
       dataSetApi()
-        .getGenomicExtractionJobs(workspaceNamespace, workspaceId)
+        .getGenomicExtractionJobs(workspaceNamespace, terraName)
         .then(({ jobs }) => jobs),
     {
       // Genomic jobs will rarely change without user interaction. Avoid some extraneous revalidation.
@@ -88,7 +88,7 @@ export const useGenomicExtractionJobs = (
 export const withGenomicExtractionJobs = (WrappedComponent) => (props) => {
   const { data } = useGenomicExtractionJobs(
     props.workspace.namespace,
-    props.workspace.id
+    props.workspace.terraName
   );
   return <WrappedComponent genomicExtractionJobs={data} {...props} />;
 };

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -215,7 +215,7 @@ export const isInteractiveUserApp = (appType: AppType) =>
 
 export const openAppInIframe = (
   workspaceNamespace: string,
-  workspaceId: string,
+  terraName: string,
   userApp: UserAppEnvironment,
   navigate: NavigateFn
 ) => {
@@ -237,11 +237,7 @@ export const openAppInIframe = (
     )
   );
   navigate([
-    appDisplayPath(
-      workspaceNamespace,
-      workspaceId,
-      toUIAppType[userApp.appType]
-    ),
+    appDisplayPath(workspaceNamespace, terraName, toUIAppType[userApp.appType]),
   ]);
 };
 
@@ -251,14 +247,14 @@ export const isDiskSizeValid = (appRequest) =>
 
 export const openAppOrConfigPanel = (
   workspaceNamespace: string,
-  workspaceId: string,
+  terraName: string,
   userApps: ListAppsResponse,
   requestedApp: UIAppType,
   navigate: NavigateFn
 ) => {
   const userApp = findApp(userApps, requestedApp);
   if (userApp?.status === AppStatus.RUNNING) {
-    openAppInIframe(workspaceNamespace, workspaceId, userApp, navigate);
+    openAppInIframe(workspaceNamespace, terraName, userApp, navigate);
   } else {
     openConfigPanelForUIApp(requestedApp);
   }

--- a/ui/src/testing/stubs/cohorts-api-stub.ts
+++ b/ui/src/testing/stubs/cohorts-api-stub.ts
@@ -15,7 +15,7 @@ import { WorkspaceStubVariables } from './workspaces';
 export const DEFAULT_COHORT_ID = 1;
 export const DEFAULT_COHORT_ID_2 = 2;
 
-export const exampleCohortStubs = [
+export const exampleCohortStubs: CohortStub[] = [
   {
     id: DEFAULT_COHORT_ID,
     name: 'sample name',
@@ -23,7 +23,7 @@ export const exampleCohortStubs = [
     criteria:
       '{"includes":[{"temporal": false,"items":[]},{"temporal": false,"items":[]}],"excludes":[],"dataFilters":[]}',
     type: '',
-    workspaceId: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+    terraName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
     creationTime: new Date().getTime(),
     lastModifiedTime: new Date().getTime() - 1000,
   },
@@ -35,7 +35,7 @@ export const exampleCohortStubs = [
       '{"includes":[{"temporal": false,"items":[]},{"temporal": false,"items":[]}],' +
       '"excludes":[{"temporal": false,"items":[]}],"dataFilters":[]}',
     type: '',
-    workspaceId: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+    terraName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
     creationTime: new Date().getTime(),
     lastModifiedTime: new Date().getTime() - 4000,
   },
@@ -58,7 +58,7 @@ class CohortStub implements Cohort {
 
   lastModifiedTime?: number;
 
-  workspaceId: string;
+  terraName: string;
 
   constructor(cohort: Cohort, terraName: string) {
     this.creationTime = cohort.creationTime;
@@ -69,7 +69,7 @@ class CohortStub implements Cohort {
     this.lastModifiedTime = cohort.lastModifiedTime;
     this.name = cohort.name;
     this.type = cohort.type;
-    this.workspaceId = terraName;
+    this.terraName = terraName;
   }
 }
 
@@ -83,7 +83,7 @@ export class CohortsApiStub extends CohortsApi {
 
     const stubWorkspace: Workspace = {
       name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME,
-      id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+      terraName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
       namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
     };
 
@@ -103,7 +103,7 @@ export class CohortsApiStub extends CohortsApi {
   ): Promise<Cohort> {
     return new Promise<Cohort>((resolve, reject) => {
       const index = this.cohorts.findIndex((cohort: CohortStub) => {
-        if (cohort.id === cid && cohort.workspaceId) {
+        if (cohort.id === cid && cohort.terraName) {
           return true;
         }
         return false;
@@ -146,7 +146,7 @@ export class CohortsApiStub extends CohortsApi {
     return new Promise<CohortListResponse>((resolve, reject) => {
       const cohortsInWorkspace: Cohort[] = [];
       this.cohorts.forEach((cohort) => {
-        if (cohort.workspaceId === terraName) {
+        if (cohort.terraName === terraName) {
           cohortsInWorkspace.push(cohort);
         }
       });
@@ -158,7 +158,11 @@ export class CohortsApiStub extends CohortsApi {
     });
   }
 
-  getCohort(namespace, id, cohortId): Promise<Cohort> {
+  getCohort(
+    _ns: string,
+    _terraName: string,
+    cohortId: number
+  ): Promise<Cohort> {
     const cohort =
       this.cohorts.find((c) => c.id === cohortId) || this.cohorts[0];
     return new Promise<Cohort>((resolve) => resolve(cohort));

--- a/ui/src/testing/stubs/concept-sets-api-stub.ts
+++ b/ui/src/testing/stubs/concept-sets-api-stub.ts
@@ -168,8 +168,8 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
   }
 
   public getConceptSet(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     conceptSetId: number
   ): Promise<ConceptSet> {
     return new Promise<ConceptSet>((resolve) => {
@@ -178,8 +178,8 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
   }
 
   public updateConceptSet(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     conceptSetId: number,
     req: ConceptSet
   ): Promise<ConceptSet> {
@@ -192,8 +192,8 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
   }
 
   public deleteConceptSet(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     conceptSetId: number
   ): Promise<EmptyResponse> {
     return new Promise<EmptyResponse>((resolve) => {
@@ -207,8 +207,8 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
   }
 
   public createConceptSet(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     conceptSetRequest: CreateConceptSetRequest
   ): Promise<ConceptSet> {
     return new Promise<ConceptSet>((resolve) => {
@@ -218,8 +218,8 @@ export class ConceptSetsApiStub extends ConceptSetsApi {
   }
 
   public updateConceptSetConcepts(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     conceptSetId: number,
     req: UpdateConceptSetRequest
   ): Promise<ConceptSet> {

--- a/ui/src/testing/stubs/data-set-api-stub.ts
+++ b/ui/src/testing/stubs/data-set-api-stub.ts
@@ -59,8 +59,8 @@ export class DataSetApiStub extends DataSetApi {
   }
 
   previewDataSetByDomain(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     dataSetPreviewRequest: DataSetPreviewRequest
   ): Promise<DataSetPreviewResponse> {
     return Promise.resolve({
@@ -82,8 +82,8 @@ export class DataSetApiStub extends DataSetApi {
   }
 
   public getValuesFromDomain(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     domain: string
   ): Promise<DomainValuesResponse> {
     const domainValueItems = [];

--- a/ui/src/testing/stubs/featured-workspaces-config-api-stub.ts
+++ b/ui/src/testing/stubs/featured-workspaces-config-api-stub.ts
@@ -7,18 +7,20 @@ import {
 
 import { WorkspaceStubVariables } from './workspaces';
 
-const phenotypeWorkspace = {
+const phenotypeWorkspace: FeaturedWorkspace = {
   name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME + ' Phenotype Library',
   namespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS + ' Phenotype Library',
-  id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + ' Phenotype Library',
+  id:
+    WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME + ' Phenotype Library',
   category: FeaturedWorkspaceCategory.PHENOTYPE_LIBRARY,
 };
 
-const tutorialWorkspace = {
+const tutorialWorkspace: FeaturedWorkspace = {
   name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME + ' Tutorial Workspace',
   namespace:
     WorkspaceStubVariables.DEFAULT_WORKSPACE_NS + ' Tutorial Workspace',
-  id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + ' Tutorial Workspace',
+  id:
+    WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME + ' Tutorial Workspace',
   category: FeaturedWorkspaceCategory.TUTORIAL_WORKSPACES,
 };
 

--- a/ui/src/testing/stubs/notebooks-api-stub.ts
+++ b/ui/src/testing/stubs/notebooks-api-stub.ts
@@ -45,8 +45,8 @@ export class NotebooksApiStub extends NotebooksApi {
   }
 
   cloneNotebook(
-    workspaceNamespace: string,
-    workspaceId: string,
+    _ns: string,
+    _terraName: string,
     notebookName: string
   ): Promise<any> {
     return new Promise<any>((resolve) => {

--- a/ui/src/testing/stubs/resources-stub.ts
+++ b/ui/src/testing/stubs/resources-stub.ts
@@ -29,7 +29,7 @@ export function convertToResources(
 
 export const stubResource: WorkspaceResource = {
   workspaceNamespace: WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-  workspaceFirecloudName: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID,
+  workspaceFirecloudName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME,
   workspaceId: 1,
   permission: 'OWNER',
   cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,

--- a/ui/src/testing/stubs/runtime-api-stub.ts
+++ b/ui/src/testing/stubs/runtime-api-stub.ts
@@ -129,7 +129,7 @@ export class RuntimeApiStub extends RuntimeApi {
 
   localize(): Promise<RuntimeLocalizeResponse> {
     return new Promise<RuntimeLocalizeResponse>((resolve) => {
-      resolve({ runtimeLocalDirectory: 'workspaces/${req.workspaceId}' });
+      resolve({ runtimeLocalDirectory: 'workspaces-local-dir' });
     });
   }
 }

--- a/ui/src/testing/stubs/workspaces.tsx
+++ b/ui/src/testing/stubs/workspaces.tsx
@@ -14,7 +14,7 @@ import { CdrVersionsStubVariables } from './cdr-versions-api-stub';
 export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_NS = 'defaultNamespace';
   static DEFAULT_WORKSPACE_NAME = 'defaultWorkspace';
-  static DEFAULT_WORKSPACE_TERRA_NAME = '1';
+  static DEFAULT_WORKSPACE_TERRA_NAME = 'one';
   static DEFAULT_WORKSPACE_PERMISSION = WorkspaceAccessLevel.OWNER;
   static DEFAULT_GOOGLE_PROJECT_ID = 'terra-vpc-sc-test';
   static DEFAULT_GOOGLE_BUCKET_NAME = 'fc-secure-bucket';

--- a/ui/src/testing/stubs/workspaces.tsx
+++ b/ui/src/testing/stubs/workspaces.tsx
@@ -14,7 +14,7 @@ import { CdrVersionsStubVariables } from './cdr-versions-api-stub';
 export class WorkspaceStubVariables {
   static DEFAULT_WORKSPACE_NS = 'defaultNamespace';
   static DEFAULT_WORKSPACE_NAME = 'defaultWorkspace';
-  static DEFAULT_WORKSPACE_ID = '1';
+  static DEFAULT_WORKSPACE_TERRA_NAME = '1';
   static DEFAULT_WORKSPACE_PERMISSION = WorkspaceAccessLevel.OWNER;
   static DEFAULT_GOOGLE_PROJECT_ID = 'terra-vpc-sc-test';
   static DEFAULT_GOOGLE_BUCKET_NAME = 'fc-secure-bucket';
@@ -23,7 +23,7 @@ export class WorkspaceStubVariables {
 export function buildWorkspaceStub(suffix = ''): Workspace {
   return {
     name: WorkspaceStubVariables.DEFAULT_WORKSPACE_NAME + suffix,
-    id: WorkspaceStubVariables.DEFAULT_WORKSPACE_ID + suffix,
+    terraName: WorkspaceStubVariables.DEFAULT_WORKSPACE_TERRA_NAME + suffix,
     googleProject: WorkspaceStubVariables.DEFAULT_GOOGLE_PROJECT_ID + suffix,
     googleBucketName:
       WorkspaceStubVariables.DEFAULT_GOOGLE_BUCKET_NAME + suffix,


### PR DESCRIPTION
I'm removing "id" on the Workspace entity model (not in this PR) because it is incorrect: it's not the RWB DB ID and it's also not the Terra/Firecloud DB ID.  Instead it refers to the Terra **name** of the workspace.  In a previous PR, I duplicated the "id" field to "terraName" and here I am switching the UI uses of the bad field to the good one.

Also a few other related changes, like renaming "firecloud name" to "terra name"

Tested locally by temporarily removing the "id" field from the Workspace entity.  I can't do that in this PR due to release sequencing safety.  No changes observed.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
