### PR TITLE
[risk=low][no ticket] Use Worspace.terraName instead of id throughout api

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
@@ -38,14 +38,14 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
           try {
             impersonatedWorkspaceService.deleteWorkspace(
                 workspace.getUsername(),
-                workspace.getWsNamespace(),
-                workspace.getWsFirecloudId(),
+                workspace.getNamespace(),
+                workspace.getTerraName(),
                 DELETE_BILLING_PROJECTS);
           } catch (NotFoundException e) {
             LOGGER.info(
                 String.format(
                     "Workspace %s/%s was not found",
-                    workspace.getWsNamespace(), workspace.getWsFirecloudId()));
+                    workspace.getNamespace(), workspace.getTerraName()));
           }
         });
 
@@ -66,15 +66,15 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
           try {
             impersonatedWorkspaceService.deleteOrphanedRawlsWorkspace(
                 workspace.getUsername(),
-                workspace.getWsNamespace(),
-                workspace.getWsGoogleProject(),
-                workspace.getWsFirecloudId(),
+                workspace.getNamespace(),
+                workspace.getGoogleProject(),
+                workspace.getTerraName(),
                 DELETE_BILLING_PROJECTS);
           } catch (NotFoundException e) {
             LOGGER.info(
                 String.format(
                     "Workspace %s/%s was not found in Rawls",
-                    workspace.getWsNamespace(), workspace.getWsFirecloudId()));
+                    workspace.getNamespace(), workspace.getTerraName()));
           }
         });
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
@@ -15,6 +15,7 @@ import org.pmiops.workbench.model.TestUserRawlsWorkspace;
 import org.pmiops.workbench.model.TestUserWorkspace;
 import org.pmiops.workbench.model.WorkspaceResponse;
 import org.pmiops.workbench.utils.UserUtils;
+import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,21 +24,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
   private static final Logger LOGGER = Logger.getLogger(OfflineTestUsersController.class.getName());
 
-  private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final ImpersonatedUserService impersonatedUserService;
   private final ImpersonatedWorkspaceService impersonatedWorkspaceService;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final TaskQueueService taskQueueService;
+  private final WorkspaceMapper workspaceMapper;
 
   @Autowired
   public OfflineTestUsersController(
-      Provider<WorkbenchConfig> workbenchConfigProvider,
       ImpersonatedUserService impersonatedUserService,
       ImpersonatedWorkspaceService impersonatedWorkspaceService,
-      TaskQueueService taskQueueService) {
-    this.workbenchConfigProvider = workbenchConfigProvider;
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      TaskQueueService taskQueueService,
+      WorkspaceMapper workspaceMapper) {
     this.impersonatedUserService = impersonatedUserService;
     this.impersonatedWorkspaceService = impersonatedWorkspaceService;
     this.taskQueueService = taskQueueService;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+    this.workspaceMapper = workspaceMapper;
   }
 
   @Override
@@ -118,12 +122,7 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
             username, workspaces.size()));
 
     return workspaces.stream()
-        .map(
-            ws ->
-                new TestUserWorkspace()
-                    .username(username)
-                    .wsNamespace(ws.getWorkspace().getNamespace())
-                    .wsFirecloudId(ws.getWorkspace().getId()));
+        .map(ws -> workspaceMapper.toTestUserWorkspace(ws.getWorkspace(), username));
   }
 
   private Stream<TestUserRawlsWorkspace> enumerateRawlsWorkspaces(String username) {

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineTestUsersController.java
@@ -133,12 +133,6 @@ public class OfflineTestUsersController implements OfflineTestUsersApiDelegate {
             username, workspaces.size()));
 
     return workspaces.stream()
