### PR TITLE
[risk=low][no ticket] Restore user admin bypass UI

### DIFF
--- a/ui/src/app/components/admin/common-toggle.tsx
+++ b/ui/src/app/components/admin/common-toggle.tsx
@@ -6,7 +6,7 @@ import colors from 'app/styles/colors';
 interface CommonToggleProps {
   name: string;
   checked: boolean;
-  onToggle: (boolean) => void;
+  onToggle: (value: boolean) => void;
   disabled?: boolean;
 }
 export const CommonToggle = (props: CommonToggleProps) => {

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -348,7 +348,7 @@ const ToggleForModule = (props: ToggleProps) => {
       }}
     >
       <CommonToggle
-        name={`Bypass ${moduleName}`}
+        name=''
         checked={isModuleBypassed}
         onToggle={() =>
           bypassUpdate({ moduleName, bypassed: !isModuleBypassed })


### PR DESCRIPTION
I made what I thought was an innocuous change here, but it affected the User Admin Profile UI, like this:

<img width="449" alt="bypass mess" src="https://github.com/user-attachments/assets/9024ae5a-1b81-460d-9379-82094ccb86f6">


This PR restores the UI to this

<img width="112" alt="bypass column" src="https://github.com/user-attachments/assets/4e955b2a-c8bc-40cb-ac48-4f1ee5b7c8d7">


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
