### PR TITLE
[RW-8478][risk=medium] Consider enabling status banners before sign-in

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -170,5 +170,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev\/all-of-us-workbench-test\/aou-rw-gar-remote-repo-docker-local"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -154,5 +154,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev\/all-of-us-rw-preprod\/aou-rw-gar-remote-repo-docker-preprod"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -174,5 +174,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev\/all-of-us-rw-prod\/aou-rw-gar-remote-repo-docker-prod"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -169,5 +169,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev\/all-of-us-rw-stable\/aou-rw-gar-remote-repo-docker-stable"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -178,5 +178,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev\/all-of-us-rw-staging\/aou-rw-gar-remote-repo-docker-staging"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -190,5 +190,8 @@
   },
   "artifactRegistry": {
     "dockerRepoName": "us-central1-docker.pkg.dev/all-of-us-workbench-test/aou-rw-gar-remote-repo-docker-test"
+  },
+  "banner": {
+    "enableLoginIssueBanner": true
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -40,6 +40,7 @@ public class WorkbenchConfig {
   public E2ETestUserConfig e2eTestUsers;
   public TermsOfServiceConfig termsOfService;
   public ArtifactRegistryConfig artifactRegistry;
+  public BannerConfig banner;
 
   /** Creates a config with non-null-but-empty member variables, for use in testing. */
   public static WorkbenchConfig createEmptyConfig() {
@@ -456,5 +457,9 @@ public class WorkbenchConfig {
 
   public static class ArtifactRegistryConfig {
     public String dockerRepoName;
+  }
+
+  public static class BannerConfig {
+    public boolean enableLoginIssueBanner;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -54,5 +54,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(
       target = "enableGKEAppMachineTypeChoice",
       source = "config.featureFlags.enableGKEAppMachineTypeChoice")
+  @Mapping(target = "enableLoginIssueBanner", source = "config.banner.enableLoginIssueBanner")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6961,6 +6961,10 @@ components:
           type: boolean
           default: false
           description: Enable admin to publish workspace
+        enableLoginIssueBanner:
+          type: boolean
+          default: false
+          description: If true, show banner notifying users of login issue
     AccessModuleConfig:
       required:
       - expirable

--- a/ui/src/app/pages/login/login-error-banner.tsx
+++ b/ui/src/app/pages/login/login-error-banner.tsx
@@ -3,7 +3,15 @@ import * as React from 'react';
 import { ErrorMessage } from 'app/components/messages';
 
 export const LOGIN_ERROR_BANNER = () => (
-  <div style={{ fontWeight: 800, paddingLeft: '1rem', paddingRight: '1rem' }}>
+  <div
+    style={{
+      fontWeight: 800,
+      fontSize: 'large',
+      paddingLeft: '1rem',
+      paddingRight: '1rem',
+      lineHeight: '2rem',
+    }}
+  >
     <ErrorMessage>
       We are currently experiencing technical difficulties with our login
       system. Our team is actively working to resolve this issue as quickly as

--- a/ui/src/app/pages/login/login-error-banner.tsx
+++ b/ui/src/app/pages/login/login-error-banner.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { ErrorMessage } from 'app/components/messages';
+
+export const LOGIN_ERROR_BANNER = () => (
+  <div style={{ fontWeight: 800, paddingLeft: '1rem', paddingRight: '1rem' }}>
+    <ErrorMessage>
+      We are currently experiencing technical difficulties with our login
+      system. Our team is actively working to resolve this issue as quickly as
+      possible. We apologize for any inconvenience this may cause and appreciate
+      your patience.
+    </ErrorMessage>
+  </div>
+);

--- a/ui/src/app/pages/login/login-error-banner.tsx
+++ b/ui/src/app/pages/login/login-error-banner.tsx
@@ -7,8 +7,7 @@ export const LOGIN_ERROR_BANNER = () => (
     style={{
       fontWeight: 800,
       fontSize: 'large',
-      paddingLeft: '1rem',
-      paddingRight: '1rem',
+      padding: '1rem',
       lineHeight: '2rem',
     }}
   >

--- a/ui/src/app/pages/login/login.spec.tsx
+++ b/ui/src/app/pages/login/login.spec.tsx
@@ -6,6 +6,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { serverConfigStore } from 'app/utils/stores';
 
+import defaultServerConfig from 'testing/default-server-config';
+
 import LoginReactComponent from './login';
 
 describe('LoginComponent', () => {
@@ -25,6 +27,7 @@ describe('LoginComponent', () => {
     };
     serverConfigStore.set({
       config: {
+        ...defaultServerConfig,
         enableLoginIssueBanner: false,
       },
     });

--- a/ui/src/app/pages/login/login.spec.tsx
+++ b/ui/src/app/pages/login/login.spec.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { render, screen } from '@testing-library/react';
+import { serverConfigStore } from 'app/utils/stores';
 
 import LoginReactComponent from './login';
 
@@ -22,12 +23,27 @@ describe('LoginComponent', () => {
       signIn: () => {},
       onCreateAccount: () => {},
     };
+    serverConfigStore.set({
+      config: {
+        enableLoginIssueBanner: false,
+      },
+    });
   });
 
   it('should render', () => {
     component(loginProps);
     expect(
       screen.getByText('Already have a Researcher Workbench account?')
+    ).toBeInTheDocument();
+  });
+
+  it('should show banner if flag is on', () => {
+    serverConfigStore.get().config.enableLoginIssueBanner = true;
+    component(loginProps);
+    expect(
+      screen.getByText(
+        /we are currently experiencing technical difficulties with our login system\./i
+      )
     ).toBeInTheDocument();
   });
 });

--- a/ui/src/app/pages/login/login.tsx
+++ b/ui/src/app/pages/login/login.tsx
@@ -7,6 +7,9 @@ import { Header, SmallHeader } from 'app/components/headers';
 import { AouTitle } from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
+import { serverConfigStore } from 'app/utils/stores';
+
+import { LOGIN_ERROR_BANNER } from './login-error-banner';
 
 export const styles = reactStyles({
   sign: {
@@ -46,6 +49,9 @@ interface LoginProps {
 export const LoginReactComponent = ({ onCreateAccount }: LoginProps) => {
   return (
     <React.Fragment>
+      {serverConfigStore.get().config.enableLoginIssueBanner && (
+        <LOGIN_ERROR_BANNER />
+      )}
       <div
         data-test-id='login'
         style={{


### PR DESCRIPTION
For now we can use a featureflag, but later we can control the banner and text via service banner by adding a new field say ShowOnLoginPage


![Screenshot 2024-07-19 at 10 18 30 AM](https://github.com/user-attachments/assets/41c825b9-4e20-45b1-a4c6-b0ca86a765fd)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