-        .map(
-            ws ->
-                new TestUserRawlsWorkspace()
-                    .username(username)
-                    .wsNamespace(ws.getWorkspace().getNamespace())
-                    .wsGoogleProject(ws.getWorkspace().getGoogleProject())
-                    .wsFirecloudId(ws.getWorkspace().getName()));
+        .map(ws -> workspaceMapper.toTestUserRawlsWorkspace(ws.getWorkspace(), username));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -320,8 +320,8 @@ public class WorkspacesController implements WorkspacesApiDelegate {
           workspaceOperationDao.save(operation.setStatus(DbWorkspaceOperationStatus.PROCESSING));
 
       Workspace w = workspaceAction.get();
-      // careful: w.getId() refers to the Terra Name, not the DB ID
-      long workspaceId = workspaceDao.getRequired(w.getNamespace(), w.getId()).getWorkspaceId();
+      long workspaceId =
+          workspaceDao.getRequired(w.getNamespace(), w.getTerraName()).getWorkspaceId();
       log.info(
           String.format(
               "processWorkspaceTask: recording SUCCESS for operation %d - workspace ID %d",

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -17,6 +17,7 @@ import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.TestUserRawlsWorkspace;
 import org.pmiops.workbench.model.TestUserWorkspace;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -185,8 +186,8 @@ public interface WorkspaceMapper {
     return String.valueOf(cdrVersion.getCdrVersionId());
   }
 
-  @Mapping(target = "wsNamespace", source = "workspace.namespace")
-  // TODO: change TestUserWorkspace.wsFirecloudId to terraName
-  @Mapping(target = "wsFirecloudId", source = "workspace.terraName")
   TestUserWorkspace toTestUserWorkspace(Workspace workspace, String username);
+
+  @Mapping(target = "terraName", source = "workspace.name")
+  TestUserRawlsWorkspace toTestUserRawlsWorkspace(RawlsWorkspaceDetails workspace, String username);
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -17,6 +17,7 @@ import org.pmiops.workbench.featuredworkspace.FeaturedWorkspaceService;
 import org.pmiops.workbench.model.CdrVersion;
 import org.pmiops.workbench.model.RecentWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
+import org.pmiops.workbench.model.TestUserWorkspace;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceResponse;
@@ -183,4 +184,9 @@ public interface WorkspaceMapper {
   default String cdrVersionId(CdrVersion cdrVersion) {
     return String.valueOf(cdrVersion.getCdrVersionId());
   }
+
+  @Mapping(target = "wsNamespace", source = "workspace.namespace")
+  // TODO: change TestUserWorkspace.wsFirecloudId to terraName
+  @Mapping(target = "wsFirecloudId", source = "workspace.terraName")
+  TestUserWorkspace toTestUserWorkspace(Workspace workspace, String username);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -11583,39 +11583,39 @@ components:
     TestUserWorkspace:
       required:
       - username
-      - wsFirecloudId
-      - wsNamespace
+      - namespace
+      - terraName
       type: object
       properties:
         username:
           type: string
           description: Test username (email address including GSuite)
-        wsNamespace:
+        namespace:
           type: string
           description: Workspace Namespace
-        wsFirecloudId:
+        terraName:
           type: string
-          description: Firecloud ID for the Workspace
+          description: The name of the Workspace in Terra
     TestUserRawlsWorkspace:
       required:
       - username
-      - wsFirecloudId
-      - wsGoogleProject
-      - wsNamespace
+      - namespace
+      - googleProject
+      - terraName
       type: object
       properties:
         username:
           type: string
           description: Test username (email address including GSuite)
-        wsNamespace:
+        namespace:
           type: string
           description: Workspace Namespace
-        wsGoogleProject:
+        googleProject:
           type: string
           description: Workspace Google Project
-        wsFirecloudId:
+        terraName:
           type: string
-          description: Firecloud ID for the Workspace
+          description: The name of the Workspace in Terra
     CreateWorkspaceTaskRequest:
       required:
       - operationId

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -115,9 +115,9 @@ public class WorkspaceAuditorTest {
 
     workspace1 =
         new Workspace()
-            .terraName("fc-id-1")
             .etag("etag_1")
             .name("DbWorkspace 1")
+            .terraName("dbworkspace1")
             .namespace("aou-rw-local1-c4be869a")
             .cdrVersionId("1")
             .creator("user@fake-research-aou.org")

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/WorkspaceAuditorTest.java
@@ -115,7 +115,7 @@ public class WorkspaceAuditorTest {
 
     workspace1 =
         new Workspace()
-            .id("fc-id-1")
+            .terraName("fc-id-1")
             .etag("etag_1")
             .name("DbWorkspace 1")
             .namespace("aou-rw-local1-c4be869a")
@@ -168,7 +168,7 @@ public class WorkspaceAuditorTest {
 
   @Test
   public void testFiresDuplicateEvent() {
-    final Workspace workspace2 = clone(workspace1).id(String.valueOf(WORKSPACE_2_DB_ID));
+    final Workspace workspace2 = clone(workspace1).terraName(String.valueOf(WORKSPACE_2_DB_ID));
     workspaceAuditor.fireDuplicateAction(
         dbWorkspace1.getWorkspaceId(), WORKSPACE_2_DB_ID, workspace2);
     verify(mockActionAuditService).send(eventCollectionCaptor.capture());
@@ -301,7 +301,7 @@ public class WorkspaceAuditorTest {
 
   private Workspace clone(Workspace in) {
     return new Workspace()
-        .id(in.getId())
+        .terraName(in.getTerraName())
         .etag(in.getEtag())
         .name(in.getName())
         .namespace(in.getNamespace())

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/TargetPropertyExtractorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/TargetPropertyExtractorTest.java
@@ -23,7 +23,7 @@ class TargetPropertyExtractorTest {
     workspace =
         new Workspace()
             .name("DbWorkspace 1")
-            .terraName("fc-id-1")
+            .terraName("dbworkspace1")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("1")

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/TargetPropertyExtractorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/TargetPropertyExtractorTest.java
@@ -23,7 +23,7 @@ class TargetPropertyExtractorTest {
     workspace =
         new Workspace()
             .name("DbWorkspace 1")
-            .id("fc-id-1")
+            .terraName("fc-id-1")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("1")

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/WorkspaceTargetPropertyTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/WorkspaceTargetPropertyTest.java
@@ -46,7 +46,7 @@ public class WorkspaceTargetPropertyTest {
     workspace1 =
         new Workspace()
             .name("Workspace 1")
-            .terraName("fc-id-1")
+            .terraName("workspace1")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("1")
@@ -60,7 +60,7 @@ public class WorkspaceTargetPropertyTest {
     workspace2 =
         new Workspace()
             .name("Workspace 2")
-            .terraName("fc-id-1")
+            .terraName("workspace2")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("33")

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/WorkspaceTargetPropertyTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/targetproperties/WorkspaceTargetPropertyTest.java
@@ -46,7 +46,7 @@ public class WorkspaceTargetPropertyTest {
     workspace1 =
         new Workspace()
             .name("Workspace 1")
-            .id("fc-id-1")
+            .terraName("fc-id-1")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("1")
@@ -60,7 +60,7 @@ public class WorkspaceTargetPropertyTest {
     workspace2 =
         new Workspace()
             .name("Workspace 2")
-            .id("fc-id-1")
+            .terraName("fc-id-1")
             .namespace("aou-rw-local1-c4be869a")
             .creator("user@fake-research-aou.org")
             .cdrVersionId("33")

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -576,7 +576,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohort.getCohortId(),
                     new CreateReviewRequest().size(1)));
 
@@ -594,7 +594,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohort.getCohortId(),
                     new CreateReviewRequest().size(0).name("review1")));
 
@@ -612,7 +612,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohort.getCohortId(),
                     new CreateReviewRequest().size(10001).name("review1")));
 
@@ -629,13 +629,13 @@ public class CohortReviewControllerTest {
     // create a new review
     cohortReviewController.createCohortReview(
         workspace.getNamespace(),
-        workspace.getId(),
+        workspace.getTerraName(),
         cohort.getCohortId(),
         new CreateReviewRequest().size(1).name("review1"));
     List<CohortReview> cohortReviewList =
         cohortReviewController
             .getCohortReviewsByCohortId(
-                workspace.getNamespace(), workspace.getId(), cohort.getCohortId())
+                workspace.getNamespace(), workspace.getTerraName(), cohort.getCohortId())
             .getBody()
             .getItems();
 
@@ -653,7 +653,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortId,
                     new CreateReviewRequest().size(1).name("review1")));
 
@@ -673,7 +673,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .createCohortReview(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortWithoutReview.getCohortId(),
                 new CreateReviewRequest().size(1).name(reviewName))
             .getBody();
@@ -696,7 +696,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortWithoutReview.getCohortId(),
                     new CreateReviewRequest().size(1).name("review1")));
 
@@ -719,7 +719,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     requestCohortReview.getCohortReviewId(),
                     requestCohortReview));
 
@@ -742,7 +742,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     requestCohortReview.getCohortReviewId(),
                     requestCohortReview));
 
@@ -767,7 +767,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateCohortReview(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     requestCohortReview.getCohortReviewId(),
                     requestCohortReview));
 
@@ -795,7 +795,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .updateCohortReview(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 requestCohortReview.getCohortReviewId(),
                 requestCohortReview)
             .getBody();
@@ -829,7 +829,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     requestCohortReview.getCohortReviewId(),
                     requestCohortReview));
 
