### PR TITLE
[risk=low][no ticket] UI: Only workspace creators can change billing accounts

### DIFF
--- a/ui/src/app/pages/workspace/create-billing-account-modal.spec.tsx
+++ b/ui/src/app/pages/workspace/create-billing-account-modal.spec.tsx
@@ -62,7 +62,7 @@ describe('CreateBillingAccountModal', () => {
       'tester@mactesterson.edu><script>alert("hello");</script>'
     );
     expect(getHTMLInputElementValue(getByTestId('user-workbench-id'))).toEqual(
-      'tester@fake-research-aou.org'
+      ProfileStubVariables.PROFILE_STUB.username
     );
     expect(getHTMLInputElementValue(getByTestId('user-institution'))).toEqual(
       BROAD.displayName
@@ -96,7 +96,7 @@ describe('CreateBillingAccountModal', () => {
       'tester@mactesterson.edu><script>alert("hello");</script>'
     );
     expect(screen.getByTestId('user-workbench-id-text')).toHaveTextContent(
-      'tester@fake-research-aou.org'
+      ProfileStubVariables.PROFILE_STUB.username
     );
     expect(screen.getByTestId('user-institution-text')).toHaveTextContent(
       BROAD.displayName

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -134,6 +134,7 @@ describe(WorkspaceEdit.name, () => {
         ],
         researchOutcomeList: [ResearchOutcomeEnum.DECREASE_ILLNESS_BURDEN],
       },
+      creator: ProfileStubVariables.PROFILE_STUB.username,
     };
 
     workspaceEditMode = WorkspaceEditMode.Create;

--- a/ui/src/app/utils/access-utils.spec.tsx
+++ b/ui/src/app/utils/access-utils.spec.tsx
@@ -694,7 +694,7 @@ describe(getTwoFactorSetupUrl.name, () => {
       /https:\/\/accounts\.google\.com\/AccountChooser/
     );
     expect(getTwoFactorSetupUrl()).toMatch(
-      encodeURIComponent('tester@fake-research-aou.org')
+      encodeURIComponent(ProfileStubVariables.PROFILE_STUB.username)
     );
     expect(getTwoFactorSetupUrl()).toMatch(
       encodeURIComponent('https://myaccount.google.com/signinoptions/')


### PR DESCRIPTION
A workspace where the user is the creator
<img width="774" alt="Billing Account Creator" src="https://github.com/user-attachments/assets/c2bc1edf-04a6-4df2-ba05-94861aad8fa9">


A workspace where they are Owner but not creator
<img width="749" alt="Billing Account not Creator" src="https://github.com/user-attachments/assets/19b6fdf5-90c0-4fb3-8242-da652b13e303">



---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
