### PR TITLE
[risk=low][RW-12482] Bump local mariadb clients to latest 10.x

### DIFF
--- a/api/db-cdr/generate-cdr/init-new-cdr-db.sh
+++ b/api/db-cdr/generate-cdr/init-new-cdr-db.sh
@@ -47,7 +47,7 @@ function run_mysql() {
   else
     echo "Outside docker: invoking mysql via docker for portability"
     docker run -i --rm --network host --entrypoint '' \
-      mariadb:10.2 \
+      mariadb:10.11.8 \
       mysql $@
   fi
 }

--- a/api/db/run-migrations.sh
+++ b/api/db/run-migrations.sh
@@ -27,7 +27,7 @@ function run_mysql() {
   else
     echo "Outside docker: invoking mysql via docker for portability"
     docker run --rm --network host --entrypoint '' -i \
-      mariadb:10.2 \
+      mariadb:10.11.8 \
       mysql $@
   fi
 }

--- a/api/docker-compose.yaml
+++ b/api/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   db:
-    image: mariadb:10.2
+    image: mariadb:10.11.8
     environment:
       - MYSQL_ROOT_PASSWORD=root-notasecret
     volumes:

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -2267,7 +2267,7 @@ def connect_to_cloud_db_binlog(cmd_name, *args)
     run_with_redirects(
       "docker run -i -t --rm --network host --entrypoint '' " +
       "-v $(pwd)/libproject/with-mysql-login.sh:/with-mysql-login.sh " +
-      "mariadb:10.2 /bin/bash -c " +
+      "mariadb:10.11.8 /bin/bash -c " +
       "'export MYSQL_HOME=$(./with-mysql-login.sh root #{password}); /bin/bash'", password)
   end
 end
@@ -2870,7 +2870,7 @@ def run_mysql_cmd(cmd)
     "--network host " +
     "--entrypoint '' " +
     "-it " +
-    "mariadb:10.2 " +
+    "mariadb:10.11.8 " +
     cmd
 end
 

--- a/api/libproject/mysql_docker.rb
+++ b/api/libproject/mysql_docker.rb
@@ -16,6 +16,6 @@ def maybe_dockerize_mysql_cmd(cmd, interactive=false, tty=false)
       (tty ? "-t " : "") +
       "--network host " +
       "--entrypoint '' " +
-      "mariadb:10.2 " +
+      "mariadb:10.11.8 " +
       cmd
 end

--- a/tanagra-aou-utils/init_new_tanagra_db.sh
+++ b/tanagra-aou-utils/init_new_tanagra_db.sh
@@ -38,7 +38,7 @@ function run_mysql() {
   else
     echo "Outside docker: invoking mysql via docker for portability"
     docker run -i --rm --network host --entrypoint '' \
-      mariadb:10.2 \
+      mariadb:10.11.8 \
       mysql $@
   fi
 }


### PR DESCRIPTION
For our local docker runs which power things like `dev-up`, deployment, config updates, environment DB access, and many other `project.rb` commands, we use MySQL-compatible [MariaDB](https://mariadb.com/) clients instead of the official MySQL docker images, because they have much better docker support.

MariaDB versions don't directly correspond to MySQL versions.  It's possible that our existing version 10.2 supports both MySQL 5.7 and 8.0, but the latest 10.x certainly should.  Let's upgrade in case that helps smooth this migration.

Tested by running these local `project.rb` commands which use the mariadb client:
* connect-to-db
* connect-to-cloud-db
* dev-up
* run-local-all-migrations
* update-cloud-config

I then confirmed that the app behavior seemed normal.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