@@ -852,7 +852,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.deleteCohortReview(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     requestCohortReview.getCohortReviewId()));
 
     assertNotFoundExceptionNoCohortReviewAndCohort(
@@ -872,7 +872,9 @@ public class CohortReviewControllerTest {
             .etag(Etags.fromVersion(cohortReview.getVersion()));
     ResponseEntity<EmptyResponse> response =
         cohortReviewController.deleteCohortReview(
-            workspace.getNamespace(), workspace.getId(), requestCohortReview.getCohortReviewId());
+            workspace.getNamespace(),
+            workspace.getTerraName(),
+            requestCohortReview.getCohortReviewId());
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
@@ -896,7 +898,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.deleteCohortReview(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     requestCohortReview.getCohortReviewId()));
 
     assertForbiddenException(exception);
@@ -915,7 +917,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantId,
                     new ParticipantCohortAnnotation()
@@ -944,7 +946,7 @@ public class CohortReviewControllerTest {
               () ->
                   cohortReviewController.createParticipantCohortAnnotation(
                       workspace.getNamespace(),
-                      workspace.getId(),
+                      workspace.getTerraName(),
                       cohortReviewId,
                       participantId,
                       request));
@@ -972,7 +974,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantId,
                     request));
@@ -998,7 +1000,11 @@ public class CohortReviewControllerTest {
     ParticipantCohortAnnotation response =
         cohortReviewController
             .createParticipantCohortAnnotation(
-                workspace.getNamespace(), workspace.getId(), cohortReviewId, participantId, request)
+                workspace.getNamespace(),
+                workspace.getTerraName(),
+                cohortReviewId,
+                participantId,
+                request)
             .getBody();
 
     assertCreatedParticipantCohortAnnotation(Objects.requireNonNull(response), request);
@@ -1025,7 +1031,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .createParticipantCohortAnnotation(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReview.getCohortReviewId(),
                 participantId,
                 request)
@@ -1056,7 +1062,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.createParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantId,
                     request));
@@ -1074,7 +1080,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     participantAnnotation.getAnnotationId(),
@@ -1094,7 +1100,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     wrongParticipantId,
                     participantAnnotation.getAnnotationId(),
@@ -1114,7 +1120,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     wrongAnnotationId,
@@ -1139,7 +1145,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     participantAnnotation.getAnnotationId(),
@@ -1164,7 +1170,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     participantAnnotationDate.getAnnotationId(),
@@ -1189,7 +1195,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     participantAnnotation.getAnnotationId(),
@@ -1218,7 +1224,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .updateParticipantCohortAnnotation(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 participantAnnotation.getAnnotationId(),
@@ -1245,7 +1251,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     participantAnnotation.getAnnotationId(),
@@ -1273,7 +1279,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.deleteParticipantCohortAnnotation(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     annotation.getAnnotationId()));
@@ -1295,7 +1301,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.deleteParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantId,
                     wrongAnnotationId));
@@ -1325,7 +1331,7 @@ public class CohortReviewControllerTest {
     ResponseEntity<EmptyResponse> response =
         cohortReviewController.deleteParticipantCohortAnnotation(
             workspace.getNamespace(),
-            workspace.getId(),
+            workspace.getTerraName(),
             cohortReview.getCohortReviewId(),
             participantCohortStatus1.getParticipantKey().getParticipantId(),
             annotation.getAnnotationId());
@@ -1350,7 +1356,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.deleteParticipantCohortAnnotation(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     annotation.getAnnotationId()));
@@ -1369,7 +1375,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortStatus(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED)));
@@ -1387,7 +1393,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortStatus(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED)));
@@ -1406,7 +1412,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortStatus(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     wrongParticipantId,
                     new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED)));
@@ -1428,7 +1434,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .updateParticipantCohortStatus(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED))
@@ -1454,7 +1460,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.updateParticipantCohortStatus(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new ModifyCohortStatusRequest().status(CohortStatus.INCLUDED)));
@@ -1473,7 +1479,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortAnnotations(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1491,7 +1497,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortAnnotations(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1512,7 +1518,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .getParticipantCohortAnnotations(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId())
             .getBody();
@@ -1542,7 +1548,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortAnnotations(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1560,7 +1566,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortStatus(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1578,7 +1584,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortStatus(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1598,7 +1604,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .getParticipantCohortStatus(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReview.getCohortReviewId(),
                 participantCohortStatus1.getParticipantKey().getParticipantId())
             .getBody();
@@ -1631,7 +1637,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortStatus(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId()));
 
@@ -1649,7 +1655,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCount(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.CONDITION)));
@@ -1668,7 +1674,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCount(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.CONDITION)));
@@ -1686,7 +1692,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCount(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(null)));
@@ -1719,7 +1725,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCount(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(domain)));
@@ -1741,7 +1747,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .getParticipantCount(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReviewId,
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 new PageFilterRequest().domain(Domain.CONDITION))
@@ -1766,7 +1772,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCount(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.CONDITION)));
@@ -1784,7 +1790,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantData(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.CONDITION)));
@@ -1803,7 +1809,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantData(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     wrongCohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.CONDITION)));
@@ -1821,7 +1827,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantData(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(null)));
@@ -1854,7 +1860,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantData(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(domain)));
@@ -1875,7 +1881,7 @@ public class CohortReviewControllerTest {
         cohortReviewController
             .getParticipantData(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 cohortReviewId,
                 participantCohortStatus1.getParticipantKey().getParticipantId(),
                 new PageFilterRequest().domain(Domain.OBSERVATION))
@@ -1899,7 +1905,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantData(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReviewId,
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     new PageFilterRequest().domain(Domain.SURVEY)));
@@ -1917,7 +1923,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortStatuses(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     new PageFilterRequest()));
 
