### PR TITLE
[noTicket][risk=none] Use exist as exists doesnt work for latest Ruby version

### DIFF
--- a/aou-utils/serviceaccounts.rb
+++ b/aou-utils/serviceaccounts.rb
@@ -33,14 +33,14 @@ class ServiceAccountContext
         # By default Tempfile on OS X does not use a docker-friendly location/
         # use /tmp/colima to make it work with colima, see https://github.com/abiosoft/colima/issues/844 for more details
         colima_path = "/tmp/colima"
-        Dir.mkdir(colima_path) unless File.exists?(colima_path)
+        Dir.mkdir(colima_path) unless File.exist?(colima_path)
         @keyfile_path = Tempfile.new(["#{@service_account}-key", ".json"], colima_path).path
       end
     end
   end
 
   def existing_file_account(keyfile_path)
-    if File.exists?(keyfile_path)
+    if File.exist?(keyfile_path)
       begin
         return JSON.parse(File.read(keyfile_path))["client_email"]
       rescue JSON::ParserError => e


### PR DESCRIPTION
Starting from jul/23 the developers are unable to run the following commands for any enviornment

deploy/project.rb deploy

As we get the following error 
_/root/workbench/aou-utils/serviceaccounts.rb:36:in `initialize': undefined method `exists?' for File:Class (NoMethodError)

        Dir.mkdir(colima_path) unless File.exists?(colima_path)_

The exists method was removed on Ruby v3.2 so we are using exist. 
I did check we do not use .exists anywhere else

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
