### PR TITLE
[RW-13222][risk=no]Locked and Published workspace

### DIFF
--- a/ui/src/app/pages/admin/workspace/admin-lock-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-lock-workspace.tsx
@@ -6,6 +6,7 @@ import { Workspace } from 'generated/fetch';
 import { cond } from '@terra-ui-packages/core-utils';
 import { Button } from 'app/components/buttons';
 import { FlexColumn, FlexRow } from 'app/components/flex';
+import { TooltipTrigger } from 'app/components/popups';
 import { Spinner } from 'app/components/spinners';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 
@@ -60,23 +61,29 @@ export const AdminLockWorkspace = ({ workspace, reload }: LockProps) => {
           <FlexColumn
             style={{ justifyContent: 'flex-end', marginRight: '4.5rem' }}
           >
-            <Button
-              data-test-id='lockUnlockButton'
-              type='secondary'
-              style={{ border: '2px solid' }}
-              onClick={() => {
-                workspace.adminLocked ? unlock() : setShowLockModal(true);
-              }}
+            <TooltipTrigger
+              disabled={!workspace.featuredCategory}
+              content={'Cannot lock published workspace'}
             >
-              <FlexRow>
-                {showSpinner && (
-                  <div style={{ paddingRight: '0.45rem' }}>
-                    <Spinner style={{ width: 20, height: 18 }} />
-                  </div>
-                )}
-                {buttonText}
-              </FlexRow>
-            </Button>
+              <Button
+                data-test-id='lockUnlockButton'
+                type='secondary'
+                style={{ border: '2px solid' }}
+                disabled={!!workspace.featuredCategory}
+                onClick={() => {
+                  workspace.adminLocked ? unlock() : setShowLockModal(true);
+                }}
+              >
+                <FlexRow>
+                  {showSpinner && (
+                    <div style={{ paddingRight: '0.45rem' }}>
+                      <Spinner style={{ width: 20, height: 18 }} />
+                    </div>
+                  )}
+                  {buttonText}
+                </FlexRow>
+              </Button>
+            </TooltipTrigger>
           </FlexColumn>
         </FlexRow>
       </h2>

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -353,7 +353,7 @@ describe('WorkspaceAbout', () => {
     expectButtonElementEnabled(publishButton);
   });
 
-  it('Publish button is disabled for non workspace owner', async () => {
+  it('should disable publish button for non workspace owner', async () => {
     serverConfigStore.set({
       config: { ...defaultServerConfig, enablePublishedWorkspacesViaDb: true },
     });
@@ -367,10 +367,26 @@ describe('WorkspaceAbout', () => {
     expectButtonElementDisabled(publishButton);
 
     await user.hover(publishButton);
-    screen.getByText('Only workspace owners can publish community workspaces.');
+    screen.getByText('Only workspace owners can publish workspaces');
   });
 
-  it('Publish button is disabled for workspace owner if workspace is already published', async () => {
+  it('should disable publish button for locked workspace', async () => {
+    serverConfigStore.set({
+      config: { ...defaultServerConfig, enablePublishedWorkspacesViaDb: true },
+    });
+    currentWorkspaceStore.next({
+      ...currentWorkspaceStore.getValue(),
+      adminLocked: true,
+    });
+    component();
+    const publishButton = screen.getByText('Publish');
+    expectButtonElementDisabled(publishButton);
+
+    await user.hover(publishButton);
+    screen.getByText('Locked workspace cannot be published');
+  });
+
+  it('should disable publish button for workspace owner if workspace is already published', async () => {
     serverConfigStore.set({
       config: { ...defaultServerConfig, enablePublishedWorkspacesViaDb: true },
     });
@@ -388,7 +404,7 @@ describe('WorkspaceAbout', () => {
     screen.getByText('Contact Support to unpublish');
   });
 
-  it('Publish button click sets showPublishConsentModal to true', async () => {
+  it('should set showPublishConsentModal to true if publish button is clicked ', async () => {
     serverConfigStore.set({
       config: { ...defaultServerConfig, enablePublishedWorkspacesViaDb: true },
     });


### PR DESCRIPTION
A workspace owner should not publish a workspace that is locked. 

Admins: Should not lock a workspace that is already published. They need to unpublish and then lock it


**Published Workspace Admin page:**
![Screenshot 2024-07-24 at 11 37 13 AM](https://github.com/user-attachments/assets/0852ac61-83fd-4ce6-b89b-414d7a2e6403)


**Locked Workspace About page**
![Screenshot 2024-07-24 at 11 37 44 AM](https://github.com/user-attachments/assets/b419efba-2d01-4bfe-b5ad-178ff47f0d66)



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