@@ -1942,7 +1948,7 @@ public class CohortReviewControllerTest {
                 cohortReviewController
                     .getParticipantCohortStatuses(
                         workspace.getNamespace(),
-                        workspace.getId(),
+                        workspace.getTerraName(),
                         cohortReview.getCohortReviewId(),
                         pageFilterRequest)
                     .getBody())
@@ -1973,7 +1979,7 @@ public class CohortReviewControllerTest {
                 cohortReviewController
                     .getParticipantCohortStatuses(
                         workspace.getNamespace(),
-                        workspace.getId(),
+                        workspace.getTerraName(),
                         cohortReview.getCohortReviewId(),
                         new PageFilterRequest())
                     .getBody())
@@ -2005,7 +2011,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantCohortStatuses(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     new PageFilterRequest()));
 
@@ -2031,7 +2037,7 @@ public class CohortReviewControllerTest {
     List<CohortReview> actual =
         Objects.requireNonNull(
                 cohortReviewController
-                    .getCohortReviewsInWorkspace(workspace.getNamespace(), workspace.getId())
+                    .getCohortReviewsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
                     .getBody())
             .getItems();
 
@@ -2054,7 +2060,7 @@ public class CohortReviewControllerTest {
             ForbiddenException.class,
             () ->
                 cohortReviewController.getCohortReviewsInWorkspace(
-                    workspace.getNamespace(), workspace.getId()));
+                    workspace.getNamespace(), workspace.getTerraName()));
 
     assertForbiddenException(exception);
   }
@@ -2087,7 +2093,7 @@ public class CohortReviewControllerTest {
         Objects.requireNonNull(
                 cohortReviewController
                     .getCohortReviewsByCohortId(
-                        workspace.getNamespace(), workspace.getId(), cohort.getCohortId())
+                        workspace.getNamespace(), workspace.getTerraName(), cohort.getCohortId())
                     .getBody())
             .getItems();
 
@@ -2110,7 +2116,7 @@ public class CohortReviewControllerTest {
             ForbiddenException.class,
             () ->
                 cohortReviewController.getCohortReviewsByCohortId(
-                    workspace.getNamespace(), workspace.getId(), cohort.getCohortId()));
+                    workspace.getNamespace(), workspace.getTerraName(), cohort.getCohortId()));
 
     assertForbiddenException(exception);
   }
@@ -2130,7 +2136,7 @@ public class CohortReviewControllerTest {
             NotFoundException.class,
             () ->
                 cohortReviewController.getCohortReviewsByCohortId(
-                    workspace2.getNamespace(), workspace2.getId(), cohort.getCohortId()));
+                    workspace2.getNamespace(), workspace2.getTerraName(), cohort.getCohortId()));
     assertNotFoundExceptionNoCohort(cohort.getCohortId(), exception);
   }
 
@@ -2151,7 +2157,7 @@ public class CohortReviewControllerTest {
                 cohortReviewController
                     .getParticipantChartData(
                         workspace.getNamespace(),
-                        workspace.getId(),
+                        workspace.getTerraName(),
                         cohortReview.getCohortReviewId(),
                         participantCohortStatus1.getParticipantKey().getParticipantId(),
                         Domain.CONDITION.toString())
@@ -2177,7 +2183,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.getParticipantChartData(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohortReview.getCohortReviewId(),
                     participantCohortStatus1.getParticipantKey().getParticipantId(),
                     Domain.CONDITION.toString()));
@@ -2202,7 +2208,7 @@ public class CohortReviewControllerTest {
                 cohortReviewController
                     .findCohortReviewDemoChartInfo(
                         workspace.getNamespace(),
-                        workspace.getId(),
+                        workspace.getTerraName(),
                         cohortReview.getCohortReviewId())
                     .getBody())
             .getItems();
@@ -2225,7 +2231,9 @@ public class CohortReviewControllerTest {
             ForbiddenException.class,
             () ->
                 cohortReviewController.findCohortReviewDemoChartInfo(
-                    workspace.getNamespace(), workspace.getId(), cohortReview.getCohortReviewId()));
+                    workspace.getNamespace(),
+                    workspace.getTerraName(),
+                    cohortReview.getCohortReviewId()));
 
     assertForbiddenException(exception);
   }
@@ -2246,7 +2254,7 @@ public class CohortReviewControllerTest {
             () ->
                 cohortReviewController.findCohortReviewDemoChartInfo(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     cohortReview.getCohortReviewId()));
     assertNotFoundExceptionNoCohortReviewAndCohort(cohortReview.getCohortReviewId(), exception);
   }
@@ -2264,7 +2272,7 @@ public class CohortReviewControllerTest {
     List<Vocabulary> actual =
         Objects.requireNonNull(
                 cohortReviewController
-                    .getVocabularies(workspace.getNamespace(), workspace.getId())
+                    .getVocabularies(workspace.getNamespace(), workspace.getTerraName())
                     .getBody())
             .getItems();
 
@@ -2284,7 +2292,7 @@ public class CohortReviewControllerTest {
             ForbiddenException.class,
             () ->
                 cohortReviewController.getVocabularies(
-                    workspace.getNamespace(), workspace.getId()));
+                    workspace.getNamespace(), workspace.getTerraName()));
 
     assertForbiddenException(exception);
   }

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -390,14 +390,20 @@ public class CohortsControllerTest {
   public void testGetCohortsInWorkspace() throws Exception {
     Cohort c1 = createDefaultCohort();
     c1.setName("c1");
-    c1 = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), c1).getBody();
+    c1 =
+        cohortsController
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), c1)
+            .getBody();
     Cohort c2 = createDefaultCohort();
     c2.setName("c2");
