### PR TITLE
[DT-858][risk=no] Fixing the age slider in Cohort Builder

### DIFF
--- a/ui/src/app/pages/data/cohort/demographics.tsx
+++ b/ui/src/app/pages/data/cohort/demographics.tsx
@@ -112,8 +112,8 @@ const ageTypes = [
   { label: 'Age at CDR Date', type: AttrName.AGE_AT_CDR },
 ];
 
-const defaultMinAge = '18';
-const defaultMaxAge = '120';
+const defaultMinAge = '17';
+const defaultMaxAge = '125';
 
 function sortByCountThenName(critA, critB) {
   const A = critA.count || 0;

--- a/ui/src/app/pages/data/cohort/demographics.tsx
+++ b/ui/src/app/pages/data/cohort/demographics.tsx
@@ -112,7 +112,7 @@ const ageTypes = [
   { label: 'Age at CDR Date', type: AttrName.AGE_AT_CDR },
 ];
 
-const defaultMinAge = '17';
+const defaultMinAge = '18';
 const defaultMaxAge = '125';
 
 function sortByCountThenName(critA, critB) {
@@ -130,6 +130,7 @@ interface Props {
 }
 
 interface State {
+  ageRange: number[];
   ageType: AttrName;
   ageTypeNodes: any;
   calculating: boolean;
@@ -152,6 +153,7 @@ export class Demographics extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
+      ageRange: [+defaultMinAge, +defaultMinAge],
       ageType: AttrName.AGE,
       ageTypeNodes: undefined,
       calculating: false,
@@ -205,6 +207,7 @@ export class Demographics extends React.Component<Props, State> {
   }
 
   async loadAgeNodesFromApi() {
+    const { ageRange } = this.state;
     const { id, namespace } = currentWorkspaceStore.getValue();
     const initialValue = {
       [AttrName.AGE]: [],
@@ -214,16 +217,23 @@ export class Demographics extends React.Component<Props, State> {
     const response = await cohortBuilderApi().findAgeTypeCounts(namespace, id);
     const ageTypeNodes = response.items.reduce((acc, item) => {
       acc[item.ageType].push(item);
+      // Compare age with upper range and update if needed. Can't currently change lower range to prevent including ages < 18
+      if (item.age > ageRange[1]) {
+        ageRange[1] = item.age;
+      }
       return acc;
     }, initialValue);
-    this.setState({ ageTypeNodes }, () => this.calculateAgeFromNodes());
+    this.setState(
+      { ageRange, ageTypeNodes, maxAge: ageRange[1].toString() },
+      () => this.calculateAgeFromNodes()
+    );
   }
 
   onMinChange(minAge: string) {
-    const { maxAge } = this.state;
+    const { ageRange, maxAge } = this.state;
     let sliderMin = +minAge;
-    if (+minAge < +defaultMinAge) {
-      sliderMin = +defaultMinAge;
+    if (+minAge < ageRange[0]) {
+      sliderMin = ageRange[0];
     } else if (+minAge > +maxAge) {
       sliderMin = +maxAge;
     }
@@ -232,10 +242,10 @@ export class Demographics extends React.Component<Props, State> {
   }
 
   onMaxChange(maxAge: string) {
-    const { minAge } = this.state;
+    const { ageRange, minAge } = this.state;
     let sliderMax = +maxAge;
-    if (+maxAge > +defaultMaxAge) {
-      sliderMax = +defaultMaxAge;
+    if (+maxAge > ageRange[1]) {
+      sliderMax = ageRange[1];
     } else if (+maxAge < +minAge) {
       sliderMax = +minAge;
     }
@@ -244,24 +254,24 @@ export class Demographics extends React.Component<Props, State> {
   }
 
   onMaxBlur() {
-    const { minAge } = this.state;
+    const { ageRange, minAge } = this.state;
     let { maxAge } = this.state;
     if (+maxAge < +minAge) {
       maxAge = minAge;
-    } else if (+maxAge > +defaultMaxAge || maxAge === '') {
-      maxAge = defaultMaxAge;
+    } else if (+maxAge > ageRange[1] || maxAge === '') {
+      maxAge = ageRange[1].toString();
     }
     this.slider.set([null, +maxAge]);
     this.setState({ maxAge });
   }
 
   onMinBlur() {
-    const { maxAge } = this.state;
+    const { ageRange, maxAge } = this.state;
     let { minAge } = this.state;
     if (+minAge > +maxAge) {
       minAge = maxAge;
-    } else if (+minAge < +defaultMinAge || minAge === '') {
-      minAge = defaultMinAge;
+    } else if (+minAge < ageRange[0] || minAge === '') {
+      minAge = ageRange[0].toString();
     }
     this.slider.set([+minAge, null]);
     this.setState({ minAge });
@@ -311,15 +321,15 @@ export class Demographics extends React.Component<Props, State> {
 
   centerAgeCount() {
     if (!!this.slider) {
+      const {
+        ageRange: [minRange, maxRange],
+      } = this.state;
       // get range from slider element and convert the strings to numbers
       const [sliderMin, sliderMax] = this.slider.get().map((v) => +v);
       // get width as a % by dividing the selected age range by the full slider range
-      const width =
-        ((sliderMax - sliderMin) / (+defaultMaxAge - +defaultMinAge)) * 100;
+      const width = ((sliderMax - sliderMin) / (maxRange - minRange)) * 100;
       // get left margin as a % by dividing the change in minAge by the full slider range
-      const marginLeft =
-        ((sliderMin - +defaultMinAge) / (+defaultMaxAge - +defaultMinAge)) *
-        100;
+      const marginLeft = ((sliderMin - minRange) / (maxRange - minRange)) * 100;
       const wrapper = document.getElementById('count-wrapper');
       if (!!wrapper) {
         wrapper.setAttribute(
@@ -380,8 +390,16 @@ export class Demographics extends React.Component<Props, State> {
 
   render() {
     const { criteriaType, selectedIds } = this.props;
-    const { ageType, calculating, count, loading, maxAge, minAge, nodes } =
-      this.state;
+    const {
+      ageRange,
+      ageType,
+      calculating,
+      count,
+      loading,
+      maxAge,
+      minAge,
+      nodes,
+    } = this.state;
     return loading ? (
       <div style={{ textAlign: 'center' }}>
         <Spinner style={{ marginTop: '4.5rem' }} />
@@ -393,7 +411,7 @@ export class Demographics extends React.Component<Props, State> {
           <div style={{ width: '3.75rem' }}>
             <NumberInput
               style={styles.ageInput}
-              min={defaultMinAge}
+              min={ageRange[0].toString()}
               max={maxAge}
               value={minAge}
               onBlur={() => this.onMinBlur()}
@@ -415,8 +433,11 @@ export class Demographics extends React.Component<Props, State> {
               connect
               instanceRef={(slider) => this.onSliderInit(slider)}
               onSlide={(v) => this.onSliderUpdate(v)}
-              range={{ min: +defaultMinAge, max: +defaultMaxAge }}
-              start={[+defaultMinAge, +defaultMaxAge]}
+              range={{
+                min: ageRange[0],
+                max: ageRange[1],
+              }}
+              start={ageRange}
               step={1}
             />
           </div>
@@ -424,7 +445,7 @@ export class Demographics extends React.Component<Props, State> {
             <NumberInput
               style={styles.ageInput}
               min={minAge}
-              max={defaultMaxAge}
+              max={ageRange[1].toString()}
               value={maxAge}
               onBlur={() => this.onMaxBlur()}
               onChange={(v) => this.onMaxChange(v)}


### PR DESCRIPTION
Fixing the age slider in Cohort Builder to account for participants over 120 years of age

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
