### PR TITLE
[risk=low][no ticket] Convert missing endpoint 500s to 404s

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @ControllerAdvice
 public class ExceptionAdvice {
@@ -21,6 +22,15 @@ public class ExceptionAdvice {
         .body(
             WorkbenchException.errorResponse("failed to parse valid JSON request message")
                 .statusCode(HttpStatus.BAD_REQUEST.value()));
+  }
+
+  @ExceptionHandler({NoHandlerFoundException.class})
+  public ResponseEntity<?> noEndpointHandler(Exception e) {
+    log.log(Level.INFO, e.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(
+            WorkbenchException.errorResponse(e.getMessage())
+                .statusCode(HttpStatus.NOT_FOUND.value()));
   }
 
   @ExceptionHandler({Exception.class})

--- a/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
+++ b/api/src/main/java/org/pmiops/workbench/exceptions/ExceptionAdvice.java
@@ -16,7 +16,7 @@ public class ExceptionAdvice {
   private static final Logger log = Logger.getLogger(ExceptionAdvice.class.getName());
 
   @ExceptionHandler({HttpMessageNotReadableException.class})
-  public ResponseEntity<?> messageNotReadableError(Exception e) {
+  public ResponseEntity<ErrorResponse> messageNotReadableError(Exception e) {
     log.log(Level.INFO, "failed to parse HTTP request message, returning 400", e);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(
@@ -25,7 +25,7 @@ public class ExceptionAdvice {
   }
 
   @ExceptionHandler({NoHandlerFoundException.class})
-  public ResponseEntity<?> noEndpointHandler(Exception e) {
+  public ResponseEntity<ErrorResponse> notFoundHandler(Exception e) {
     log.log(Level.INFO, e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND)
         .body(
@@ -34,7 +34,7 @@ public class ExceptionAdvice {
   }
 
   @ExceptionHandler({Exception.class})
-  public ResponseEntity<?> serverError(Exception e) {
+  public ResponseEntity<ErrorResponse> serverError(Exception e) {
     final int statusCode;
     // if exception class has an HTTP status associated with it, grab it
     if (e.getClass().getAnnotation(ResponseStatus.class) != null) {
@@ -46,9 +46,9 @@ public class ExceptionAdvice {
     ErrorResponse errorResponse = WorkbenchException.errorResponse().statusCode(statusCode);
 
     // Only include Exception details on Workbench errors.
-    if (e instanceof WorkbenchException) {
+    if (e instanceof WorkbenchException exception) {
       errorResponse.setErrorClassName(e.getClass().getName());
-      ErrorResponse thrownErrorResponse = ((WorkbenchException) e).getErrorResponse();
+      ErrorResponse thrownErrorResponse = exception.getErrorResponse();
       if (thrownErrorResponse != null) {
         errorResponse
             .message(thrownErrorResponse.getMessage())


### PR DESCRIPTION
We weren't handling missing API endpoints, causing clients to see 500s.  Instead, handle them with the expected 404 Not Found.

Tested locally.  The RWB continues to work as expected.  Local curl calls to nonexistent endpoints now see returned 404s instead of 500s.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