-    c2 = cohortsController.createCohort(workspace.getNamespace(), workspace.getId(), c2).getBody();
+    c2 =
+        cohortsController
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), c2)
+            .getBody();
 
     List<Cohort> cohorts =
         cohortsController
-            .getCohortsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getCohortsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
     assertThat(cohorts.size()).isEqualTo(2);
@@ -409,7 +415,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.OWNER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     assertThat(saved.getCriteria()).isEqualTo(createDefaultCohort().getCriteria());
     assertThat(saved.getCreator()).isEqualTo(CREATOR_EMAIL);
@@ -422,7 +428,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     assertThat(saved.getCriteria()).isEqualTo(createDefaultCohort().getCriteria());
     assertThat(saved.getCreator()).isEqualTo(CREATOR_EMAIL);
@@ -438,7 +444,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.createCohort(
-                    workspace.getNamespace(), workspace.getId(), createDefaultCohort()));
+                    workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort()));
     assertForbiddenException(exception);
   }
 
@@ -450,7 +456,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.createCohort(
-                    workspace.getNamespace(), workspace.getId(), createDefaultCohort()));
+                    workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort()));
     assertForbiddenException(exception);
   }
 
@@ -462,7 +468,7 @@ public class CohortsControllerTest {
           Cohort cohort = createDefaultCohort();
           cohort.setCriteria(badCohortCriteria);
           cohortsController
-              .createCohort(workspace.getNamespace(), workspace.getId(), cohort)
+              .createCohort(workspace.getNamespace(), workspace.getTerraName(), cohort)
               .getBody();
         });
   }
@@ -473,7 +479,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, update and check
     CLOCK.increment(1000); // lets say time ticked 1 sec past
@@ -482,7 +488,7 @@ public class CohortsControllerTest {
         cohortsController
             .updateCohort(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 saved.getId(),
                 saved.name(UPDATED_COHORT_NAME))
             .getBody();
@@ -499,7 +505,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, update and check
     CLOCK.increment(1000); // lets say time ticked 1 sec past
@@ -508,7 +514,7 @@ public class CohortsControllerTest {
         cohortsController
             .updateCohort(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 saved.getId(),
                 saved.name(UPDATED_COHORT_NAME))
             .getBody();
@@ -525,7 +531,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, update and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.READER);
@@ -535,7 +541,7 @@ public class CohortsControllerTest {
             () ->
                 cohortsController.updateCohort(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     saved.getId(),
                     saved.name(UPDATED_COHORT_NAME)));
     assertForbiddenException(exception);
@@ -547,7 +553,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, update and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.NO_ACCESS);
@@ -557,7 +563,7 @@ public class CohortsControllerTest {
             () ->
                 cohortsController.updateCohort(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     saved.getId(),
                     saved.name(UPDATED_COHORT_NAME)));
     assertForbiddenException(exception);
@@ -569,12 +575,13 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, delete and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.OWNER);
     ResponseEntity<EmptyResponse> response =
-        cohortsController.deleteCohort(workspace.getNamespace(), workspace.getId(), saved.getId());
+        cohortsController.deleteCohort(
+            workspace.getNamespace(), workspace.getTerraName(), saved.getId());
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
@@ -584,12 +591,13 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, delete and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     ResponseEntity<EmptyResponse> response =
-        cohortsController.deleteCohort(workspace.getNamespace(), workspace.getId(), saved.getId());
+        cohortsController.deleteCohort(
+            workspace.getNamespace(), workspace.getTerraName(), saved.getId());
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
@@ -599,7 +607,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, delete and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.READER);
@@ -608,7 +616,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.deleteCohort(
-                    workspace.getNamespace(), workspace.getId(), saved.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), saved.getId()));
     assertForbiddenException(exception);
   }
 
@@ -618,7 +626,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort saved =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, delete and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.READER);
@@ -627,7 +635,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.deleteCohort(
-                    workspace.getNamespace(), workspace.getId(), saved.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), saved.getId()));
     assertForbiddenException(exception);
   }
 
@@ -637,7 +645,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort original =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, duplicate and check
     CLOCK.increment(1000L); // increment clock before duplicating
@@ -648,7 +656,8 @@ public class CohortsControllerTest {
             .originalCohortId(original.getId());
     Cohort duplicated =
         cohortsController
-            .duplicateCohort(workspace.getNamespace(), workspace.getId(), duplicateCohortRequest)
+            .duplicateCohort(
+                workspace.getNamespace(), workspace.getTerraName(), duplicateCohortRequest)
             .getBody();
     assertDuplicatedCohort(original, duplicated);
   }
@@ -659,7 +668,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort original =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, duplicate and check
     CLOCK.increment(1000L); // increment clock before duplicating
@@ -670,7 +679,8 @@ public class CohortsControllerTest {
             .originalCohortId(original.getId());
     Cohort duplicated =
         cohortsController
-            .duplicateCohort(workspace.getNamespace(), workspace.getId(), duplicateCohortRequest)
+            .duplicateCohort(
+                workspace.getNamespace(), workspace.getTerraName(), duplicateCohortRequest)
             .getBody();
     assertDuplicatedCohort(original, duplicated);
   }
@@ -681,7 +691,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort original =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, duplicate and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.READER);
@@ -694,7 +704,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.duplicateCohort(
-                    workspace.getNamespace(), workspace.getId(), duplicateCohortRequest));
+                    workspace.getNamespace(), workspace.getTerraName(), duplicateCohortRequest));
     assertForbiddenException(exception);
   }
 
@@ -704,7 +714,7 @@ public class CohortsControllerTest {
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.WRITER);
     Cohort original =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     // change access, duplicate and check
     stubWorkspaceAccessLevelWithCreatorEmail(workspace, WorkspaceAccessLevel.NO_ACCESS);
