### PR TITLE
[risk=low][no ticket] Workspace Admin: only show billing status for Initial Credits

### DIFF
--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 
 import { Workspace, WorkspaceActiveStatus } from 'generated/fetch';
 
-import { FlexRow } from 'app/components/flex';
 import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
 
 import { WorkspaceInfoField } from './workspace-info-field';
@@ -33,12 +32,10 @@ export const BasicInformation = ({
         </WorkspaceInfoField>
         {isUsingFreeTierBillingAccount(workspace) && (
           <WorkspaceInfoField labelText='Initial Credits Billing Status'>
-            <FlexRow>
-              {workspace.initialCredits?.exhausted
-                ? 'Exhausted'
-                : 'Not Exhausted'}
-              , {workspace.initialCredits?.expired ? 'Expired' : 'Not Expired'}
-            </FlexRow>
+            {workspace.initialCredits?.exhausted
+              ? 'Exhausted'
+              : 'Not Exhausted'}
+            , {workspace.initialCredits?.expired ? 'Expired' : 'Not Expired'}
           </WorkspaceInfoField>
         )}
         <WorkspaceInfoField labelText='Workspace Name'>

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -25,8 +25,15 @@ export const BasicInformation = ({
         <WorkspaceInfoField labelText='Active Status'>
           {activeStatus}
         </WorkspaceInfoField>
+        <WorkspaceInfoField labelText='Billing Account Type'>
+          {isUsingFreeTierBillingAccount(workspace)
+            ? 'Initial credits'
+            : 'User provided'}
+        </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Billing Status'>
-          {workspace.billingStatus}
+          {isUsingFreeTierBillingAccount(workspace)
+            ? workspace.billingStatus
+            : '[unable to determine status of user-provided billing]'}
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Workspace Name'>
           {workspace.name}
@@ -42,11 +49,6 @@ export const BasicInformation = ({
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Google Project Id'>
           {workspace.googleProject}
-        </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='Billing Account Type'>
-          {isUsingFreeTierBillingAccount(workspace)
-            ? 'Initial credits'
-            : 'User provided'}
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Creation Time'>
           {new Date(workspace.creationTime).toDateString()}

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -28,7 +28,7 @@ export const BasicInformation = ({
         </WorkspaceInfoField>
         <WorkspaceInfoField labelText='Billing Account Type'>
           {isUsingFreeTierBillingAccount(workspace)
-            ? 'Initial credits'
+            ? `Initial credits (${workspace.creator})`
             : 'User provided'}
         </WorkspaceInfoField>
         {isUsingFreeTierBillingAccount(workspace) && (

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { Workspace, WorkspaceActiveStatus } from 'generated/fetch';
 
+import { FlexRow } from 'app/components/flex';
 import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
 
 import { WorkspaceInfoField } from './workspace-info-field';
@@ -30,11 +31,16 @@ export const BasicInformation = ({
             ? 'Initial credits'
             : 'User provided'}
         </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='Billing Status'>
-          {isUsingFreeTierBillingAccount(workspace)
-            ? workspace.billingStatus
-            : '[unable to determine status of user-provided billing]'}
-        </WorkspaceInfoField>
+        {isUsingFreeTierBillingAccount(workspace) && (
+          <WorkspaceInfoField labelText='Initial Credits Billing Status'>
+            <FlexRow>
+              {workspace.initialCredits?.exhausted
+                ? 'Exhausted'
+                : 'Not Exhausted'}
+              , {workspace.initialCredits?.expired ? 'Expired' : 'Not Expired'}
+            </FlexRow>
+          </WorkspaceInfoField>
+        )}
         <WorkspaceInfoField labelText='Workspace Name'>
           {workspace.name}
         </WorkspaceInfoField>


### PR DESCRIPTION
Don't show an invalid "Billing Status" for User Provided billing.  For Initial Credits, break out the reasons for billing to be inactive and also show whose credits are being used.

<img width="648" alt="ws admin billing status" src="https://github.com/user-attachments/assets/57e83b49-0f62-4091-bd5b-ff87fe92ddea">




---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
