### PR TITLE
[RW-13300][risk=no] Add credit expiration for new access to RT

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -28,6 +28,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -115,7 +115,8 @@
     "enableGKEAppPausing": true,
     "enableGKEAppMachineTypeChoice": true,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": true
+    "enableGcsFuseOnGke": true,
+    "enableInitialCreditsExpiration": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -28,7 +28,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -28,6 +28,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -28,7 +28,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -115,7 +115,8 @@
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": true,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": true
+    "enableGcsFuseOnGke": true,
+    "enableInitialCreditsExpiration": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -28,6 +28,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "freeTierCronUserBatchSize": 200,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -28,7 +28,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "freeTierCronUserBatchSize": 200,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -115,7 +115,8 @@
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": false,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": false
+    "enableGcsFuseOnGke": false,
+    "enableInitialCreditsExpiration": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -28,6 +28,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -28,7 +28,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -115,7 +115,8 @@
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": false,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": true
+    "enableGcsFuseOnGke": true,
+    "enableInitialCreditsExpiration": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -116,7 +116,8 @@
     "enableGKEAppPausing": false,
     "enableGKEAppMachineTypeChoice": true,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": true
+    "enableGcsFuseOnGke": true,
+    "enableInitialCreditsExpiration": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -29,6 +29,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -29,7 +29,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 100,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -28,7 +28,7 @@
       0.5,
       0.75
     ],
-    "freeTierCreditValidityPeriodDays": 90,
+    "freeTierCreditValidityPeriodDays": 120,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 5,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -115,7 +115,8 @@
     "enableGKEAppPausing": true,
     "enableGKEAppMachineTypeChoice": true,
     "enablePublishedWorkspacesViaDb": true,
-    "enableGcsFuseOnGke": true
+    "enableGcsFuseOnGke": true,
+    "enableInitialCreditsExpiration": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -28,6 +28,7 @@
       0.5,
       0.75
     ],
+    "freeTierCreditValidityPeriodDays": 90,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "freeTierCronUserBatchSize": 5,
     "minutesBeforeLastFreeTierJob": 60,