@@ -717,7 +727,7 @@ public class CohortsControllerTest {
             ForbiddenException.class,
             () ->
                 cohortsController.duplicateCohort(
-                    workspace.getNamespace(), workspace.getId(), duplicateCohortRequest));
+                    workspace.getNamespace(), workspace.getTerraName(), duplicateCohortRequest));
     assertForbiddenException(exception);
   }
 
@@ -729,7 +739,7 @@ public class CohortsControllerTest {
           Cohort cohort = createDefaultCohort();
           cohort =
               cohortsController
-                  .createCohort(workspace.getNamespace(), workspace.getId(), cohort)
+                  .createCohort(workspace.getNamespace(), workspace.getTerraName(), cohort)
                   .getBody();
           cohortsController.getCohort(workspace2.getNamespace(), WORKSPACE_NAME_2, cohort.getId());
         });
@@ -743,12 +753,12 @@ public class CohortsControllerTest {
           Cohort cohort = createDefaultCohort();
           cohort =
               cohortsController
-                  .createCohort(workspace.getNamespace(), workspace.getId(), cohort)
+                  .createCohort(workspace.getNamespace(), workspace.getTerraName(), cohort)
                   .getBody();
           cohortsController
               .updateCohort(
                   workspace.getNamespace(),
-                  workspace.getId(),
+                  workspace.getTerraName(),
                   cohort.getId(),
                   new Cohort().name("updated-name").etag(cohort.getEtag()))
               .getBody();
@@ -756,7 +766,7 @@ public class CohortsControllerTest {
           cohortsController
               .updateCohort(
                   workspace.getNamespace(),
-                  workspace.getId(),
+                  workspace.getTerraName(),
                   cohort.getId(),
                   new Cohort().name("updated-name2").etag(cohort.getEtag()))
               .getBody();
@@ -769,7 +779,7 @@ public class CohortsControllerTest {
   public void testUpdateCohortInvalidEtagsThrow(String eTag) throws Exception {
     final Cohort cohort =
         cohortsController
-            .createCohort(workspace.getNamespace(), workspace.getId(), createDefaultCohort())
+            .createCohort(workspace.getNamespace(), workspace.getTerraName(), createDefaultCohort())
             .getBody();
     Throwable exception =
         assertThrows(
@@ -777,7 +787,7 @@ public class CohortsControllerTest {
             () ->
                 cohortsController.updateCohort(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     cohort.getId(),
                     new Cohort().name("updated-name").etag(eTag)));
     String errMsg = "missing required update field 'etag'";

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -493,7 +493,7 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId()));
 
     assertNotFoundException(exception, defaultConceptSet.getId());
   }
@@ -515,7 +515,7 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId()));
 
     assertNotFoundException(exception, defaultConceptSet.getId());
   }
@@ -531,7 +531,7 @@ public class ConceptSetsControllerTest {
             ForbiddenException.class,
             () ->
                 conceptSetsController.deleteConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId()));
 
     assertForbiddenException(exception);
   }
@@ -547,7 +547,7 @@ public class ConceptSetsControllerTest {
             ForbiddenException.class,
             () ->
                 conceptSetsController.deleteConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId()));
 
     assertForbiddenException(exception);
   }
@@ -561,7 +561,7 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace2.getNamespace(), workspace2.getId(), 1L));
+                    workspace2.getNamespace(), workspace2.getTerraName(), 1L));
 
     assertNotFoundException(exception, 1L);
   }
@@ -575,7 +575,9 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace2.getNamespace(), workspace2.getId(), defaultConceptSet.getId()));
+                    workspace2.getNamespace(),
+                    workspace2.getTerraName(),
+                    defaultConceptSet.getId()));
 
     assertNotFoundException(exception, 1L);
   }
@@ -591,7 +593,7 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace.getNamespace(), workspace.getId(), wrongConceptSetId));
+                    workspace.getNamespace(), workspace.getTerraName(), wrongConceptSetId));
 
     assertNotFoundException(exception, wrongConceptSetId);
   }
@@ -603,7 +605,8 @@ public class ConceptSetsControllerTest {
     stubWorkspaceAccessLevel(workspace, RawlsWorkspaceAccessLevel.OWNER);
     ConceptSet retrieved =
         conceptSetsController
-            .getConceptSet(workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId())
+            .getConceptSet(
+                workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId())
             .getBody();
 
     assertThat(retrieved).isEqualTo(defaultConceptSet.participantCount(0));
@@ -617,7 +620,8 @@ public class ConceptSetsControllerTest {
 
     ConceptSet retrieved =
         conceptSetsController
-            .getConceptSet(workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId())
+            .getConceptSet(
+                workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId())
             .getBody();
 
     assertThat(retrieved).isEqualTo(defaultConceptSet.participantCount(0));
@@ -632,7 +636,8 @@ public class ConceptSetsControllerTest {
 
     ConceptSet retrieved =
         conceptSetsController
-            .getConceptSet(workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId())
+            .getConceptSet(
+                workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId())
             .getBody();
 
     assertThat(retrieved).isEqualTo(defaultConceptSet.participantCount(0));
@@ -649,7 +654,7 @@ public class ConceptSetsControllerTest {
             ForbiddenException.class,
             () ->
                 conceptSetsController.getConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId()));
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId()));
 
     assertForbiddenException(exception);
   }
