### PR TITLE
[risk=low][no ticket] Ws admin UI: split out publishing from basic info

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -51,7 +51,6 @@ import org.pmiops.workbench.mandrill.model.MandrillMessageStatus;
 import org.pmiops.workbench.mandrill.model.MandrillMessageStatuses;
 import org.pmiops.workbench.mandrill.model.RecipientAddress;
 import org.pmiops.workbench.mandrill.model.RecipientType;
-import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -424,16 +423,6 @@ public class MailServiceImpl implements MailService {
               emailResource,
               publishUnpublishWorkspaceSubstitutionMap(workspace, owner, supportEmail)));
     }
-  }
-
-  private String featuredWorkspaceCategoryAsDisplayString(
-      FeaturedWorkspaceCategory featuredWorkspaceCategory) {
-    return switch (featuredWorkspaceCategory) {
-      case TUTORIAL_WORKSPACES -> "Tutorial Workspaces";
-      case PHENOTYPE_LIBRARY -> "Phenotype Library";
-      case DEMO_PROJECTS -> "Demonstration Projects";
-      case COMMUNITY -> "Community";
-    };
   }
 
   @Override

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -20,33 +20,27 @@ import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
 
 import { WorkspaceInfoField } from './workspace-info-field';
 
-interface Props {
+interface PublishingProps {
   workspace: Workspace;
-  activeStatus: WorkspaceActiveStatus;
   reload: () => Promise<void>;
 }
-export const BasicInformation = ({
-  workspace,
-  activeStatus,
-  reload,
-}: Props) => {
-  const [featuredCategory, setFeaturedCategory] =
-    React.useState<FeaturedWorkspaceCategory>(workspace.featuredCategory);
-  const [featuredCategoryLoading, setFeaturedCategoryLoading] =
-    React.useState<boolean>(false);
+const WorkspacePublishingInfo = ({ workspace, reload }: PublishingProps) => {
   const { enablePublishedWorkspacesViaDb } = serverConfigStore.get().config;
+
+  const [featuredCategory, setFeaturedCategory] = useState(
+    workspace.featuredCategory
+  );
+  const [featuredCategoryLoading, setFeaturedCategoryLoading] = useState(false);
 
   useEffect(() => {
     setFeaturedCategory(workspace.featuredCategory);
     setFeaturedCategoryLoading(false);
   }, [workspace.featuredCategory]);
-
   const publishingDisabled =
     featuredCategoryLoading ||
     workspace.adminLocked ||
     !featuredCategory ||
     featuredCategory === workspace.featuredCategory;
-
   const getWorkspacePublishTooltip = () => {
     return cond(
       [
@@ -65,6 +59,75 @@ export const BasicInformation = ({
     );
   };
 
+  return (
+    <WorkspaceInfoField labelText='Workspace Published'>
+      {enablePublishedWorkspacesViaDb ? (
+        <>
+          <Select
+            key={featuredCategory || 'placeholder'}
+            value={featuredCategory}
+            placeholder='Select a category...'
+            isDisabled={featuredCategoryLoading}
+            options={FeaturedWorkspaceCategoryOptions}
+            onChange={(v: FeaturedWorkspaceCategory) => setFeaturedCategory(v)}
+          />
+          <TooltipTrigger
+            disabled={!publishingDisabled}
+            content={getWorkspacePublishTooltip()}
+          >
+            <Button
+              type='primary'
+              disabled={publishingDisabled}
+              onClick={() => {
+                setFeaturedCategoryLoading(true);
+                workspaceAdminApi()
+                  .publishWorkspaceViaDB(workspace.namespace, {
+                    category: featuredCategory,
+                  })
+                  .then(async () => {
+                    await reload();
+                  });
+              }}
+            >
+              Publish
+            </Button>
+          </TooltipTrigger>
+          <Button
+            type='secondaryOutline'
+            disabled={featuredCategoryLoading || !workspace.featuredCategory}
+            onClick={() => {
+              setFeaturedCategory(null);
+              setFeaturedCategoryLoading(true);
+              workspaceAdminApi()
+                .unpublishWorkspaceViaDB(workspace.namespace)
+                .then(async () => {
+                  await reload();
+                });
+            }}
+          >
+            Unpublish
+          </Button>
+          {featuredCategoryLoading && <Spinner size={36} />}
+        </>
+      ) : workspace.published ? (
+        'Yes'
+      ) : (
+        'No'
+      )}
+    </WorkspaceInfoField>
+  );
+};
+
+interface Props {
+  workspace: Workspace;
+  activeStatus: WorkspaceActiveStatus;
+  reload: () => Promise<void>;
+}
+export const BasicInformation = ({
+  workspace,
+  activeStatus,
+  reload,
+}: Props) => {
   return (
     <>
       <h3>Basic Information</h3>
@@ -101,63 +164,7 @@ export const BasicInformation = ({
         <WorkspaceInfoField labelText='Last Modified Time'>
           {new Date(workspace.lastModifiedTime).toDateString()}
         </WorkspaceInfoField>
-        <WorkspaceInfoField labelText='Workspace Published'>
-          {enablePublishedWorkspacesViaDb ? (
-            <>
-              <Select
-                key={featuredCategory || 'placeholder'}
-                value={featuredCategory}
-                placeholder='Select a category...'
-                isDisabled={featuredCategoryLoading}
-                options={FeaturedWorkspaceCategoryOptions}
-                onChange={(v) => setFeaturedCategory(v)}
-              />
-              <TooltipTrigger
-                disabled={!publishingDisabled}
-                content={getWorkspacePublishTooltip()}
-              >
-                <Button
-                  type='primary'
-                  disabled={publishingDisabled}
-                  onClick={() => {
-                    setFeaturedCategoryLoading(true);
-                    workspaceAdminApi()
-                      .publishWorkspaceViaDB(workspace.namespace, {
-                        category: featuredCategory,
-                      })
-                      .then(async () => {
-                        await reload();
-                      });
-                  }}
-                >
-                  Publish
-                </Button>
-              </TooltipTrigger>
-              <Button
-                type='secondaryOutline'
-                disabled={
-                  featuredCategoryLoading || !workspace.featuredCategory
-                }
-                onClick={() => {
-                  setFeaturedCategory(null);
-                  setFeaturedCategoryLoading(true);
-                  workspaceAdminApi()
-                    .unpublishWorkspaceViaDB(workspace.namespace)
-                    .then(async () => {
-                      await reload();
-                    });
-                }}
-              >
-                Unpublish
-              </Button>
-              {featuredCategoryLoading && <Spinner size={36} />}
-            </>
-          ) : workspace.published ? (
-            'Yes'
-          ) : (
-            'No'
-          )}
-        </WorkspaceInfoField>
+        <WorkspacePublishingInfo {...{ workspace, reload }} />
         <WorkspaceInfoField labelText='Audit'>
           {
             <Link to={`/admin/workspace-audit/${workspace.namespace}`}>

--- a/ui/src/app/pages/admin/workspace/basic-information.tsx
+++ b/ui/src/app/pages/admin/workspace/basic-information.tsx
@@ -1,122 +1,12 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import {
-  FeaturedWorkspaceCategory,
-  Workspace,
-  WorkspaceActiveStatus,
-} from 'generated/fetch';
+import { Workspace, WorkspaceActiveStatus } from 'generated/fetch';
 
-import { cond } from '@terra-ui-packages/core-utils';
-import { Button } from 'app/components/buttons';
-import { Select } from 'app/components/inputs';
-import { TooltipTrigger } from 'app/components/popups';
-import { Spinner } from 'app/components/spinners';
-import { FeaturedWorkspaceCategoryOptions } from 'app/pages/admin/admin-featured-category-options';
-import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
-import { serverConfigStore } from 'app/utils/stores';
 import { isUsingFreeTierBillingAccount } from 'app/utils/workspace-utils';
 
 import { WorkspaceInfoField } from './workspace-info-field';
-
-interface PublishingProps {
-  workspace: Workspace;
-  reload: () => Promise<void>;
-}
-const WorkspacePublishingInfo = ({ workspace, reload }: PublishingProps) => {
-  const { enablePublishedWorkspacesViaDb } = serverConfigStore.get().config;
-
-  const [featuredCategory, setFeaturedCategory] = useState(
-    workspace.featuredCategory
-  );
-  const [featuredCategoryLoading, setFeaturedCategoryLoading] = useState(false);
-
-  useEffect(() => {
-    setFeaturedCategory(workspace.featuredCategory);
-    setFeaturedCategoryLoading(false);
-  }, [workspace.featuredCategory]);
-  const publishingDisabled =
-    featuredCategoryLoading ||
-    workspace.adminLocked ||
-    !featuredCategory ||
-    featuredCategory === workspace.featuredCategory;
-  const getWorkspacePublishTooltip = () => {
-    return cond(
-      [
-        featuredCategoryLoading,
-        'Your workspace is loading, please wait until loading is completed before publishing.',
-      ],
-      [
-        workspace.adminLocked,
-        'This workspace is locked and cannot be published.',
-      ],
-      [!featuredCategory, 'Please select a category to publish the workspace.'],
-      [
-        featuredCategory === workspace.featuredCategory,
-        'This workspace is already published in the selected category.',
-      ]
-    );
-  };
-
-  return (
-    <WorkspaceInfoField labelText='Workspace Published'>
-      {enablePublishedWorkspacesViaDb ? (
-        <>
-          <Select
-            key={featuredCategory || 'placeholder'}
-            value={featuredCategory}
-            placeholder='Select a category...'
-            isDisabled={featuredCategoryLoading}
-            options={FeaturedWorkspaceCategoryOptions}
-            onChange={(v: FeaturedWorkspaceCategory) => setFeaturedCategory(v)}
-          />
-          <TooltipTrigger
-            disabled={!publishingDisabled}
-            content={getWorkspacePublishTooltip()}
-          >
-            <Button
-              type='primary'
-              disabled={publishingDisabled}
-              onClick={() => {
-                setFeaturedCategoryLoading(true);
-                workspaceAdminApi()
-                  .publishWorkspaceViaDB(workspace.namespace, {
-                    category: featuredCategory,
-                  })
-                  .then(async () => {
-                    await reload();
-                  });
-              }}
-            >
-              Publish
-            </Button>
-          </TooltipTrigger>
-          <Button
-            type='secondaryOutline'
-            disabled={featuredCategoryLoading || !workspace.featuredCategory}
-            onClick={() => {
-              setFeaturedCategory(null);
-              setFeaturedCategoryLoading(true);
-              workspaceAdminApi()
-                .unpublishWorkspaceViaDB(workspace.namespace)
-                .then(async () => {
-                  await reload();
-                });
-            }}
-          >
-            Unpublish
-          </Button>
-          {featuredCategoryLoading && <Spinner size={36} />}
-        </>
-      ) : workspace.published ? (
-        'Yes'
-      ) : (
-        'No'
-      )}
-    </WorkspaceInfoField>
-  );
-};
+import { WorkspacePublishingInfo } from './workspace-publishing-info';
 
 interface Props {
   workspace: Workspace;

--- a/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
@@ -132,7 +132,7 @@ describe(WorkspacePublishingInfo.name, () => {
 
   it('should disable publishing when workspace is locked  (enablePublishedWorkspacesViaDb = true)', async () => {
     enablePublishedWorkspacesViaDb();
-    workspace.featuredCategory = FeaturedWorkspaceCategory.COMMUNITY;
+    workspace.featuredCategory = undefined;
     workspace.adminLocked = true;
     component();
     const publishButton = await screen.findByRole('button', {

--- a/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
@@ -2,11 +2,7 @@ import '@testing-library/jest-dom';
 
 import * as React from 'react';
 
-import {
-  FeaturedWorkspaceCategory,
-  WorkspaceActiveStatus,
-  WorkspaceAdminApi,
-} from 'generated/fetch';
+import { FeaturedWorkspaceCategory, WorkspaceAdminApi } from 'generated/fetch';
 
 import { screen } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
@@ -26,7 +22,6 @@ import {
 import { WorkspaceAdminApiStub } from 'testing/stubs/workspace-admin-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
 
-import { BasicInformation } from './basic-information';
 import { WorkspacePublishingInfo } from './workspace-publishing-info';
 
 describe(WorkspacePublishingInfo.name, () => {

--- a/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-publishing-info.spec.tsx
@@ -27,15 +27,15 @@ import { WorkspaceAdminApiStub } from 'testing/stubs/workspace-admin-api-stub';
 import { workspaceStubs } from 'testing/stubs/workspaces';
 
 import { BasicInformation } from './basic-information';
+import { WorkspacePublishingInfo } from './workspace-publishing-info';
 
-describe('BasicInformation', () => {
-  const activeStatus = WorkspaceActiveStatus.ACTIVE;
+describe(WorkspacePublishingInfo.name, () => {
   let user: UserEvent;
   let workspace;
   const component = () => {
     return renderWithRouter(
-      <BasicInformation
-        {...{ workspace, activeStatus }}
+      <WorkspacePublishingInfo
+        {...{ workspace }}
         reload={async () => Promise.resolve()}
       />
     );
@@ -64,9 +64,7 @@ describe('BasicInformation', () => {
 
   it('renders', async () => {
     component();
-    expect(
-      await screen.findByRole('heading', { name: /basic information/i })
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Workspace Published/)).toBeInTheDocument();
   });
 
   it('should show unpublished workspace (enablePublishedWorkspacesViaDb = false)', async () => {
@@ -93,6 +91,7 @@ describe('BasicInformation', () => {
       screen.getByRole('button', { name: /unpublish/i })
     );
   });
+
   it('should show published workspace  (enablePublishedWorkspacesViaDb = true)', async () => {
     enablePublishedWorkspacesViaDb();
     workspace.featuredCategory = FeaturedWorkspaceCategory.COMMUNITY;
@@ -105,6 +104,7 @@ describe('BasicInformation', () => {
       screen.getByRole('button', { name: /unpublish/i })
     );
   });
+
   it('should change category of published workspace  (enablePublishedWorkspacesViaDb = true)', async () => {
     enablePublishedWorkspacesViaDb();
     workspace.featuredCategory = FeaturedWorkspaceCategory.COMMUNITY;

--- a/ui/src/app/pages/admin/workspace/workspace-publishing-info.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-publishing-info.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import { FeaturedWorkspaceCategory, Workspace } from 'generated/fetch';
+
+import { cond } from '@terra-ui-packages/core-utils';
+import { Button } from 'app/components/buttons';
+import { Select } from 'app/components/inputs';
+import { TooltipTrigger } from 'app/components/popups';
+import { Spinner } from 'app/components/spinners';
+import { FeaturedWorkspaceCategoryOptions } from 'app/pages/admin/admin-featured-category-options';
+import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
+import { serverConfigStore } from 'app/utils/stores';
+
+import { WorkspaceInfoField } from './workspace-info-field';
+
+interface PublishingProps {
+  workspace: Workspace;
+  reload: () => Promise<void>;
+}
+
+export const WorkspacePublishingInfo = ({
+  workspace,
+  reload,
+}: PublishingProps) => {
+  const { enablePublishedWorkspacesViaDb } = serverConfigStore.get().config;
+
+  const [featuredCategory, setFeaturedCategory] = useState(
+    workspace.featuredCategory
+  );
+  const [featuredCategoryLoading, setFeaturedCategoryLoading] = useState(false);
+
+  useEffect(() => {
+    setFeaturedCategory(workspace.featuredCategory);
+    setFeaturedCategoryLoading(false);
+  }, [workspace.featuredCategory]);
+  const publishingDisabled =
+    featuredCategoryLoading ||
+    workspace.adminLocked ||
+    !featuredCategory ||
+    featuredCategory === workspace.featuredCategory;
+
+  const getWorkspacePublishTooltip = () => {
+    return cond(
+      [
+        featuredCategoryLoading,
+        'Your workspace is loading, please wait until loading is completed before publishing.',
+      ],
+      [
+        workspace.adminLocked,
+        'This workspace is locked and cannot be published.',
+      ],
+      [!featuredCategory, 'Please select a category to publish the workspace.'],
+      [
+        featuredCategory === workspace.featuredCategory,
+        'This workspace is already published in the selected category.',
+      ]
+    );
+  };
+
+  return (
+    <WorkspaceInfoField labelText='Workspace Published'>
+      {enablePublishedWorkspacesViaDb ? (
+        <>
+          <Select
+            key={featuredCategory || 'placeholder'}
+            value={featuredCategory}
+            placeholder='Select a category...'
+            isDisabled={featuredCategoryLoading}
+            options={FeaturedWorkspaceCategoryOptions}
+            onChange={(v: FeaturedWorkspaceCategory) => setFeaturedCategory(v)}
+          />
+          <TooltipTrigger
+            disabled={!publishingDisabled}
+            content={getWorkspacePublishTooltip()}
+          >
+            <Button
+              type='primary'
+              disabled={publishingDisabled}
+              onClick={() => {
+                setFeaturedCategoryLoading(true);
+                workspaceAdminApi()
+                  .publishWorkspaceViaDB(workspace.namespace, {
+                    category: featuredCategory,
+                  })
+                  .then(async () => {
+                    await reload();
+                  });
+              }}
+            >
+              Publish
+            </Button>
+          </TooltipTrigger>
+          <Button
+            type='secondaryOutline'
+            disabled={featuredCategoryLoading || !workspace.featuredCategory}
+            onClick={() => {
+              setFeaturedCategory(null);
+              setFeaturedCategoryLoading(true);
+              workspaceAdminApi()
+                .unpublishWorkspaceViaDB(workspace.namespace)
+                .then(async () => {
+                  await reload();
+                });
+            }}
+          >
+            Unpublish
+          </Button>
+          {featuredCategoryLoading && <Spinner size={36} />}
+        </>
+      ) : workspace.published ? (
+        'Yes'
+      ) : (
+        'No'
+      )}
+    </WorkspaceInfoField>
+  );
+};


### PR DESCRIPTION
No expected changes.  Tested locally, works as expected.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