--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -77,7 +77,6 @@ public class AccessSyncServiceImpl implements AccessSyncService {
     long freeTierCreditValidityPeriodDays =
         workbenchConfigProvider.get().billing.freeTierCreditValidityPeriodDays;
 
-
     if (!newAccessTiers.equals(previousAccessTiers)) {
       userServiceAuditor.fireUpdateAccessTiersAction(
           dbUser, previousAccessTiers, newAccessTiers, agent);
@@ -93,8 +92,7 @@ public class AccessSyncServiceImpl implements AccessSyncService {
 
         Timestamp now = new Timestamp(clock.instant().toEpochMilli());
         Timestamp expirationTime =
-            new Timestamp(
-                now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
+            new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
         userInitialCreditsExpirationDao.save(
             new DbUserInitialCreditsExpiration()
                 .setUser(dbUser)

--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -6,19 +6,24 @@ import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForContr
 import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForRegisteredTierAccess;
 
 import jakarta.inject.Provider;
+import java.sql.Timestamp;
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.javers.common.collections.Lists;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserInitialCreditsExpirationDao;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Institution;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +40,8 @@ public class AccessSyncServiceImpl implements AccessSyncService {
   private final InstitutionService institutionService;
   private final UserDao userDao;
   private final UserServiceAuditor userServiceAuditor;
+  private final UserInitialCreditsExpirationDao userInitialCreditsExpirationDao;
+  private final Clock clock;
 
   @Autowired
   public AccessSyncServiceImpl(
@@ -43,13 +50,17 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       AccessModuleService accessModuleService,
       InstitutionService institutionService,
       UserDao userDao,
-      UserServiceAuditor userServiceAuditor) {
+      UserServiceAuditor userServiceAuditor,
+      UserInitialCreditsExpirationDao userInitialCreditsExpirationDao,
+      Clock clock) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.accessTierService = accessTierService;
     this.accessModuleService = accessModuleService;
     this.institutionService = institutionService;
     this.userDao = userDao;
     this.userServiceAuditor = userServiceAuditor;
+    this.userInitialCreditsExpirationDao = userInitialCreditsExpirationDao;
+    this.clock = clock;
   }
 
   /**
@@ -60,9 +71,36 @@ public class AccessSyncServiceImpl implements AccessSyncService {
     final List<DbAccessTier> previousAccessTiers = accessTierService.getAccessTiersForUser(dbUser);
 
     final List<DbAccessTier> newAccessTiers = getUserAccessTiersList(dbUser);
+
+    boolean enableInitialCreditsExpiration =
+        workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration;
+    long freeTierCreditValidityPeriodDays =
+        workbenchConfigProvider.get().billing.freeTierCreditValidityPeriodDays;
+
+
     if (!newAccessTiers.equals(previousAccessTiers)) {
       userServiceAuditor.fireUpdateAccessTiersAction(
           dbUser, previousAccessTiers, newAccessTiers, agent);
+    }
+
+    if (enableInitialCreditsExpiration) {
+      Optional<DbUserInitialCreditsExpiration> maybeCreditsExpiration =
+          userInitialCreditsExpirationDao.findByUser(dbUser);
+
+      if (previousAccessTiers.isEmpty()
+          && !newAccessTiers.isEmpty()
+          && maybeCreditsExpiration.isEmpty()) {
+
+        Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+        Timestamp expirationTime =
+            new Timestamp(
+                now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
+        userInitialCreditsExpirationDao.save(
+            new DbUserInitialCreditsExpiration()
+                .setUser(dbUser)
+                .setCreditStartTime(now)
+                .setExpirationTime(expirationTime));
+      }
     }
 
     // add user to each Access Tier DB table and the tiers' Terra Auth Domains

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -130,7 +130,8 @@ public class WorkbenchConfig {
     public Long numberOfDaysToConsiderForFreeTierUsageUpdate;
 
     // The number of days that free tier credits are valid for.
-    // Extensions to free credit validity period are for the same duration as the original validity period.
+    // Extensions to free credit validity period are for the same duration as the original validity
+    // period.
     public Long freeTierCreditValidityPeriodDays;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -322,6 +322,7 @@ public class WorkbenchConfig {
     public boolean enablePublishedWorkspacesViaDb;
     // If true, enable mounting GCS buckets on GKE apps
     public boolean enableGcsFuseOnGke;
+    public boolean enableInitialCreditsExpiration;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -128,6 +128,10 @@ public class WorkbenchConfig {
     // workspace free tier usage to be updated. To account for charges that may occur after the
     // workspace gets deleted and after the last cron had run
     public Long numberOfDaysToConsiderForFreeTierUsageUpdate;
+
+    // The number of days that free tier credits are valid for.
+    // Extensions to free credit validity period are for the same duration as the original validity period.
+    public Long freeTierCreditValidityPeriodDays;
   }
 
   public static class FireCloudConfig {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -55,5 +55,8 @@ public interface WorkbenchConfigMapper {
       target = "enableGKEAppMachineTypeChoice",
       source = "config.featureFlags.enableGKEAppMachineTypeChoice")
   @Mapping(target = "enableLoginIssueBanner", source = "config.banner.enableLoginIssueBanner")
+  @Mapping(
+      target = "enableInitialCreditsExpiration",
+      source = "config.featureFlags.enableInitialCreditsExpiration")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserInitialCreditsExpirationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserInitialCreditsExpirationDao.java
@@ -1,0 +1,11 @@
+package org.pmiops.workbench.db.dao;
+
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserInitialCreditsExpirationDao
+    extends CrudRepository<DbUserInitialCreditsExpiration, Long> {
+  Optional<DbUserInitialCreditsExpiration> findByUser(DbUser user);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -32,11 +32,13 @@ import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -80,6 +82,7 @@ public class UserServiceImpl implements UserService {
   private final UserServiceAuditor userServiceAuditor;
 
   private final UserDao userDao;
+  private final UserInitialCreditsExpirationDao userInitialCreditsExpirationDao;
   private final UserTermsOfServiceDao userTermsOfServiceDao;
   private final VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
@@ -102,6 +105,7 @@ public class UserServiceImpl implements UserService {
       Random random,
       UserServiceAuditor userServiceAuditor,
       UserDao userDao,
+      UserInitialCreditsExpirationDao userInitialCreditsExpirationDao,
       UserTermsOfServiceDao userTermsOfServiceDao,
       VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao,
       AccessModuleNameMapper accessModuleNameMapper,
@@ -118,6 +122,7 @@ public class UserServiceImpl implements UserService {
     this.random = random;
     this.userServiceAuditor = userServiceAuditor;
     this.userDao = userDao;
+    this.userInitialCreditsExpirationDao = userInitialCreditsExpirationDao;
     this.userTermsOfServiceDao = userTermsOfServiceDao;
     this.verifiedInstitutionalAffiliationDao = verifiedInstitutionalAffiliationDao;
     this.accessModuleNameMapper = accessModuleNameMapper;
@@ -144,6 +149,22 @@ public class UserServiceImpl implements UserService {
     while (true) {
       dbUser = userModifier.apply(dbUser);
       dbUser = accessSyncService.updateUserAccessTiers(dbUser, agent);
+
+      List<DbAccessTier> userTiers = accessTierService.getAccessTiersForUser(dbUser);
+      Optional<DbUserInitialCreditsExpiration> maybeCreditsExpiration =
+          userInitialCreditsExpirationDao.findByUser(dbUser);
+
+      if (!userTiers.isEmpty() && maybeCreditsExpiration.isEmpty()) {
+
+        Timestamp now = clockNow();
+        Timestamp expirationTime = new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(90));
+        userInitialCreditsExpirationDao.save(
+            new DbUserInitialCreditsExpiration()
+                .setUser(dbUser)
+                .setCreditStartTime(now)
+                .setExpirationTime(expirationTime));
+      }
+
       try {
         return userDao.save(dbUser);
       } catch (ObjectOptimisticLockingFailureException e) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -153,6 +153,8 @@ public class UserServiceImpl implements UserService {
 
       boolean enableInitialCreditsExpiration =
           configProvider.get().featureFlags.enableInitialCreditsExpiration;
+      long freeTierCreditValidityPeriodDays =
+          configProvider.get().billing.freeTierCreditValidityPeriodDays;
 
       if (enableInitialCreditsExpiration) {
         List<DbAccessTier> updatedUserTiers = accessTierService.getAccessTiersForUser(dbUser);
@@ -162,7 +164,7 @@ public class UserServiceImpl implements UserService {
         if (initialUserTiers.isEmpty() && !updatedUserTiers.isEmpty() && maybeCreditsExpiration.isEmpty()) {
 
           Timestamp now = clockNow();
-          Timestamp expirationTime = new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(90));
+          Timestamp expirationTime = new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
           userInitialCreditsExpirationDao.save(
               new DbUserInitialCreditsExpiration()
                   .setUser(dbUser)

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -153,7 +153,7 @@ public class UserServiceImpl implements UserService {
       boolean enableInitialCreditsExpiration =
           configProvider.get().featureFlags.enableInitialCreditsExpiration;
 
-      if(enableInitialCreditsExpiration) {
+      if (enableInitialCreditsExpiration) {
         List<DbAccessTier> userTiers = accessTierService.getAccessTiersForUser(dbUser);
         Optional<DbUserInitialCreditsExpiration> maybeCreditsExpiration =
             userInitialCreditsExpirationDao.findByUser(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -144,7 +144,6 @@ public class UserServiceImpl implements UserService {
     while (true) {
       dbUser = userModifier.apply(dbUser);
       dbUser = accessSyncService.updateUserAccessTiers(dbUser, agent);
-
       try {
         return userDao.save(dbUser);
       } catch (ObjectOptimisticLockingFailureException e) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -150,10 +150,10 @@ public class UserServiceImpl implements UserService {
       dbUser = userModifier.apply(dbUser);
       dbUser = accessSyncService.updateUserAccessTiers(dbUser, agent);
 
-      boolean enablePublishedWorkspaces =
+      boolean enableInitialCreditsExpiration =
           configProvider.get().featureFlags.enableInitialCreditsExpiration;
 
-      if(enablePublishedWorkspaces) {
+      if(enableInitialCreditsExpiration) {
         List<DbAccessTier> userTiers = accessTierService.getAccessTiersForUser(dbUser);
         Optional<DbUserInitialCreditsExpiration> maybeCreditsExpiration =
             userInitialCreditsExpirationDao.findByUser(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -161,10 +161,14 @@ public class UserServiceImpl implements UserService {
         Optional<DbUserInitialCreditsExpiration> maybeCreditsExpiration =
             userInitialCreditsExpirationDao.findByUser(dbUser);
 
-        if (initialUserTiers.isEmpty() && !updatedUserTiers.isEmpty() && maybeCreditsExpiration.isEmpty()) {
+        if (initialUserTiers.isEmpty()
+            && !updatedUserTiers.isEmpty()
+            && maybeCreditsExpiration.isEmpty()) {
 
           Timestamp now = clockNow();
-          Timestamp expirationTime = new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
+          Timestamp expirationTime =
+              new Timestamp(
+                  now.getTime() + TimeUnit.DAYS.toMillis(freeTierCreditValidityPeriodDays));
           userInitialCreditsExpirationDao.save(
               new DbUserInitialCreditsExpiration()
                   .setUser(dbUser)

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
@@ -1,0 +1,88 @@
+package org.pmiops.workbench.db.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "user_access_tier")
+public class DbUserInitialCreditsExpiration {
+
+  private long id;
+  private DbUser user;
+  private Timestamp creditStartTime;
+  private Timestamp expirationTime;
+  private boolean bypassed;
+  private int extensionCount;
+
+  public DbUserInitialCreditsExpiration() {}
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  public long getId() {
+    return id;
+  }
+
+public DbUserInitialCreditsExpiration setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  @OneToOne
+  @JoinColumn(name = "user_id")
+  public DbUser getUser() {
+    return user;
+  }
+
+  public DbUserInitialCreditsExpiration setUser(DbUser user) {
+    this.user = user;
+    return this;
+  }
+
+  @Column(name = "credit_start_time")
+  public Timestamp getCreditStartTime() {
+    return creditStartTime;
+  }
+
+  public DbUserInitialCreditsExpiration setCreditStartTime(Timestamp creditStartTime) {
+    this.creditStartTime = creditStartTime;
+    return this;
+  }
+
+  @Column(name = "expiration_time")
+  public Timestamp getExpirationTime() {
+    return expirationTime;
+  }
+
+  public DbUserInitialCreditsExpiration setExpirationTime(Timestamp expirationTime) {
+    this.expirationTime = expirationTime;
+    return this;
+  }
+
+  @Column(name = "bypassed")
+  public boolean isBypassed() {
+    return bypassed;
+  }
+
+  public DbUserInitialCreditsExpiration setBypassed(boolean bypassed) {
+    this.bypassed = bypassed;
+    return this;
+  }
+
+  @Column(name = "extension_count")
+  public int getExtensionCount() {
+    return extensionCount;
+  }
+
+  public DbUserInitialCreditsExpiration setExtensionCount(int extensionCount) {
+    this.extensionCount = extensionCount;
+    return this;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Table;
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "user_access_tier")
+@Table(name = "user_initial_credits_expiration")
 public class DbUserInitialCreditsExpiration {
 
   private long id;
@@ -30,7 +30,7 @@ public class DbUserInitialCreditsExpiration {
     return id;
   }
 
-public DbUserInitialCreditsExpiration setId(long id) {
+  public DbUserInitialCreditsExpiration setId(long id) {
     this.id = id;
     return this;
   }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
@@ -21,8 +21,6 @@ public class DbUserInitialCreditsExpiration {
   private boolean bypassed;
   private int extensionCount;
 
-  public DbUserInitialCreditsExpiration() {}
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7148,6 +7148,10 @@ components:
           type: boolean
           default: false
           description: If true, show banner notifying users of login issue
+        enableInitialCreditsExpiration:
+          type: boolean
+          default: false
+          description: If true, allow for user's initial credits to expire.
     AccessModuleConfig:
       required:
       - expirable

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -168,7 +168,8 @@ public class AccessSyncServiceTest {
   }
 
   @Test
-  public void testUpdateUserAccessTiers_existingCreditExpirationDoesNotChangeWithAdditionalAccess() {
+  public void
+      testUpdateUserAccessTiers_existingCreditExpirationDoesNotChangeWithAdditionalAccess() {
     stubWorkbenchConfig_enableInitialCreditsExpiration(true);
 
     DbAccessTier controlledTier = createControlledTier();

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -1,0 +1,149 @@
+package org.pmiops.workbench.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
+import static org.pmiops.workbench.utils.PresetData.createDbUser;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
+
+import jakarta.inject.Provider;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.actionaudit.Agent;
+import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserInitialCreditsExpirationDao;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.pmiops.workbench.institution.InstitutionService;
+import org.pmiops.workbench.model.Institution;
+
+@ExtendWith(MockitoExtension.class)
+public class AccessSyncServiceTest {
+
+  @Mock private AccessTierService accessTierService;
+
+  @Mock private UserDao userDao;
+
+  @Mock UserInitialCreditsExpirationDao userInitialCreditsExpirationDao;
+
+  @Mock Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  @Mock AccessModuleService accessModuleService;
+
+  @Mock InstitutionService institutionService;
+
+  @Mock UserServiceAuditor userServiceAuditor;
+
+  Instant now = Instant.parse("2000-01-01T00:00:00.00Z");
+
+  @Spy Clock clock = Clock.fixed(now, ZoneId.systemDefault());
+
+  @InjectMocks private AccessSyncServiceImpl accessSyncService;
+
+  private Institution institution;
+
+  @BeforeEach
+  public void setUp() {
+    institution = new Institution();
+    Mockito.reset(
+        accessTierService,
+        userDao,
+        userInitialCreditsExpirationDao,
+        workbenchConfigProvider,
+        accessModuleService,
+        institutionService,
+        userServiceAuditor);
+    DbAccessTier registeredTier = createRegisteredTier();
+    when(accessTierService.getAllTiers()).thenReturn(List.of(registeredTier));
+    doNothing().when(userServiceAuditor).fireUpdateAccessTiersAction(any(), any(), any(), any());
+  }
+
+  private void stubWorkbenchConfig_enableInitialCreditsExpiration(boolean enable) {
+
+    WorkbenchConfig workbenchConfig = createEmptyConfig();
+    workbenchConfig.featureFlags.enableInitialCreditsExpiration = enable;
+    workbenchConfig.access.enableRasLoginGovLinking = false;
+    workbenchConfig.billing.freeTierCreditValidityPeriodDays = 57L;
+
+    when(workbenchConfigProvider.get()).thenReturn(workbenchConfig);
+  }
+
+  private void assertCreditExpirationEquality(
+      DbUserInitialCreditsExpiration expected, DbUserInitialCreditsExpiration actual) {
+    assertEquals(expected.getUser(), actual.getUser());
+    assertEquals(expected.getCreditStartTime(), actual.getCreditStartTime());
+    assertEquals(expected.getExpirationTime(), actual.getExpirationTime());
+    assertEquals(expected.getExtensionCount(), actual.getExtensionCount());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"false", "true"})
+  public void testUpdateUserAccessTiers_whenRTGranted(
+      boolean enableInitialCreditsExpiration) {
+    stubWorkbenchConfig_enableInitialCreditsExpiration(enableInitialCreditsExpiration);
+    DbUser dbUser = createDbUser();
+    dbUser.setDisabled(false);
+    institution = new Institution();
+    Agent agent = Agent.asUser(dbUser);
+
+    // User starts with access to no tiers
+    List<DbAccessTier> oldAccessTiers = List.of();
+    when(accessTierService.getAccessTiersForUser(dbUser)).thenReturn(oldAccessTiers);
+    when(userDao.save(dbUser)).thenReturn(dbUser);
+
+    // Ensures that users meets all requirements for registered tier
+    when(accessModuleService.isModuleCompliant(any(), any())).thenReturn(true);
+    when(institutionService.getByUser(any())).thenReturn(Optional.of(institution));
+    when(institutionService.validateInstitutionalEmail(any(), any(), any())).thenReturn(true);
+    Mockito.lenient()
+        .when(userInitialCreditsExpirationDao.findByUser(dbUser))
+        .thenReturn(Optional.empty());
+
+    DbUser updatedUser = accessSyncService.updateUserAccessTiers(dbUser, agent);
+
+    DbUserInitialCreditsExpiration expected = new DbUserInitialCreditsExpiration();
+
+    expected.setUser(dbUser);
+
+    if (enableInitialCreditsExpiration) {
+      ArgumentCaptor<DbUserInitialCreditsExpiration> captor =
+          ArgumentCaptor.forClass(DbUserInitialCreditsExpiration.class);
+      verify(userInitialCreditsExpirationDao).save(captor.capture());
+      DbUserInitialCreditsExpiration actual = captor.getValue();
+      Timestamp now = new Timestamp(clock.instant().toEpochMilli());
+      Timestamp expirationTime =
+          new Timestamp(
+              now.getTime()
+                  + TimeUnit.DAYS.toMillis(
+                      workbenchConfigProvider.get().billing.freeTierCreditValidityPeriodDays));
+      expected.setCreditStartTime(now);
+      expected.setExpirationTime(expirationTime);
+      assertCreditExpirationEquality(expected, actual);
+    } else {
+      verify(userInitialCreditsExpirationDao, Mockito.never()).save(any());
+    }
+
+    assertEquals(updatedUser, dbUser);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -169,6 +169,7 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.renewal.expiryDays = EXPIRATION_DAYS;
     providedWorkbenchConfig.access.renewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
+    providedWorkbenchConfig.billing.freeTierCreditValidityPeriodDays = 57L;
     registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = accessTierDao.save(createControlledTier());
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
@@ -1210,7 +1211,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_inCompleteCTRequirements_CTCompliance(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1228,7 +1229,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_inCompleteCTRequirements_eraRequired(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1253,7 +1254,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_eraNotRequiredForTiers(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1274,7 +1275,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void testInstitutionRequirement_rtEraDoesNotAffectCTEra(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1300,7 +1301,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_emailValidForRTButNotValidForCT(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1318,7 +1319,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_updateInvalidEmailForCT(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     test_updateUserWithRetries_emailValidForRTButNotValidForCT(
@@ -1334,7 +1335,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_didNotSignCTAgreement(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1356,7 +1357,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_eraFFisOff_CT(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1382,7 +1383,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_ct_complianceTrainingFFisOff_CT(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);
@@ -1405,7 +1406,7 @@ public class UserServiceAccessTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"false,false", "true,false"})
+  @CsvSource({"false,false", "true,true"})
   public void test_updateUserWithRetries_noCT(
       boolean enableInitialCreditsExpiration, boolean initialCreditsExpirationExists) {
     setEnableInitialCreditsExpiration(enableInitialCreditsExpiration);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -167,6 +167,7 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.renewal.expiryDays = EXPIRATION_DAYS;
     providedWorkbenchConfig.access.renewal.expiryDaysWarningThresholds =
         ImmutableList.of(1L, 3L, 7L, 15L, 30L);
+    providedWorkbenchConfig.billing.freeTierCreditValidityPeriodDays = 30L;
     registeredTier = accessTierDao.save(createRegisteredTier());
     controlledTier = accessTierDao.save(createControlledTier());
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -118,6 +118,7 @@ public class ComplianceTrainingServiceTest {
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
     providedWorkbenchConfig.access.renewal.expiryDays = 365L;
     providedWorkbenchConfig.access.enableComplianceTraining = true;
+    providedWorkbenchConfig.billing.freeTierCreditValidityPeriodDays = 57L;
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
+import org.pmiops.workbench.access.AccessSyncService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.actionaudit.Agent;
@@ -143,6 +144,7 @@ public class UserServiceTest {
     providedWorkbenchConfig.access.renewal.expiryDays = 365L;
     providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.termsOfService.latestAouVersion = 5; // arbitrary
+    providedWorkbenchConfig.billing.freeTierCreditValidityPeriodDays = 17L; // arbitrary
 
     // key UserService logic depends on the existence of the Registered Tier
     accessTierDao.save(createRegisteredTier());

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -28,7 +28,6 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
-import org.pmiops.workbench.access.AccessSyncService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.actionaudit.Agent;

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -193,6 +193,7 @@ public class RasLinkServiceTest {
       config.access.renewal.expiryDays = 365L;
       config.access.enableEraCommons = true;
       config.access.enableRasLoginGovLinking = true;
+      config.billing.freeTierCreditValidityPeriodDays = 57L;
       return config;
     }
 


### PR DESCRIPTION
Added logic so that when enableInitialCreditsExpiration is true, a credit expiration record is added when a user is updated.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