@@ -660,7 +665,7 @@ public class ConceptSetsControllerTest {
   public void getConceptSetsInWorkspaceEmpty() {
     assertThat(
             conceptSetsController
-                .getConceptSetsInWorkspace(workspace2.getNamespace(), workspace2.getId())
+                .getConceptSetsInWorkspace(workspace2.getNamespace(), workspace2.getTerraName())
                 .getBody()
                 .getItems())
         .isEmpty();
@@ -671,7 +676,7 @@ public class ConceptSetsControllerTest {
     // use defaultConceptSet
     List<ConceptSet> response =
         conceptSetsController
-            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
 
@@ -685,7 +690,7 @@ public class ConceptSetsControllerTest {
     assertThat(
             conceptSetsController
                 .countConceptsInConceptSet(
-                    workspace.getNamespace(), workspace.getId(), defaultConceptSet.getId())
+                    workspace.getNamespace(), workspace.getTerraName(), defaultConceptSet.getId())
                 .getBody())
         .isEqualTo(1);
   }
@@ -720,7 +725,7 @@ public class ConceptSetsControllerTest {
     // check for 4 conceptSets
     List<ConceptSet> response =
         conceptSetsController
-            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
 
@@ -741,7 +746,7 @@ public class ConceptSetsControllerTest {
     // access from workspace2 check is empty
     assertThat(
             conceptSetsController
-                .getConceptSetsInWorkspace(workspace2.getNamespace(), workspace2.getId())
+                .getConceptSetsInWorkspace(workspace2.getNamespace(), workspace2.getTerraName())
                 .getBody()
                 .getItems())
         .isEmpty();
@@ -755,7 +760,7 @@ public class ConceptSetsControllerTest {
 
     List<ConceptSet> response =
         conceptSetsController
-            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
 
@@ -771,7 +776,7 @@ public class ConceptSetsControllerTest {
 
     List<ConceptSet> response =
         conceptSetsController
-            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
 
@@ -787,7 +792,7 @@ public class ConceptSetsControllerTest {
 
     List<ConceptSet> response =
         conceptSetsController
-            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getId())
+            .getConceptSetsInWorkspace(workspace.getNamespace(), workspace.getTerraName())
             .getBody()
             .getItems();
 
@@ -806,7 +811,7 @@ public class ConceptSetsControllerTest {
             ForbiddenException.class,
             () ->
                 conceptSetsController.getConceptSetsInWorkspace(
-                    workspace.getNamespace(), workspace.getId()));
+                    workspace.getNamespace(), workspace.getTerraName()));
 
     assertForbiddenException(exception);
   }
@@ -828,7 +833,10 @@ public class ConceptSetsControllerTest {
             NotFoundException.class,
             () ->
                 conceptSetsController.updateConceptSet(
-                    workspace2.getNamespace(), workspace2.getId(), conceptSet.getId(), conceptSet));
+                    workspace2.getNamespace(),
+                    workspace2.getTerraName(),
+                    conceptSet.getId(),
+                    conceptSet));
 
     assertNotFoundException(exception, conceptSet.getId());
   }
@@ -843,7 +851,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSet(
                     workspace2.getNamespace(),
-                    workspace2.getId(),
+                    workspace2.getTerraName(),
                     defaultConceptSet.getId(),
                     defaultConceptSet));
 
@@ -864,7 +872,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     defaultConceptSet));
 
@@ -884,7 +892,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     defaultConceptSet));
 
@@ -904,7 +912,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSet(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 defaultConceptSet.description(UPDATED_DESC).name(UPDATED_NAME))
             .getBody();
@@ -923,7 +931,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSet(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 defaultConceptSet.description(UPDATED_DESC).name(UPDATED_NAME))
             .getBody();
@@ -944,7 +952,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     defaultConceptSet.description(UPDATED_DESC).name(UPDATED_NAME)));
 
@@ -964,7 +972,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     defaultConceptSet.description(UPDATED_DESC).name(UPDATED_NAME)));
 
@@ -1004,7 +1012,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSetConcepts(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 updateConceptSetRequest)
             .getBody();
@@ -1030,7 +1038,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSetConcepts(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 updateConceptSetRequest)
             .getBody();
@@ -1075,7 +1083,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSetConcepts(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 conceptSet.getId(),
                 updateConceptSetRequest)
             .getBody();
@@ -1107,7 +1115,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSetConcepts(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     updateConceptSetRequest));
 
@@ -1131,7 +1139,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSetConcepts(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 updateConceptSetRequest)
             .getBody();
@@ -1157,7 +1165,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .updateConceptSetConcepts(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 defaultConceptSet.getId(),
                 updateConceptSetRequest)
             .getBody();
@@ -1185,7 +1193,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSetConcepts(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     updateConceptSetRequest));
 
@@ -1208,7 +1216,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.updateConceptSetConcepts(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     defaultConceptSet.getId(),
                     updateConceptSetRequest));
 
@@ -1241,7 +1249,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .copyConceptSet(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 String.valueOf(conceptSet.getId()),
                 copyRequest)
             .getBody();
@@ -1278,7 +1286,7 @@ public class ConceptSetsControllerTest {
         conceptSetsController
             .copyConceptSet(
                 workspace.getNamespace(),
-                workspace.getId(),
+                workspace.getTerraName(),
                 String.valueOf(conceptSet.getId()),
                 copyRequest)
             .getBody();
@@ -1309,7 +1317,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.copyConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     String.valueOf(defaultConceptSet.getId()),
                     copyRequest));
 
@@ -1334,7 +1342,7 @@ public class ConceptSetsControllerTest {
             () ->
                 conceptSetsController.copyConceptSet(
                     workspace.getNamespace(),
-                    workspace.getId(),
+                    workspace.getTerraName(),
                     String.valueOf(defaultConceptSet.getId()),
                     copyRequest));
 
