### PR TITLE
[risk=low][RW-13485] Add initial credits expiration to user Profile

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationService.java
@@ -1,0 +1,9 @@
+package org.pmiops.workbench.initialcredits;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbUser;
+
+public interface InitialCreditsExpirationService {
+  Optional<Timestamp> getCreditsExpiration(DbUser user);
+}

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -1,0 +1,17 @@
+package org.pmiops.workbench.initialcredits;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpirationService {
+
+  @Override
+  public Optional<Timestamp> getCreditsExpiration(DbUser user) {
+    return Optional.ofNullable(user.getUserInitialCreditsExpiration())
+        .map(DbUserInitialCreditsExpiration::getExpirationTime);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -13,7 +13,7 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
   public Optional<Timestamp> getCreditsExpiration(DbUser user) {
     return Optional.ofNullable(user.getUserInitialCreditsExpiration())
         .filter(exp -> !exp.isBypassed()) // If the expiration is bypassed, return empty.
-        // TODO filter on institutional bypass as well, maybe something like
+        // TODO RW-13502 filter on institutional bypass as well, maybe something like
         // .filter(() -> institutionService.shouldBypassForCreditsExpiration(user))
         .map(DbUserInitialCreditsExpiration::getExpirationTime);
   }

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -12,6 +12,9 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
   @Override
   public Optional<Timestamp> getCreditsExpiration(DbUser user) {
     return Optional.ofNullable(user.getUserInitialCreditsExpiration())
+        .filter(exp -> !exp.isBypassed()) // If the expiration is bypassed, return empty.
+        // TODO filter on institutional bypass as well, maybe something like
+        // .filter(() -> institutionService.shouldBypassForCreditsExpiration(user))
         .map(DbUserInitialCreditsExpiration::getExpirationTime);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
 import org.pmiops.workbench.model.AccountDisabledStatus;
@@ -63,6 +64,7 @@ public class ProfileService {
   private final Clock clock;
   private final DemographicSurveyMapper demographicSurveyMapper;
   private final FreeTierBillingService freeTierBillingService;
+  private final InitialCreditsExpirationService initialCreditsExpirationService;
   private final InstitutionDao institutionDao;
   private final InstitutionService institutionService;
   private final Javers javers;
@@ -84,6 +86,7 @@ public class ProfileService {
       Clock clock,
       DemographicSurveyMapper demographicSurveyMapper,
       FreeTierBillingService freeTierBillingService,
+      InitialCreditsExpirationService initialCreditsExpirationService,
       InstitutionDao institutionDao,
       InstitutionService institutionService,
       Javers javers,
@@ -102,6 +105,7 @@ public class ProfileService {
     this.clock = clock;
     this.demographicSurveyMapper = demographicSurveyMapper;
     this.freeTierBillingService = freeTierBillingService;
+    this.initialCreditsExpirationService = initialCreditsExpirationService;
     this.institutionDao = institutionDao;
     this.institutionService = institutionService;
     this.javers = javers;
@@ -148,6 +152,7 @@ public class ProfileService {
 
     return profileMapper.toModel(
         user,
+        initialCreditsExpirationService,
         verifiedInstitutionalAffiliation,
         latestTermsOfService,
         freeTierUsage,

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -23,7 +23,7 @@ public class CommonMappers {
     this.clock = clock;
   }
 
-  public Long timestamp(Timestamp timestamp) {
+  public static Long timestamp(Timestamp timestamp) {
     if (timestamp != null) {
       return timestamp.getTime();
     }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8672,6 +8672,10 @@ components:
           type: string
           description: Timestamp indicating when the user is ineligible to take the
             new user survey in ISO 8601 format
+        initialCreditsExpirationEpochMillis:
+          type: integer
+          description: Timestamp indicating when the user's initial credits will expire, if applicable
+          format: int64
     AccessModuleStatus:
       required:
       - moduleName

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -72,6 +72,7 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionMapperImpl;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.institution.InstitutionServiceImpl;
@@ -143,7 +144,6 @@ public class ProfileControllerTest extends BaseControllerTest {
   @MockBean private ShibbolethService mockShibbolethService;
   @MockBean private UserServiceAuditor mockUserServiceAuditor;
   @MockBean private RasLinkService mockRasLinkService;
-  @MockBean private AbsorbService mockAbsorbService;
 
   @Autowired private AccessModuleDao accessModuleDao;
   @Autowired private AccessModuleService accessModuleService;
@@ -214,7 +214,9 @@ public class ProfileControllerTest extends BaseControllerTest {
     WorkspaceFreeTierUsageService.class,
   })
   @MockBean({
+    AbsorbService.class,
     BigQueryService.class,
+    InitialCreditsExpirationService.class,
     NewUserSatisfactionSurveyService.class,
     TaskQueueService.class,
   })

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -39,6 +39,7 @@ import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapper;
 import org.pmiops.workbench.institution.VerifiedInstitutionalAffiliationMapperImpl;
@@ -138,9 +139,10 @@ public class ProfileServiceTest {
     AccessModuleService.class,
     AccessTierService.class,
     FreeTierBillingService.class,
+    InitialCreditsExpirationService.class,
+    NewUserSatisfactionSurveyService.class,
     ProfileAuditor.class,
     VerifiedInstitutionalAffiliationDao.class,
-    NewUserSatisfactionSurveyService.class,
   })
   static class Configuration {
     @Bean


### PR DESCRIPTION
Tested locally.  Works as expected, and includes checking the `bypassed` field.

Also add InitialCreditsExpirationService

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
