### PR TITLE
[risk=low][RW-13484] Add initialCreditsExpirationEpochMillis to Workspace endpoints

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/CohortReviewControllerBQTest.java
@@ -59,6 +59,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClientImpl;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.Domain;
@@ -130,6 +131,7 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
   @MockBean({
     AccessTierService.class,
     BillingProjectAuditor.class,
+    CloudBillingClientImpl.class,
     CohortBuilderService.class,
     CohortFactory.class,
     CohortService.class,
@@ -138,10 +140,10 @@ public class CohortReviewControllerBQTest extends BigQueryBaseTest {
     FeaturedWorkspaceMapper.class,
     FireCloudService.class,
     FreeTierBillingService.class,
+    InitialCreditsExpirationService.class,
     MailService.class,
     UserRecentResourceService.class,
     UserService.class,
-    CloudBillingClientImpl.class
   })
   static class Configuration {
     @Bean

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
@@ -11,6 +11,7 @@ import org.pmiops.workbench.db.model.DbFeaturedWorkspace.DbFeaturedCategory;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.WorkspaceResponse;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
@@ -25,6 +26,7 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
   private final FeaturedWorkspaceMapper featuredWorkspaceMapper;
   private final Provider<FeaturedWorkspacesConfig> featuredWorkspacesConfigProvider;
   private final FireCloudService fireCloudService;
+  private final InitialCreditsExpirationService initialCreditsExpirationService;
   private final WorkspaceDao workspaceDao;
   private final WorkspaceMapper workspaceMapper;
 
@@ -34,12 +36,14 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
       FeaturedWorkspaceMapper featuredWorkspaceMapper,
       Provider<FeaturedWorkspacesConfig> featuredWorkspacesConfigProvider,
       FireCloudService fireCloudService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper) {
     this.featuredWorkspaceDao = featuredWorkspaceDao;
     this.featuredWorkspaceMapper = featuredWorkspaceMapper;
     this.featuredWorkspacesConfigProvider = featuredWorkspacesConfigProvider;
     this.fireCloudService = fireCloudService;
+    this.initialCreditsExpirationService = initialCreditsExpirationService;
     this.workspaceDao = workspaceDao;
     this.workspaceMapper = workspaceMapper;
   }
@@ -93,7 +97,9 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
                       dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
               return workspaceMapper.toApiWorkspaceResponse(
                   workspaceMapper.toApiWorkspace(
-                      dbWorkspace, rawlsWorkspaceResponse.getWorkspace()),
+                      dbWorkspace,
+                      rawlsWorkspaceResponse.getWorkspace(),
+                      initialCreditsExpirationService),
                   rawlsWorkspaceResponse.getAccessLevel());
             })
         .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -16,6 +16,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.model.WorkspaceResponse;
@@ -41,6 +42,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
   private final FireCloudService firecloudService;
   private final FirecloudMapper firecloudMapper;
   private final ImpersonatedFirecloudService impersonatedFirecloudService;
+  private final InitialCreditsExpirationService initialCreditsExpirationService;
   private final UserDao userDao;
   private final WorkspaceDao workspaceDao;
   private final WorkspaceMapper workspaceMapper;