@@ -1544,7 +1552,8 @@ public class ConceptSetsControllerTest {
         buildCreateConceptSetRequest(conceptSet, domainConceptIds);
 
     return conceptSetsController
-        .createConceptSet(workspace.getNamespace(), workspace.getId(), createConceptSetRequest)
+        .createConceptSet(
+            workspace.getNamespace(), workspace.getTerraName(), createConceptSetRequest)
         .getBody();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -1312,7 +1312,7 @@ public class DataSetControllerTest {
         new MarkDataSetRequest().resourceType(ResourceType.COHORT).id(cohort.getId());
     assertThat(
             dataSetController
-                .markDirty(workspace.getNamespace(), workspace.getId(), markDataSetRequest)
+                .markDirty(workspace.getNamespace(), workspace.getTerraName(), markDataSetRequest)
                 .getBody())
         .isTrue();
   }
@@ -1323,7 +1323,7 @@ public class DataSetControllerTest {
         new MarkDataSetRequest().resourceType(ResourceType.CONCEPT_SET).id(conceptSet1.getId());
     assertThat(
             dataSetController
-                .markDirty(workspace.getNamespace(), workspace.getId(), markDataSetRequest)
+                .markDirty(workspace.getNamespace(), workspace.getTerraName(), markDataSetRequest)
                 .getBody())
         .isTrue();
   }
@@ -1334,7 +1334,7 @@ public class DataSetControllerTest {
         new MarkDataSetRequest().resourceType(ResourceType.DATASET).id(noAccessDataSet.getId());
     assertThat(
             dataSetController
-                .markDirty(workspace.getNamespace(), workspace.getId(), markDataSetRequest)
+                .markDirty(workspace.getNamespace(), workspace.getTerraName(), markDataSetRequest)
                 .getBody())
         .isTrue();
   }
@@ -1351,7 +1351,7 @@ public class DataSetControllerTest {
 
     DataSet dataset =
         dataSetController
-            .createDataSet(workspace.getNamespace(), workspace.getId(), dataSetRequest)
+            .createDataSet(workspace.getNamespace(), workspace.getTerraName(), dataSetRequest)
             .getBody();
     // criteriums must be empty and not null, since
     // conceptSetDao will return an empty hashSet for dbConceptEtConceptIds
@@ -1374,7 +1374,7 @@ public class DataSetControllerTest {
 
     DataSet dataset =
         dataSetController
-            .createDataSet(workspace.getNamespace(), workspace.getId(), dataSetRequest)
+            .createDataSet(workspace.getNamespace(), workspace.getTerraName(), dataSetRequest)
             .getBody();
     // criteriums must be empty and not null, since
     // conceptSetDao will return an empty hashSet for dbConceptEtConceptIds
@@ -1400,7 +1400,7 @@ public class DataSetControllerTest {
             ForbiddenException.class,
             () ->
                 dataSetController.createDataSet(
-                    workspace.getNamespace(), workspace.getId(), dataSetRequest));
+                    workspace.getNamespace(), workspace.getTerraName(), dataSetRequest));
 
     assertForbiddenException(exception);
   }
@@ -1420,7 +1420,7 @@ public class DataSetControllerTest {
             ForbiddenException.class,
             () ->
                 dataSetController.createDataSet(
-                    workspace.getNamespace(), workspace.getId(), dataSetRequest));
+                    workspace.getNamespace(), workspace.getTerraName(), dataSetRequest));
 
     assertForbiddenException(exception);
   }

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -120,7 +120,7 @@ public class TestMockFactory {
     ResearchOutcomeEnumsList.add(ResearchOutcomeEnum.IMPROVED_RISK_ASSESMENT);
 
     return new Workspace()
-        .id(WORKSPACE_FIRECLOUD_NAME)
+        .terraName(WORKSPACE_FIRECLOUD_NAME)
         .etag("\"1\"")
         .name(workspaceName)
         .namespace(workspaceNameSpace)
@@ -253,7 +253,7 @@ public class TestMockFactory {
     dbWorkspace.setName(workspace.getName());
     dbWorkspace.setWorkspaceNamespace(workspace.getNamespace());
     // a.k.a. RawlsWorkspaceDetails.name
-    dbWorkspace.setFirecloudName(workspace.getId()); // DB_WORKSPACE_FIRECLOUD_NAME
+    dbWorkspace.setFirecloudName(workspace.getTerraName()); // DB_WORKSPACE_FIRECLOUD_NAME
     ResearchPurpose researchPurpose = workspace.getResearchPurpose();
     dbWorkspace.setDiseaseFocusedResearch(researchPurpose.isDiseaseFocusedResearch());
     dbWorkspace.setDiseaseOfFocus(researchPurpose.getDiseaseOfFocus());

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -158,7 +158,7 @@ public class WorkspaceMapperTest {
     final Workspace ws =
         workspaceMapper.toApiWorkspace(
             sourceDbWorkspace, sourceFirecloudWorkspace, mockFeaturedWorkspaceService);
-    assertThat(ws.getId()).isEqualTo(WORKSPACE_FIRECLOUD_NAME);
+    assertThat(ws.getTerraName()).isEqualTo(WORKSPACE_FIRECLOUD_NAME);
     assertThat(ws.getEtag()).isEqualTo(Etags.fromVersion(WORKSPACE_VERSION));
     assertThat(ws.getName()).isEqualTo(WORKSPACE_AOU_NAME);
     assertThat(ws.getNamespace()).isEqualTo(FIRECLOUD_NAMESPACE);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -704,7 +704,7 @@ public class WorkspaceServiceTest {
     var resultWorkspace = result.get(0).getWorkspace();
     assertThat(resultWorkspace.getName()).isEqualTo(testWorkspace.getName());
     assertThat(resultWorkspace.getNamespace()).isEqualTo(testWorkspace.getWorkspaceNamespace());
-    assertThat(resultWorkspace.getId()).isEqualTo(testWorkspace.getFirecloudName());
+    assertThat(resultWorkspace.getTerraName()).isEqualTo(testWorkspace.getFirecloudName());
     assertThat(resultWorkspace.getFeaturedCategory())
         .isEqualTo(FeaturedWorkspaceCategory.DEMO_PROJECTS);
   }

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/DeleteWorkspaces.java
@@ -180,9 +180,9 @@ public class DeleteWorkspaces extends Tool {
 
   private void deleteAouWorkspace(WorkspaceResponse response, String username) {
     String namespace = response.getWorkspace().getNamespace();
-    String fcName = response.getWorkspace().getId();
-    LOG.info(String.format("Deleting workspace %s/%s", namespace, fcName));
-    workspaceService.deleteWorkspace(username, namespace, fcName, DELETE_BILLING_PROJECTS);
+    String terraName = response.getWorkspace().getTerraName();
+    LOG.info(String.format("Deleting workspace %s/%s", namespace, terraName));
+    workspaceService.deleteWorkspace(username, namespace, terraName, DELETE_BILLING_PROJECTS);
   }
 
   private void deleteRawlsWorkspace(RawlsWorkspaceListResponse response, String username) {


### PR DESCRIPTION
Tested locally with no obvious problems.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