@@ -52,6 +54,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
       FireCloudService firecloudService,
       FirecloudMapper firecloudMapper,
       ImpersonatedFirecloudService impersonatedFirecloudService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       UserDao userDao,
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper) {
@@ -60,6 +63,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
     this.firecloudMapper = firecloudMapper;
     this.firecloudService = firecloudService;
     this.impersonatedFirecloudService = impersonatedFirecloudService;
+    this.initialCreditsExpirationService = initialCreditsExpirationService;
     this.userDao = userDao;
     this.workspaceDao = workspaceDao;
     this.workspaceMapper = workspaceMapper;
@@ -76,7 +80,9 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
     try {
       return workspaceMapper
           .toApiWorkspaceResponseList(
-              workspaceDao, impersonatedFirecloudService.getWorkspaces(dbUser))
+              workspaceDao,
+              impersonatedFirecloudService.getWorkspaces(dbUser),
+              initialCreditsExpirationService)
           .stream()
           .filter(response -> response.getAccessLevel() == WorkspaceAccessLevel.OWNER)
           .collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -7,11 +7,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.pmiops.workbench.db.dao.UserDao.DbAdminTableUser;
 import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
@@ -46,7 +44,8 @@ public interface ProfileMapper {
   @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
   @Mapping(
       target = "initialCreditsExpirationEpochMillis",
-      ignore = true) // set by setInitialCreditsExpiration()
+      source = "dbUser",
+      qualifiedByName = "getInitialCreditsExpiration")
   Profile toModel(
       DbUser dbUser,
       @Context InitialCreditsExpirationService expirationService,
@@ -59,18 +58,6 @@ public interface ProfileMapper {
       ProfileAccessModules accessModules,
       boolean newUserSatisfactionSurveyEligibility,
       Instant newUserSatisfactionSurveyEligibilityEndTime);
-
-  @AfterMapping
-  default void setInitialCreditsExpiration(
-      @MappingTarget Profile target,
-      DbUser source,
-      @Context InitialCreditsExpirationService expirationService) {
-    expirationService
-        .getCreditsExpiration(source)
-        .ifPresent(
-            expiration ->
-                target.setInitialCreditsExpirationEpochMillis(CommonMappers.timestamp(expiration)));
-  }
 
   List<AdminTableUser> adminViewToModel(List<DbAdminTableUser> adminTableUsers);
 

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -124,9 +124,6 @@ public class CommonMappers {
   @Nullable
   public Long getInitialCreditsExpiration(
       DbUser source, @Context InitialCreditsExpirationService expirationService) {
-    return expirationService
-        .getCreditsExpiration(source)
-        .map(this::timestamp)
-        .orElse(null);
+    return expirationService.getCreditsExpiration(source).map(this::timestamp).orElse(null);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -1,16 +1,19 @@
 package org.pmiops.workbench.utils.mappers;
 
 import com.google.common.base.Strings;
+import jakarta.annotation.Nullable;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import org.mapstruct.Context;
 import org.mapstruct.Named;
 import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.Domain;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +26,7 @@ public class CommonMappers {
     this.clock = clock;
   }
 
-  public static Long timestamp(Timestamp timestamp) {
+  public Long timestamp(Timestamp timestamp) {
     if (timestamp != null) {
       return timestamp.getTime();
     }
@@ -115,5 +118,15 @@ public class CommonMappers {
   @Named("domainIdToDomain")
   public Domain domainIdToDomain(String domainId) {
     return Enum.valueOf(Domain.class, domainId);
+  }
+
+  @Named("getInitialCreditsExpiration")
+  @Nullable
+  public Long getInitialCreditsExpiration(
+      DbUser source, @Context InitialCreditsExpirationService expirationService) {
+    return expirationService
+        .getCreditsExpiration(source)
+        .map(this::timestamp)
+        .orElse(null);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoRuntimeStatus;
@@ -87,6 +88,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   private final FeaturedWorkspaceMapper featuredWorkspaceMapper;
   private final FeaturedWorkspaceDao featuredWorkspaceDao;
   private final FireCloudService fireCloudService;
+  private final InitialCreditsExpirationService initialCreditsExpirationService;
   private final LeonardoMapper leonardoMapper;
   private final LeonardoApiClient leonardoNotebooksClient;
   private final LeonardoRuntimeAuditor leonardoRuntimeAuditor;
@@ -112,6 +114,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       FeaturedWorkspaceMapper featuredWorkspaceMapper,
       FeaturedWorkspaceDao featuredWorkspaceDao,
       FireCloudService fireCloudService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       LeonardoMapper leonardoMapper,
       LeonardoApiClient leonardoNotebooksClient,
       LeonardoRuntimeAuditor leonardoRuntimeAuditor,
@@ -135,6 +138,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     this.featuredWorkspaceMapper = featuredWorkspaceMapper;
     this.featuredWorkspaceDao = featuredWorkspaceDao;
     this.fireCloudService = fireCloudService;
+    this.initialCreditsExpirationService = initialCreditsExpirationService;
     this.leonardoMapper = leonardoMapper;
     this.leonardoNotebooksClient = leonardoNotebooksClient;
     this.leonardoRuntimeAuditor = leonardoRuntimeAuditor;
@@ -242,7 +246,9 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
             .getWorkspaceAsService(workspaceNamespace, workspaceFirecloudName)
             .getWorkspace();
 
-    Workspace workspace = workspaceMapper.toApiWorkspace(dbWorkspace, firecloudWorkspace);
+    Workspace workspace =
+        workspaceMapper.toApiWorkspace(
+            dbWorkspace, firecloudWorkspace, initialCreditsExpirationService);
 
     return new WorkspaceAdminView()
         .workspace(workspace)
@@ -254,7 +260,9 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
 
   private WorkspaceAdminView getDeletedWorkspaceAdminView(DbWorkspace dbWorkspace) {
     return new WorkspaceAdminView()
-        .workspace(workspaceMapper.toApiWorkspace(dbWorkspace, new RawlsWorkspaceDetails()))
+        .workspace(
+            workspaceMapper.toApiWorkspace(
+                dbWorkspace, new RawlsWorkspaceDetails(), initialCreditsExpirationService))
         .workspaceDatabaseId(dbWorkspace.getWorkspaceId())
         .activeStatus(dbWorkspace.getWorkspaceActiveStatusEnum());
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspaceOperation;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceOperation;
 import org.pmiops.workbench.utils.mappers.MapStructConfig;
@@ -21,6 +22,7 @@ public interface WorkspaceOperationMapper {
       DbWorkspaceOperation source,
       WorkspaceDao workspaceDao,
       FireCloudService fireCloudService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       WorkspaceMapper workspaceMapper) {
 
     WorkspaceOperation modelOperation = toModelWithoutWorkspace(source);
@@ -28,7 +30,12 @@ public interface WorkspaceOperationMapper {
     Optional.ofNullable(source.getWorkspaceId())
         .flatMap(
             workspaceId ->
-                getWorkspaceMaybe(workspaceId, workspaceDao, fireCloudService, workspaceMapper))
+                getWorkspaceMaybe(
+                    workspaceId,
+                    workspaceDao,
+                    fireCloudService,
+                    initialCreditsExpirationService,
+                    workspaceMapper))
         .ifPresent(modelOperation::workspace);
 
     return modelOperation;
@@ -50,6 +57,7 @@ public interface WorkspaceOperationMapper {
       long workspaceId,
       WorkspaceDao workspaceDao,
       FireCloudService fireCloudService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       WorkspaceMapper workspaceMapper) {
     return workspaceDao
         .findActiveByWorkspaceId(workspaceId)
@@ -61,6 +69,8 @@ public interface WorkspaceOperationMapper {
                     .map(
                         fcWorkspaceResponse ->
                             workspaceMapper.toApiWorkspace(
-                                dbWorkspace, fcWorkspaceResponse.getWorkspace())));
+                                dbWorkspace,
+                                fcWorkspaceResponse.getWorkspace(),
+                                initialCreditsExpirationService)));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -45,6 +45,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
@@ -83,56 +84,58 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   private final AccessTierService accessTierService;
   private final BillingProjectAuditor billingProjectAuditor;
   private final Clock clock;
+  private final CloudBillingClient cloudBillingClient;
   private final CohortCloningService cohortCloningService;
   private final ConceptSetService conceptSetService;
   private final DataSetService dataSetService;
   private final FeaturedWorkspaceDao featuredWorkspaceDao;
   private final FeaturedWorkspaceMapper featuredWorkspaceMapper;
-  private final FirecloudMapper firecloudMapper;
   private final FireCloudService fireCloudService;
+  private final FirecloudMapper firecloudMapper;
   private final FreeTierBillingService freeTierBillingService;
-  private final CloudBillingClient cloudBillingClient;
+  private final InitialCreditsExpirationService initialCreditsExpirationService;
   private final MailService mailService;
   private final Provider<DbUser> userProvider;
+  private final Provider<TanagraApi> tanagraApiProvider;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final UserDao userDao;
   private final UserMapper userMapper;
   private final UserRecentWorkspaceDao userRecentWorkspaceDao;
   private final UserService userService;
+  private final WorkspaceAuthService workspaceAuthService;
   private final WorkspaceDao workspaceDao;
   private final WorkspaceMapper workspaceMapper;
-  private final WorkspaceAuthService workspaceAuthService;
-  private final Provider<TanagraApi> tanagraApiProvider;
 
   @Autowired
   public WorkspaceServiceImpl(
       AccessTierService accessTierService,
       BillingProjectAuditor billingProjectAuditor,
       Clock clock,
+      CloudBillingClient cloudBillingClient,
       CohortCloningService cohortCloningService,
       ConceptSetService conceptSetService,
       DataSetService dataSetService,
       FeaturedWorkspaceDao featuredWorkspaceDao,
       FeaturedWorkspaceMapper featuredWorkspaceMapper,
-      FirecloudMapper firecloudMapper,
       FireCloudService fireCloudService,
+      FirecloudMapper firecloudMapper,
       FreeTierBillingService freeTierBillingService,
-      CloudBillingClient cloudBillingClient,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       MailService mailService,
       Provider<DbUser> userProvider,
+      Provider<TanagraApi> tanagraApiProvider,
       Provider<WorkbenchConfig> workbenchConfigProvider,
       UserDao userDao,
       UserMapper userMapper,
       UserRecentWorkspaceDao userRecentWorkspaceDao,
       UserService userService,
-      WorkspaceDao workspaceDao,
-      WorkspaceMapper workspaceMapper,
       WorkspaceAuthService workspaceAuthService,
-      Provider<TanagraApi> tanagraApiProvider) {
+      WorkspaceDao workspaceDao,
+      WorkspaceMapper workspaceMapper) {
     this.accessTierService = accessTierService;
-    this.cloudBillingClient = cloudBillingClient;
     this.billingProjectAuditor = billingProjectAuditor;
     this.clock = clock;
+    this.cloudBillingClient = cloudBillingClient;
     this.cohortCloningService = cohortCloningService;
     this.conceptSetService = conceptSetService;
     this.dataSetService = dataSetService;
@@ -141,17 +144,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     this.fireCloudService = fireCloudService;
     this.firecloudMapper = firecloudMapper;
     this.freeTierBillingService = freeTierBillingService;
+    this.initialCreditsExpirationService = initialCreditsExpirationService;
     this.mailService = mailService;
+    this.tanagraApiProvider = tanagraApiProvider;
     this.userDao = userDao;
     this.userMapper = userMapper;
     this.userProvider = userProvider;
     this.userRecentWorkspaceDao = userRecentWorkspaceDao;
     this.userService = userService;
     this.workbenchConfigProvider = workbenchConfigProvider;
+    this.workspaceAuthService = workspaceAuthService;
     this.workspaceDao = workspaceDao;
     this.workspaceMapper = workspaceMapper;
-    this.workspaceAuthService = workspaceAuthService;
-    this.tanagraApiProvider = tanagraApiProvider;
   }
 
   @Override
@@ -159,7 +163,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     boolean enablePublishedWorkspaces =
         workbenchConfigProvider.get().featureFlags.enablePublishedWorkspacesViaDb;
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspaces())
+        .toApiWorkspaceResponseList(
+            workspaceDao, fireCloudService.getWorkspaces(), initialCreditsExpirationService)
         .stream()
         .filter(
             (workspaceResponse) ->
@@ -182,7 +187,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public List<WorkspaceResponse> getPublishedWorkspaces() {
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspaces())
+        .toApiWorkspaceResponseList(
+            workspaceDao, fireCloudService.getWorkspaces(), initialCreditsExpirationService)
         .stream()
         .filter(workspaceResponse -> workspaceResponse.getWorkspace().isPublished())
         .toList();
@@ -191,7 +197,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public List<WorkspaceResponse> getFeaturedWorkspaces() {
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspaces())
+        .toApiWorkspaceResponseList(
+            workspaceDao, fireCloudService.getWorkspaces(), initialCreditsExpirationService)
         .stream()
         .filter(workspaceResponse -> workspaceResponse.getWorkspace().getFeaturedCategory() != null)
         .toList();
@@ -231,7 +238,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
 
     workspaceResponse.setAccessLevel(
         firecloudMapper.fcToApiWorkspaceAccessLevel(fcResponse.getAccessLevel()));
-    Workspace workspace = workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    Workspace workspace =
+        workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, initialCreditsExpirationService);
     workspaceResponse.setWorkspace(workspace);
 
     return workspaceResponse;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7415,6 +7415,11 @@ components:
         googleProject:
           type: string
           description: the google project used by the workspace for compute and storage
+        initialCreditsExpirationEpochMillis:
+          type: integer
+          description: Timestamp indicating when the workspace creator's initial credits will expire, if applicable
+          format: int64
+
       example:
         billingAccountName: billingAccounts/000000-AAAAAA-111111
         billingStatus: ACTIVE

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
@@ -38,6 +38,7 @@ import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.BillingStatus;
@@ -99,6 +100,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     FirecloudMapper.class,
     FireCloudService.class,
     ImpersonatedWorkspaceService.class,
+    InitialCreditsExpirationService.class,
     LeonardoApiClient.class,
     MailService.class,
     TaskQueueService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortReviewControllerTest.java
@@ -100,6 +100,7 @@ import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AnnotationType;
@@ -299,6 +300,7 @@ public class CohortReviewControllerTest {
     FireCloudService.class,
     FreeTierBillingService.class,
     IamService.class,
+    InitialCreditsExpirationService.class,
     LeonardoApiClient.class,
     MailService.class,
     TaskQueueService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CohortsControllerTest.java
@@ -69,6 +69,7 @@ import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.Cohort;
@@ -212,6 +213,7 @@ public class CohortsControllerTest {
     FreeTierBillingService.class,
     LeonardoApiClient.class,
     IamService.class,
+    InitialCreditsExpirationService.class,
     MailService.class,
     ParticipantCohortAnnotationMapper.class,
     ParticipantCohortStatusMapper.class,

--- a/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ConceptSetsControllerTest.java
@@ -59,6 +59,7 @@ import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.ConceptSet;
 import org.pmiops.workbench.model.ConceptSetConceptId;
@@ -249,6 +250,7 @@ public class ConceptSetsControllerTest {
     FirecloudMapperImpl.class,
     FreeTierBillingService.class,
     IamService.class,
+    InitialCreditsExpirationService.class,
     MailService.class,
     NotebooksService.class,
     TaskQueueService.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -101,6 +101,7 @@ import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AnalysisLanguage;
 import org.pmiops.workbench.model.BillingStatus;
@@ -273,6 +274,7 @@ public class DataSetControllerTest {
     FeaturedWorkspaceMapper.class,
     FreeTierBillingService.class,
     IamService.class,
+    InitialCreditsExpirationService.class,
     MailService.class,
     ParticipantCohortAnnotationMapper.class,
     ParticipantCohortStatusMapper.class,

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -135,6 +135,7 @@ import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AnnotationType;
@@ -384,6 +385,7 @@ public class WorkspacesControllerTest {
     ConceptBigQueryService.class,
     FireCloudService.class,
     GenomicExtractionService.class,
+    InitialCreditsExpirationService.class,
     LeonardoApiClient.class,
     LeonardoRuntimeAuditor.class,
     MailService.class,

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -46,9 +46,6 @@ public class FeaturedWorkspaceTest {
   @MockBean private InitialCreditsExpirationService mockInitialCreditsExpirationService;
   @MockBean private WorkspaceMapper mockWorkspaceMapper;
 
-  // Delete this once published flag is on
-  // @MockBean private Provider<FeaturedWorkspacesConfig> featuredWorkspacesConfigProvider;
-
   @Autowired private FeaturedWorkspaceService featuredWorkspaceService;
 
   private DbWorkspace dbWorkspace;
@@ -61,8 +58,6 @@ public class FeaturedWorkspaceTest {
   @MockBean({
     AccessTierServiceImpl.class,
     WorkspaceAdminServiceImpl.class,
-    // Delete this once enablePublishedWorkspacesViaDb is on
-    //  FireCloudService.class,
     WorkspaceDao.class,
   })
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
@@ -32,7 +32,9 @@ public class InitialCreditsExpirationServiceTest {
     DbUser user =
         new DbUser()
             .setUserInitialCreditsExpiration(
-                new DbUserInitialCreditsExpiration().setBypassed(true));
+                new DbUserInitialCreditsExpiration()
+                    .setBypassed(true)
+                    .setExpirationTime(new Timestamp(1234567890L)));
     assertThat(service.getCreditsExpiration(user)).isEmpty();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
@@ -1,0 +1,64 @@
+package org.pmiops.workbench.initialcredits;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import java.sql.Timestamp;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({
+  FakeClockConfiguration.class,
+  InitialCreditsExpirationServiceImpl.class,
+})
+public class InitialCreditsExpirationServiceTest {
+
+  @Autowired private InitialCreditsExpirationService service;
+
+  @Test
+  public void test_none() {
+    DbUser user = new DbUser();
+    assertThat(service.getCreditsExpiration(user)).isEmpty();
+  }
+
+  @Test
+  public void test_userBypassed() {
+    DbUser user =
+        new DbUser()
+            .setUserInitialCreditsExpiration(
+                new DbUserInitialCreditsExpiration().setBypassed(true));
+    assertThat(service.getCreditsExpiration(user)).isEmpty();
+  }
+
+  // TODO RW-13502
+  //  @Test
+  //  public void test_institutionBypassed() {
+  //  }
+
+  @Test
+  public void test_nullTimestamp() {
+    DbUser user =
+        new DbUser()
+            .setUserInitialCreditsExpiration(
+                new DbUserInitialCreditsExpiration().setBypassed(false).setExpirationTime(null));
+    assertThat(service.getCreditsExpiration(user)).isEmpty();
+  }
+
+  @Test
+  public void test_validTimestamp() {
+    Timestamp testTime = new Timestamp(1234567890L);
+    DbUser user =
+        new DbUser()
+            .setUserInitialCreditsExpiration(
+                new DbUserInitialCreditsExpiration()
+                    .setBypassed(false)
+                    .setExpirationTime(testTime));
+    assertThat(service.getCreditsExpiration(user)).hasValue(testTime);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -23,6 +23,7 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbFeaturedWorkspace;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
@@ -67,6 +68,7 @@ public class WorkspaceMapperTest {
   private RawlsWorkspaceDetails sourceFirecloudWorkspace;
 
   @Autowired private WorkspaceMapper workspaceMapper;
+  @MockBean private InitialCreditsExpirationService mockInitialCreditsExpirationService;
 
   @TestConfiguration
   @Import({
@@ -152,7 +154,8 @@ public class WorkspaceMapperTest {
   public void testConvertsDbToApiWorkspace() {
 
     final Workspace ws =
-        workspaceMapper.toApiWorkspace(sourceDbWorkspace, sourceFirecloudWorkspace);
+        workspaceMapper.toApiWorkspace(
+            sourceDbWorkspace, sourceFirecloudWorkspace, mockInitialCreditsExpirationService);
     assertThat(ws.getTerraName()).isEqualTo(WORKSPACE_FIRECLOUD_NAME);
     assertThat(ws.getEtag()).isEqualTo(Etags.fromVersion(WORKSPACE_VERSION));
     assertThat(ws.getName()).isEqualTo(WORKSPACE_AOU_NAME);
@@ -176,7 +179,8 @@ public class WorkspaceMapperTest {
   public void testConvertsFeaturedWorkspace() {
     sourceDbWorkspace.setFeaturedCategory(DbFeaturedWorkspace.DbFeaturedCategory.COMMUNITY);
     final Workspace ws =
-        workspaceMapper.toApiWorkspace(sourceDbWorkspace, sourceFirecloudWorkspace);
+        workspaceMapper.toApiWorkspace(
+            sourceDbWorkspace, sourceFirecloudWorkspace, mockInitialCreditsExpirationService);
     assertThat(ws.getFeaturedCategory()).isEqualTo(FeaturedWorkspaceCategory.COMMUNITY);
   }
 
@@ -184,7 +188,8 @@ public class WorkspaceMapperTest {
   public void testConvertsFirecloudResponseToApiResponse() {
     final WorkspaceResponse resp =
         workspaceMapper.toApiWorkspaceResponse(
-            workspaceMapper.toApiWorkspace(sourceDbWorkspace, sourceFirecloudWorkspace),
+            workspaceMapper.toApiWorkspace(
+                sourceDbWorkspace, sourceFirecloudWorkspace, mockInitialCreditsExpirationService),
             RawlsWorkspaceAccessLevel.PROJECT_OWNER);
 
     assertThat(resp.getAccessLevel()).isEqualTo(WorkspaceAccessLevel.OWNER);

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -71,8 +71,8 @@ public class WorkspaceMapperTest {
   private DbWorkspace sourceDbWorkspace;
   private RawlsWorkspaceDetails sourceFirecloudWorkspace;
 
-  @Autowired private WorkspaceMapper workspaceMapper;
   @Autowired private InitialCreditsExpirationService initialCreditsExpirationService;
+  @Autowired private WorkspaceMapper workspaceMapper;
 
   @TestConfiguration
   @Import({

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -58,6 +58,7 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudManagedGroupWithMembers;
 import org.pmiops.workbench.google.CloudMonitoringService;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
 import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
@@ -159,6 +160,7 @@ public class WorkspaceAdminServiceTest {
     DataSetDao.class,
     DataSetMapper.class,
     FirecloudMapper.class,
+    InitialCreditsExpirationService.class,
     LeonardoApiClient.class,
     UserMapper.class,
     UserService.class,

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
@@ -17,6 +17,7 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
 import org.pmiops.workbench.firecloud.FirecloudRetryHandler;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.Workspace;
 import org.pmiops.workbench.model.WorkspaceOperation;
 import org.pmiops.workbench.model.WorkspaceOperationStatus;
@@ -40,6 +41,7 @@ public class WorkspaceOperationMapperTest {
   @Autowired private WorkspaceDao workspaceDao;
 
   @MockBean private FireCloudService mockFirecloudService;
+  @MockBean private InitialCreditsExpirationService mockInitialCreditsExpirationService;
 
   @TestConfiguration
   @Import({
@@ -106,7 +108,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                mockInitialCreditsExpirationService,
+                workspaceMapper))
         .isEqualTo(expectedOperation);
   }
 
@@ -128,7 +134,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                mockInitialCreditsExpirationService,
+                workspaceMapper))
         .isEqualTo(expectedOperation);
   }
 
@@ -151,7 +161,11 @@ public class WorkspaceOperationMapperTest {
 
     assertThat(
             workspaceOperationMapper.toModelWithWorkspace(
-                dbOperation, workspaceDao, mockFirecloudService, workspaceMapper))
+                dbOperation,
+                workspaceDao,
+                mockFirecloudService,
+                mockInitialCreditsExpirationService,
+                workspaceMapper))
         .isEqualTo(expectedOperation);
   }
 
@@ -164,7 +178,11 @@ public class WorkspaceOperationMapperTest {
 
     Optional<Workspace> maybeWorkspace =
         workspaceOperationMapper.getWorkspaceMaybe(
-            dbWorkspace.getWorkspaceId(), workspaceDao, mockFirecloudService, workspaceMapper);
+            dbWorkspace.getWorkspaceId(),
+            workspaceDao,
+            mockFirecloudService,
+            mockInitialCreditsExpirationService,
+            workspaceMapper);
 
     assertThat(maybeWorkspace).hasValue(expectedWorkspace);
   }
@@ -173,7 +191,11 @@ public class WorkspaceOperationMapperTest {
   public void test_getWorkspaceMaybe_not_found() {
     assertThat(
             workspaceOperationMapper.getWorkspaceMaybe(
-                -1L, workspaceDao, mockFirecloudService, workspaceMapper))
+                -1L,
+                workspaceDao,
+                mockFirecloudService,
+                mockInitialCreditsExpirationService,
+                workspaceMapper))
         .isEmpty();
   }
 
@@ -185,6 +207,7 @@ public class WorkspaceOperationMapperTest {
 
     when(mockFirecloudService.getWorkspace(namespace, fcName))
         .thenReturn(new RawlsWorkspaceResponse().workspace(fcWorkspace));
-    return workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace);
+    return workspaceMapper.toApiWorkspace(
+        dbWorkspace, fcWorkspace, mockInitialCreditsExpirationService);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -64,6 +64,7 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.google.CloudStorageClientImpl;
 import org.pmiops.workbench.iam.IamService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -118,6 +119,7 @@ public class WorkspaceServiceTest {
     FeaturedWorkspaceMapper.class,
     FreeTierBillingService.class,
     IamService.class,
+    InitialCreditsExpirationService.class,
     ProfileMapper.class,
     UserDao.class,
     UserMapper.class,


### PR DESCRIPTION
Return this value (when applicable) in the user Profile object and in the Workspace object for at least these API calls
* ~Get Profile~ moved to #8743
* Get Workspace
* List Workspaces
* List Recent Workspaces
* List Featured Workspaces (new style)

Tested locally

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
