### PR TITLE
[risk=low][no ticket] Centralize billing account naming logic

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.api;
 
-import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
+import static org.pmiops.workbench.utils.BillingUtils.isInitialCredits;
 import static org.pmiops.workbench.utils.CostComparisonUtils.getUserFreeTierDollarLimit;
 
 import com.google.common.collect.Sets;
@@ -241,7 +241,8 @@ public class CloudTaskInitialCreditsExpiryController
 
     workspaceDao.findAllByCreator(user).stream()
         .filter(
-            dbWorkspace -> isFreeTier(dbWorkspace.getBillingAccountName(), workbenchConfig.get()))
+            dbWorkspace ->
+                isInitialCredits(dbWorkspace.getBillingAccountName(), workbenchConfig.get()))
         .filter(DbWorkspace::isActive)
         .forEach(
             dbWorkspace -> {

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -1,13 +1,12 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
 import static org.pmiops.workbench.utils.CostComparisonUtils.getUserFreeTierDollarLimit;
-import static org.pmiops.workbench.workspaces.WorkspaceUtils.isFreeTier;
 
 import com.google.common.collect.Sets;
 import jakarta.inject.Provider;
 import jakarta.mail.MessagingException;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -233,7 +232,7 @@ public class CloudTaskInitialCreditsExpiryController
   private Set<DbUser> getFreeTierActiveWorkspaceCreatorsIn(Set<DbUser> users) {
     return workspaceDao.findCreatorsByBillingStatusAndBillingAccountNameIn(
         BillingStatus.ACTIVE,
-        new ArrayList<>(workbenchConfig.get().billing.freeTierBillingAccountNames()),
+        List.of(workbenchConfig.get().billing.initialCreditsBillingAccountName()),
         users);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -43,8 +43,8 @@ import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
+import org.pmiops.workbench.utils.BillingUtils;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
-import org.pmiops.workbench.workspaces.WorkspaceUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
@@ -351,7 +351,7 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
     }
 
     Double initialCreditsRemaining = null;
-    if (WorkspaceUtils.isFreeTier(workspace.get().getBillingAccountName(), configProvider.get())) {
+    if (BillingUtils.isFreeTier(workspace.get().getBillingAccountName(), configProvider.get())) {
       initialCreditsRemaining =
           freeTierBillingService.getWorkspaceCreatorFreeCreditsRemaining(workspace.get());
     }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -351,7 +351,8 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
     }
 
     Double initialCreditsRemaining = null;
-    if (BillingUtils.isFreeTier(workspace.get().getBillingAccountName(), configProvider.get())) {
+    if (BillingUtils.isInitialCredits(
+        workspace.get().getBillingAccountName(), configProvider.get())) {
       initialCreditsRemaining =
           freeTierBillingService.getWorkspaceCreatorFreeCreditsRemaining(workspace.get());
     }

--- a/api/src/main/java/org/pmiops/workbench/api/UserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserController.java
@@ -222,7 +222,7 @@ public class UserController implements UserApiDelegate {
         new BillingAccount()
             .freeTier(true)
             .displayName("Use All of Us initial credits")
-            .name(configProvider.get().billing.freeTierBillingAccountName())
+            .name(configProvider.get().billing.initialCreditsBillingAccountName())
             .open(true));
   }
 

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -193,7 +193,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
       // There might be a refactoring opportunity here to separate out the Google Cloud
       // API calls so we can call just that instead of this which does that and a little more.
       workspaceService.updateWorkspaceBillingAccount(
-          dbWorkspace, workbenchConfigProvider.get().billing.freeTierBillingAccountName());
+          dbWorkspace, workbenchConfigProvider.get().billing.initialCreditsBillingAccountName());
       throw e;
     }
     final Workspace createdWorkspace =
@@ -413,7 +413,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     // code to skip an unnecessary GCP API call if the billing account is being kept at the free
     // tier
     dbWorkspace.setBillingAccountName(
-        workbenchConfigProvider.get().billing.freeTierBillingAccountName());
+        workbenchConfigProvider.get().billing.initialCreditsBillingAccountName());
 
     try {
       workspaceService.updateWorkspaceBillingAccount(
@@ -617,7 +617,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     } catch (Exception e) {
       // Tell Google to set the billing account back to the free tier if our clone fails
       workspaceService.updateWorkspaceBillingAccount(
-          dbWorkspace, workbenchConfigProvider.get().billing.freeTierBillingAccountName());
+          dbWorkspace, workbenchConfigProvider.get().billing.initialCreditsBillingAccountName());
       throw e;
     }
 

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -27,8 +27,8 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
 import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.model.BillingStatus;
+import org.pmiops.workbench.utils.BillingUtils;
 import org.pmiops.workbench.utils.CostComparisonUtils;
-import org.pmiops.workbench.workspaces.WorkspaceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -255,8 +255,7 @@ public class FreeTierBillingService {
     workspaceDao.findAllByCreator(user).stream()
         .filter(
             ws ->
-                WorkspaceUtils.isFreeTier(
-                    ws.getBillingAccountName(), workbenchConfigProvider.get()))
+                BillingUtils.isFreeTier(ws.getBillingAccountName(), workbenchConfigProvider.get()))
         .forEach(
             ws -> {
               ws.setInitialCreditsExhausted(false);

--- a/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
+++ b/api/src/main/java/org/pmiops/workbench/billing/FreeTierBillingService.java
@@ -255,7 +255,8 @@ public class FreeTierBillingService {
     workspaceDao.findAllByCreator(user).stream()
         .filter(
             ws ->
-                BillingUtils.isFreeTier(ws.getBillingAccountName(), workbenchConfigProvider.get()))
+                BillingUtils.isInitialCredits(
+                    ws.getBillingAccountName(), workbenchConfigProvider.get()))
         .forEach(
             ws -> {
               ws.setInitialCreditsExhausted(false);

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -1,11 +1,9 @@
 package org.pmiops.workbench.config;
 
-import jakarta.annotation.Nullable;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
+
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * A class representing the main workbench configuration; parsed from JSON stored in the database.
@@ -82,28 +80,11 @@ public class WorkbenchConfig {
     // The environment-driven prefix to apply to Terra billing projects we create. Example:
     // "aou-rw-stable-" causes us to create projects named like "aou-rw-stable-8aec175b".
     public String projectNamePrefix;
-    // The free tier GCP billing account ID to associate with Terra / GCP projects.
+    // The initial credits GCP billing account ID to associate with Terra / GCP projects.
     public String accountId;
 
-    // The legacy free tier billing account id that is migrating away. This value helps to make
-    // migration process smooth.
-    // Null if not set in Config.
-    @Nullable public String legacyAccountId;
-
-    public String freeTierBillingAccountName() {
-      return "billingAccounts/" + accountId;
-    }
-
-    public Optional<String> legacyFreeTierBillingAccountName() {
-      return Optional.ofNullable(legacyAccountId).map(a -> "billingAccounts/" + a);
-    }
-
-    /// All valid free tier billing accounts, including accountId and legacyAccountId(if present).
-    public Set<String> freeTierBillingAccountNames() {
-      Set<String> billingAccountNames = new HashSet<>();
-      billingAccountNames.add(freeTierBillingAccountName());
-      legacyFreeTierBillingAccountName().ifPresent(billingAccountNames::add);
-      return billingAccountNames;
+    public String initialCreditsBillingAccountName() {
+      return fullBillingAccountName(accountId);
     }
 
     // The full table name for the BigQuery billing export, which is read from by the free-tier

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -13,8 +13,8 @@ import static org.pmiops.workbench.db.model.DbStorageEnums.sexAtBirthFromStorage
 import static org.pmiops.workbench.db.model.DbStorageEnums.workspaceActiveStatusToStorage;
 import static org.pmiops.workbench.db.model.DbUser.USER_APP_NAME_PREFIX;
 import static org.pmiops.workbench.leonardo.LeonardoAppUtils.appServiceNameToAppType;
+import static org.pmiops.workbench.utils.BillingUtils.getBillingAccountType;
 import static org.pmiops.workbench.utils.mappers.CommonMappers.offsetDateTimeUtc;
-import static org.pmiops.workbench.workspaces.WorkspaceUtils.getBillingAccountType;
 
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.QueryJobConfiguration;

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -268,7 +268,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
     RawlsCreateRawlsV2BillingProjectFullRequest request =
         new RawlsCreateRawlsV2BillingProjectFullRequest()
-            .billingAccount(configProvider.get().billing.freeTierBillingAccountName())
+            .billingAccount(configProvider.get().billing.initialCreditsBillingAccountName())
             .projectName(billingProjectName)
             .servicePerimeter(servicePerimeter);
     BillingV2Api billingV2Api = serviceAccountBillingV2ApiProvider.get();

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -17,7 +17,7 @@ import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.BillingStatus;
-import org.pmiops.workbench.workspaces.WorkspaceUtils;
+import org.pmiops.workbench.utils.BillingUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -95,7 +95,7 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
       workspaceDao.findAllByCreator(user).stream()
           .filter(
               ws ->
-                  WorkspaceUtils.isFreeTier(
+                  BillingUtils.isFreeTier(
                       ws.getBillingAccountName(), workbenchConfigProvider.get()))
           .filter(DbWorkspace::isActive)
           .filter(ws -> !ws.isInitialCreditsExpired())

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -95,7 +95,7 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
       workspaceDao.findAllByCreator(user).stream()
           .filter(
               ws ->
-                  BillingUtils.isFreeTier(
+                  BillingUtils.isInitialCredits(
                       ws.getBillingAccountName(), workbenchConfigProvider.get()))
           .filter(DbWorkspace::isActive)
           .filter(ws -> !ws.isInitialCreditsExpired())

--- a/api/src/main/java/org/pmiops/workbench/utils/BillingUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/BillingUtils.java
@@ -12,15 +12,18 @@ public class BillingUtils {
     return BILLING_ACCOUNT_PREFIX + "/" + billingAccount;
   }
 
-  /** Returns {@code true} if the given billing account is workbench free tier billing account. */
-  public static boolean isFreeTier(String billingAccountName, WorkbenchConfig workbenchConfig) {
+  /**
+   * Returns {@code true} if the given billing account is workbench initial credits billing account.
+   */
+  public static boolean isInitialCredits(
+      String billingAccountName, WorkbenchConfig workbenchConfig) {
     return workbenchConfig.billing.initialCreditsBillingAccountName().equals(billingAccountName);
   }
 
   /** Returns {@code BillingAccountType} by given billing account name. */
   public static BillingAccountType getBillingAccountType(
       String billingAccountName, WorkbenchConfig workbenchConfig) {
-    return isFreeTier(billingAccountName, workbenchConfig)
+    return isInitialCredits(billingAccountName, workbenchConfig)
         ? BillingAccountType.FREE_TIER
         : BillingAccountType.USER_PROVIDED;
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/BillingUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/BillingUtils.java
@@ -1,15 +1,20 @@
-package org.pmiops.workbench.workspaces;
+package org.pmiops.workbench.utils;
 
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.model.BillingAccountType;
 
-/** Utility methods for parsing the workspace. */
-public class WorkspaceUtils {
-  private WorkspaceUtils() {}
+public class BillingUtils {
+  private BillingUtils() {}
+
+  public static final String BILLING_ACCOUNT_PREFIX = "billingAccounts";
+
+  public static String fullBillingAccountName(String billingAccount) {
+    return BILLING_ACCOUNT_PREFIX + "/" + billingAccount;
+  }
 
   /** Returns {@code true} if the given billing account is workbench free tier billing account. */
   public static boolean isFreeTier(String billingAccountName, WorkbenchConfig workbenchConfig) {
-    return workbenchConfig.billing.freeTierBillingAccountNames().contains(billingAccountName);
+    return workbenchConfig.billing.initialCreditsBillingAccountName().equals(billingAccountName);
   }
 
   /** Returns {@code BillingAccountType} by given billing account name. */

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceAuthService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceAuthService.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
-import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
+import static org.pmiops.workbench.utils.BillingUtils.isInitialCredits;
 
 import jakarta.inject.Provider;
 import java.util.List;
@@ -59,7 +59,7 @@ public class WorkspaceAuthService {
   public void validateInitialCreditUsage(String workspaceNamespace, String workspaceId)
       throws ForbiddenException {
     DbWorkspace workspace = workspaceDao.getRequired(workspaceNamespace, workspaceId);
-    if (isFreeTier(workspace.getBillingAccountName(), workbenchConfigProvider.get())
+    if (isInitialCredits(workspace.getBillingAccountName(), workbenchConfigProvider.get())
         && (workspace.isInitialCreditsExhausted() || workspace.isInitialCreditsExpired())) {
       throw new ForbiddenException(
           String.format(

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceAuthService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceAuthService.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
-import static org.pmiops.workbench.workspaces.WorkspaceUtils.isFreeTier;
+import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
 
 import jakarta.inject.Provider;
 import java.util.List;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
-import static org.pmiops.workbench.workspaces.WorkspaceUtils.isFreeTier;
+import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import jakarta.inject.Provider;

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -1,6 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
-import static org.pmiops.workbench.utils.BillingUtils.isFreeTier;
+import static org.pmiops.workbench.utils.BillingUtils.isInitialCredits;
 
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo;
 import jakarta.inject.Provider;
@@ -447,7 +447,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       return;
     }
 
-    if (isFreeTier(newBillingAccountName, workbenchConfigProvider.get())) {
+    if (isInitialCredits(newBillingAccountName, workbenchConfigProvider.get())) {
       fireCloudService.updateBillingAccountAsService(
           workspace.getWorkspaceNamespace(), newBillingAccountName);
     } else {
@@ -470,7 +470,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
 
     workspace.setBillingAccountName(newBillingAccountName);
 
-    if (isFreeTier(newBillingAccountName, workbenchConfigProvider.get())) {
+    if (isInitialCredits(newBillingAccountName, workbenchConfigProvider.get())) {
       DbUser creator = workspace.getCreator();
       boolean hasInitialCreditsRemaining =
           freeTierBillingService.userHasRemainingFreeTierCredits(creator);
@@ -510,7 +510,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public void updateInitialCreditsExhaustion(DbUser user, boolean exhausted) {
     workspaceDao.findAllByCreator(user).stream()
-        .filter(ws -> isFreeTier(ws.getBillingAccountName(), workbenchConfigProvider.get()))
+        .filter(ws -> isInitialCredits(ws.getBillingAccountName(), workbenchConfigProvider.get()))
         .forEach(
             ws -> {
               ws.setInitialCreditsExhausted(exhausted);

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Doubles;
@@ -563,7 +564,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
     workspaceDao.save(
         workspace
-            .setBillingAccountName("billingAccounts/byo-account")
+            .setBillingAccountName(fullBillingAccountName("byo-account"))
             .setBillingStatus(BillingStatus.ACTIVE));
 
     cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiry(
@@ -712,7 +713,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
             .setCreator(creator)
             .setWorkspaceNamespace(project + "-ns")
             .setGoogleProject(project)
-            .setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName()));
+            .setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName()));
   }
 
   @NotNull

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -229,7 +229,8 @@ public class DataSetControllerTest {
 
   @TestConfiguration
   @Import({
-    FakeClockConfiguration.class,
+    AccessTierServiceImpl.class,
+    AnalysisLanguageMapperImpl.class,
     CohortFactoryImpl.class,
     CohortMapperImpl.class,
     CohortReviewMapperImpl.class,
@@ -243,7 +244,9 @@ public class DataSetControllerTest {
     DataSetController.class,
     DataSetMapperImpl.class,
     DataSetServiceImpl.class,
+    FakeClockConfiguration.class,
     FirecloudMapperImpl.class,
+    ObjectNameLengthServiceImpl.class,
     TestBigQueryCdrSchemaConfig.class,
     UserMapperImpl.class,
     UserServiceTestConfiguration.class,
@@ -253,15 +256,12 @@ public class DataSetControllerTest {
     WorkspaceResourcesServiceImpl.class,
     WorkspaceServiceImpl.class,
     WorkspacesController.class,
-    AccessTierServiceImpl.class,
-    ObjectNameLengthServiceImpl.class,
-    BucketAuditQueryService.class,
-    AnalysisLanguageMapperImpl.class,
   })
   @MockBean({
     AccessModuleService.class,
     BigQueryService.class,
     BillingProjectAuditor.class,
+    BucketAuditQueryService.class,
     CloudBillingClient.class,
     CloudStorageClient.class,
     CohortBuilderMapper.class,

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -184,7 +184,6 @@ public class DataSetControllerTest {
   private static final String NAMED_PARAMETER_ARRAY_NAME = "p2_1";
   private static final QueryParameterValue NAMED_PARAMETER_ARRAY_VALUE =
       QueryParameterValue.array(new Integer[] {2, 5}, StandardSQLTypeName.INT64);
-  private static final String BILLING_ACCOUNT_PREFIX = "billingAccounts";
   private static final String TEST_FREE_TIER = "free-tier";
 
   private static final Instant NOW = Instant.now();
@@ -802,7 +801,7 @@ public class DataSetControllerTest {
             DbStorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE));
     dbWorkspace
         .setInitialCreditsExhausted(true)
-        .setBillingAccountName(BILLING_ACCOUNT_PREFIX + "/" + TEST_FREE_TIER);
+        .setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
     workspaceDao.save(dbWorkspace);
 
     DataSetExportRequest request =

--- a/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DataSetControllerTest.java
@@ -184,7 +184,6 @@ public class DataSetControllerTest {
   private static final String NAMED_PARAMETER_ARRAY_NAME = "p2_1";
   private static final QueryParameterValue NAMED_PARAMETER_ARRAY_VALUE =
       QueryParameterValue.array(new Integer[] {2, 5}, StandardSQLTypeName.INT64);
-  private static final String TEST_FREE_TIER = "free-tier";
 
   private static final Instant NOW = Instant.now();
   private static final FakeClock CLOCK = new FakeClock(NOW, ZoneId.systemDefault());
@@ -213,7 +212,6 @@ public class DataSetControllerTest {
   @Autowired private FirecloudMapper firecloudMapper;
 
   @MockBean private BigQueryService mockBigQueryService;
-  @MockBean private BucketAuditQueryService bucketAuditQueryService;
   @MockBean private CdrBigQuerySchemaConfigService mockCdrBigQuerySchemaConfigService;
   @MockBean private CdrVersionService mockCdrVersionService;
   @MockBean private CloudBillingClient cloudBillingClient;
@@ -334,7 +332,7 @@ public class DataSetControllerTest {
     doReturn(cdrBigQuerySchemaConfig).when(mockCdrBigQuerySchemaConfigService).getConfig();
 
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.billing.accountId = TEST_FREE_TIER;
+    workbenchConfig.billing.accountId = "free-tier";
 
     DbUser user = new DbUser();
     user.setUsername(USER_EMAIL);

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -83,10 +83,6 @@ public class OfflineRuntimeControllerTest {
   static class Configuration {
     @Bean
     public WorkbenchConfig workbenchConfig() {
-      WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
-      config.firecloud.notebookRuntimeMaxAgeDays = (int) RUNTIME_MAX_AGE.toDays();
-      config.firecloud.notebookRuntimeIdleMaxAgeDays = (int) RUNTIME_IDLE_MAX_AGE.toDays();
-      config.billing.accountId = "free-tier";
       return config;
     }
   }
@@ -121,9 +117,15 @@ public class OfflineRuntimeControllerTest {
   private DbUser user2;
   private DbWorkspace workspace;
   private int runtimeProjectIdIndex = 0;
+  private static WorkbenchConfig config;
 
   @BeforeEach
   public void setUp() {
+    config = WorkbenchConfig.createEmptyConfig();
+    config.firecloud.notebookRuntimeMaxAgeDays = (int) RUNTIME_MAX_AGE.toDays();
+    config.firecloud.notebookRuntimeIdleMaxAgeDays = (int) RUNTIME_IDLE_MAX_AGE.toDays();
+    config.billing.accountId = "free-tier";
+
     runtimeProjectIdIndex = 0;
     DbCdrVersion cdrVersion = createDefaultCdrVersion();
     accessTierDao.save(cdrVersion.getAccessTier());
@@ -415,7 +417,7 @@ public class OfflineRuntimeControllerTest {
     stubWorkspaceOwners(workspace, ImmutableList.of(user1));
     stubDisks(ImmutableList.of(idleDisk(Duration.ofDays(14L))));
 
-    workspace.setBillingAccountName("billingAccounts/free-tier");
+    workspace.setBillingAccountName(config.billing.initialCreditsBillingAccountName());
     when(mockFreeTierBillingService.getWorkspaceCreatorFreeCreditsRemaining(workspace))
         .thenReturn(123.0);
 

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -117,11 +117,10 @@ public class OfflineRuntimeControllerTest {
   private DbUser user2;
   private DbWorkspace workspace;
   private int runtimeProjectIdIndex = 0;
-  private static WorkbenchConfig config;
+  private static WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
 
   @BeforeEach
   public void setUp() {
-    config = WorkbenchConfig.createEmptyConfig();
     config.firecloud.notebookRuntimeMaxAgeDays = (int) RUNTIME_MAX_AGE.toDays();
     config.firecloud.notebookRuntimeIdleMaxAgeDays = (int) RUNTIME_IDLE_MAX_AGE.toDays();
     config.billing.accountId = "free-tier";

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -336,7 +336,7 @@ public class RuntimeControllerTest {
             .setName(WORKSPACE_NAME)
             .setFirecloudName(WORKSPACE_ID)
             .setCdrVersion(cdrVersion)
-            .setBillingAccountName("billingAccounts/free-tier");
+            .setBillingAccountName(config.billing.initialCreditsBillingAccountName());
     doReturn(testWorkspace).when(workspaceService).lookupWorkspaceByNamespace(WORKSPACE_NS);
     doReturn(Optional.of(testWorkspace)).when(workspaceDao).getByNamespace(WORKSPACE_NS);
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.google.GoogleConfig.END_USER_CLOUD_BILLING;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
@@ -348,11 +349,12 @@ public class UserControllerTest {
   // free tier available vs. expired
   // cloud accounts available vs. none
 
-  static final BillingAccount freeTierBillingAccount =
+  static final String INITIAL_CREDITS_ID = "free-tier";
+  static final BillingAccount INITIAL_CREDITS_BILLING_ACCOUNT =
       new BillingAccount()
           .freeTier(true)
           .displayName("Use All of Us initial credits")
-          .name("billingAccounts/free-tier")
+          .name(fullBillingAccountName(INITIAL_CREDITS_ID))
           .open(true);
 
   static final List<com.google.api.services.cloudbilling.model.BillingAccount>
@@ -383,7 +385,7 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeYES_cloudYES() throws IOException {
-    config.billing.accountId = "free-tier";
+    config.billing.accountId = INITIAL_CREDITS_ID;
 
     when(mockFreeTierBillingService.userHasRemainingFreeTierCredits(any())).thenReturn(true);
 
@@ -392,7 +394,7 @@ public class UserControllerTest {
 
     final List<BillingAccount> expectedWorkbenchBillingAccounts =
         ListUtils.union(
-            Lists.newArrayList(freeTierBillingAccount), cloudbillingAccountsInWorkbench);
+            Lists.newArrayList(INITIAL_CREDITS_BILLING_ACCOUNT), cloudbillingAccountsInWorkbench);
 
     final WorkbenchListBillingAccountsResponse response =
         userController.listBillingAccounts().getBody();
@@ -403,7 +405,7 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeYES_cloudNO() throws IOException {
-    config.billing.accountId = "free-tier";
+    config.billing.accountId = INITIAL_CREDITS_ID;
 
     when(mockFreeTierBillingService.userHasRemainingFreeTierCredits(any())).thenReturn(true);
 
@@ -411,7 +413,7 @@ public class UserControllerTest {
         .thenReturn(new ListBillingAccountsResponse().setBillingAccounts(null));
 
     final List<BillingAccount> expectedWorkbenchBillingAccounts =
-        Lists.newArrayList(freeTierBillingAccount);
+        Lists.newArrayList(INITIAL_CREDITS_BILLING_ACCOUNT);
 
     final WorkbenchListBillingAccountsResponse response =
         userController.listBillingAccounts().getBody();
@@ -422,7 +424,7 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeNO_cloudYES() throws IOException {
-    config.billing.accountId = "free-tier";
+    config.billing.accountId = INITIAL_CREDITS_ID;
 
     when(mockFreeTierBillingService.userHasRemainingFreeTierCredits(any())).thenReturn(false);
 
@@ -440,7 +442,7 @@ public class UserControllerTest {
 
   @Test
   public void listBillingAccounts_upgradeYES_freeNO_cloudNO() throws IOException {
-    config.billing.accountId = "free-tier";
+    config.billing.accountId = INITIAL_CREDITS_ID;
 
     when(mockFreeTierBillingService.userHasRemainingFreeTierCredits(any())).thenReturn(false);
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -701,7 +701,7 @@ public class WorkspacesControllerTest {
           .updateBillingAccount(workspace.getNamespace(), workspace.getBillingAccountName());
       verify(fireCloudService)
           .updateBillingAccountAsService(
-              workspace.getNamespace(), workbenchConfig.billing.freeTierBillingAccountName());
+              workspace.getNamespace(), workbenchConfig.billing.initialCreditsBillingAccountName());
       return;
     }
     fail();
@@ -710,7 +710,7 @@ public class WorkspacesControllerTest {
   @Test
   public void testCreateWorkspace_doNotUpdateBillingForFreeTier() {
     Workspace workspace = createWorkspace();
-    workspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    workspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
 
     workspacesController.createWorkspace(workspace);
 
@@ -1138,7 +1138,7 @@ public class WorkspacesControllerTest {
             argThat(dbUser -> dbUser.getUserId() == currentUser.getUserId()));
 
     UpdateWorkspaceRequest request = new UpdateWorkspaceRequest();
-    workspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    workspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
     request.setWorkspace(workspace);
     Workspace response =
         workspacesController
@@ -1166,7 +1166,7 @@ public class WorkspacesControllerTest {
             argThat(dbUser -> dbUser.getUserId() == currentUser.getUserId()));
 
     UpdateWorkspaceRequest request = new UpdateWorkspaceRequest();
-    workspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    workspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
     workspace.setEtag("\"1\"");
     request.setWorkspace(workspace);
     Workspace response =
@@ -1418,7 +1418,8 @@ public class WorkspacesControllerTest {
           .updateBillingAccount(modWorkspace.getNamespace(), modWorkspace.getBillingAccountName());
       verify(fireCloudService)
           .updateBillingAccountAsService(
-              modWorkspace.getNamespace(), workbenchConfig.billing.freeTierBillingAccountName());
+              modWorkspace.getNamespace(),
+              workbenchConfig.billing.initialCreditsBillingAccountName());
       return;
     }
     fail();
@@ -1432,7 +1433,7 @@ public class WorkspacesControllerTest {
     final Workspace modWorkspace = new Workspace();
     modWorkspace.setName("cloned");
     modWorkspace.setNamespace("cloned-ns");
-    modWorkspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    modWorkspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
     modWorkspace.setResearchPurpose(new ResearchPurpose());
 
     final CloneWorkspaceRequest req = new CloneWorkspaceRequest();
@@ -1467,7 +1468,8 @@ public class WorkspacesControllerTest {
           final Workspace modWorkspace = new Workspace();
           modWorkspace.setName("cloned");
           modWorkspace.setNamespace("cloned-ns");
-          modWorkspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+          modWorkspace.setBillingAccountName(
+              workbenchConfig.billing.initialCreditsBillingAccountName());
           modWorkspace.setResearchPurpose(new ResearchPurpose());
           modWorkspace.setCdrVersionId(String.valueOf(altCdrVersion.getCdrVersionId()));
           final CloneWorkspaceRequest req = new CloneWorkspaceRequest();

--- a/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/billing/FreeTierBillingServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.pmiops.workbench.billing.InitialCreditsExpiryTaskMatchers.*;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import com.google.cloud.PageImpl;
 import com.google.cloud.bigquery.Field;
@@ -574,7 +575,7 @@ public class FreeTierBillingServiceTest {
     workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
     workspaceDao.save(
         workspace
-            .setBillingAccountName("billingAccounts/byo-account")
+            .setBillingAccountName(fullBillingAccountName("byo-account"))
             .setBillingStatus(BillingStatus.ACTIVE));
 
     commitTransaction();
@@ -852,7 +853,7 @@ public class FreeTierBillingServiceTest {
             .setCreator(creator)
             .setWorkspaceNamespace(project + "-ns")
             .setGoogleProject(project)
-            .setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName()));
+            .setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName()));
   }
 
   private void assertWithinBillingTolerance(double actualValue, double expectedValue) {

--- a/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/firecloud/FireCloudServiceImplTest.java
@@ -251,9 +251,11 @@ public class FireCloudServiceImplTest {
   @Test
   public void testCreateAllOfUsBillingProject_v2BillingApi() throws Exception {
     final String servicePerimeter = "a-cloud-with-a-fence-around-it";
+    final String projectName = "project-name";
+
     // confirm that this value is no longer how we choose perimeters
 
-    service.createAllOfUsBillingProject("project-name", servicePerimeter);
+    service.createAllOfUsBillingProject(projectName, servicePerimeter);
 
     ArgumentCaptor<RawlsCreateRawlsV2BillingProjectFullRequest> captor =
         ArgumentCaptor.forClass(RawlsCreateRawlsV2BillingProjectFullRequest.class);
@@ -262,10 +264,11 @@ public class FireCloudServiceImplTest {
 
     // N.B. FireCloudServiceImpl doesn't add the project prefix; this is done by callers such
     // as BillingProjectBufferService.
-    assertThat(request.getProjectName()).isEqualTo("project-name");
+    assertThat(request.getProjectName()).isEqualTo(projectName);
     // FireCloudServiceImpl always adds the "billingAccounts/" prefix to the billing account
     // from config.
-    assertThat(request.getBillingAccount()).isEqualTo("billingAccounts/test-billing-account");
+    assertThat(request.getBillingAccount())
+        .isEqualTo(workbenchConfig.billing.initialCreditsBillingAccountName());
     assertThat(request.getServicePerimeter()).isEqualTo(servicePerimeter);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceTest.java
@@ -82,7 +82,7 @@ public class InitialCreditsExpirationServiceTest {
     workspace =
         spyWorkspaceDao.save(
             new DbWorkspace()
-                .setBillingAccountName("billingAccounts/" + config.billing.accountId)
+                .setBillingAccountName(config.billing.initialCreditsBillingAccountName())
                 .setWorkspaceId(1L));
     when(spyWorkspaceDao.findAllByCreator(any())).thenReturn(Set.of(workspace));
   }

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.testconfig;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 import static org.pmiops.workbench.utils.TimeAssertions.assertTimeApprox;
 import static org.pmiops.workbench.utils.mappers.CommonMappers.offsetDateTimeUtc;
 
@@ -189,7 +190,7 @@ public class ReportingTestUtils {
     workspace.setTimeRequested(WORKSPACE__RP_TIME_REQUESTED);
     workspace.setWorkspaceId(WORKSPACE__WORKSPACE_ID);
     workspace.setWorkspaceNamespace(WORKSPACE__WORKSPACE_NAMESPACE);
-    workspace.setBillingAccountName("billingAccounts/" + WORKSPACE__BILLING_ACCOUNT_ID);
+    workspace.setBillingAccountName(fullBillingAccountName(WORKSPACE__BILLING_ACCOUNT_ID));
     return workspace;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
 import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import com.google.api.services.cloudbilling.Cloudbilling;
 import com.google.api.services.cloudbilling.model.BillingAccount;
@@ -69,7 +70,8 @@ import org.pmiops.workbench.rawls.model.RawlsWorkspaceResponse;
 public class TestMockFactory {
   public static final String WORKSPACE_BUCKET_NAME = "fc-secure-111111-2222-AAAA-BBBB-000000000000";
   private static final String CDR_VERSION_ID = "1";
-  public static final String WORKSPACE_BILLING_ACCOUNT_NAME = "billingAccounts/00000-AAAAA-BBBBB";
+  public static final String WORKSPACE_BILLING_ACCOUNT_NAME =
+      fullBillingAccountName("00000-AAAAA-BBBBB");
   private static final String WORKSPACE_FIRECLOUD_NAME =
       "gonewiththewind"; // should match workspace name w/o spaces
   public static final String DEFAULT_GOOGLE_PROJECT = "aou-rw-test-123";

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
@@ -275,7 +275,7 @@ public class WorkspaceAuthServiceTest {
             .setFirecloudName(fcName)
             .setInitialCreditsExhausted(initialCreditsExhausted)
             .setInitialCreditsExpired(initialCreditsExpired)
-            .setBillingAccountName("billingAccounts/free-tier");
+            .setBillingAccountName(config.billing.initialCreditsBillingAccountName());
     when(mockWorkspaceDao.getRequired(namespace, fcName)).thenReturn(toReturn);
     return toReturn;
   }

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceAuthServiceTest.java
@@ -99,8 +99,8 @@ public class WorkspaceAuthServiceTest {
   public void test_validateInitialCreditUsage_invalid() {
     final String namespace = "wsns";
     final String fcName = "firecloudname";
-    stubDaoGetRequired(namespace, fcName, true, true);
     config.billing.accountId = "free-tier";
+    stubDaoGetRequired(namespace, fcName, true, true);
 
     assertThrows(
         ForbiddenException.class,

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -165,7 +165,6 @@ public class WorkspaceServiceTest {
   private static final long USER_ID = 1L;
   private static final String DEFAULT_USERNAME = "mock@mock.com";
   private static final String DEFAULT_WORKSPACE_NAMESPACE = "namespace";
-  private static final String FREE_TIER_BILLING_ACCOUNT_ID = "free-tier-account";
 
   private final AtomicLong workspaceIdIncrementer = new AtomicLong(1);
 
@@ -216,7 +215,7 @@ public class WorkspaceServiceTest {
     currentUser.setDisabled(false);
 
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.billing.accountId = FREE_TIER_BILLING_ACCOUNT_ID;
+    workbenchConfig.billing.accountId = "free-tier-account";
   }
 
   private RawlsWorkspaceResponse mockRawlsWorkspaceResponse(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -581,7 +581,7 @@ public class WorkspaceServiceTest {
   public void updateBillingAccount_freeTierToUserOwned() throws Exception {
     String newBillingAccount = "billing-123";
     DbWorkspace workspace = dbWorkspaces.get(1); // arbitrary choice of those defined for testing
-    workspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    workspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
     ProjectBillingInfo projectBillingInfo =
         new ProjectBillingInfo()
             .setProjectId(workspace.getGoogleProject())
@@ -592,7 +592,7 @@ public class WorkspaceServiceTest {
         .thenReturn(projectBillingInfo);
 
     assertThat(workspace.getBillingAccountName())
-        .isEqualTo(workbenchConfig.billing.freeTierBillingAccountName());
+        .isEqualTo(workbenchConfig.billing.initialCreditsBillingAccountName());
 
     workspaceService.updateWorkspaceBillingAccount(workspace, newBillingAccount);
 
@@ -613,21 +613,22 @@ public class WorkspaceServiceTest {
     ProjectBillingInfo projectBillingInfo =
         new ProjectBillingInfo()
             .setProjectId(workspace.getGoogleProject())
-            .setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName())
+            .setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName())
             .setBillingEnabled(true);
     when(mockCloudBillingClient.pollUntilBillingAccountLinked(
-            workspace.getGoogleProject(), workbenchConfig.billing.freeTierBillingAccountName()))
+            workspace.getGoogleProject(),
+            workbenchConfig.billing.initialCreditsBillingAccountName()))
         .thenReturn(projectBillingInfo);
     workspaceService.updateWorkspaceBillingAccount(
-        workspace, workbenchConfig.billing.freeTierBillingAccountName());
+        workspace, workbenchConfig.billing.initialCreditsBillingAccountName());
 
     verify(mockFireCloudService)
         .updateBillingAccountAsService(
             workspace.getWorkspaceNamespace(),
-            workbenchConfig.billing.freeTierBillingAccountName());
+            workbenchConfig.billing.initialCreditsBillingAccountName());
     verify(mockFireCloudService, never()).updateBillingAccount(anyString(), anyString());
     assertThat(workspace.getBillingAccountName())
-        .isEqualTo(workbenchConfig.billing.freeTierBillingAccountName());
+        .isEqualTo(workbenchConfig.billing.initialCreditsBillingAccountName());
   }
 
   @Test
@@ -646,7 +647,7 @@ public class WorkspaceServiceTest {
   public void updateBillingAccount_accountNotOpen() throws Exception {
     String newBillingAccount = "billing-123";
     DbWorkspace workspace = dbWorkspaces.get(1); // arbitrary choice of those defined for testing
-    workspace.setBillingAccountName(workbenchConfig.billing.freeTierBillingAccountName());
+    workspace.setBillingAccountName(workbenchConfig.billing.initialCreditsBillingAccountName());
 
     ProjectBillingInfo projectBillingInfo =
         new ProjectBillingInfo()

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateWgsCohortExtractionBillingProjectWorkspace.java
@@ -141,7 +141,7 @@ public class CreateWgsCohortExtractionBillingProjectWorkspace extends Tool {
       log.info("Creating billing project");
       RawlsCreateRawlsV2BillingProjectFullRequest billingProjectRequest =
           new RawlsCreateRawlsV2BillingProjectFullRequest()
-              .billingAccount("billingAccounts/" + workbenchConfig.billing.accountId)
+              .billingAccount(workbenchConfig.billing.initialCreditsBillingAccountName())
               .projectName(opts.getOptionValue(billingProjectNameOpt.getLongOpt()));
       BillingV2Api billingV2Api = rawlsApiClientFactory.billingV2Api();
       billingV2Api.createBillingProjectFullV2(billingProjectRequest);


### PR DESCRIPTION
Tested locally by interacting with an Initial-Credits workspace and observing that it worked nornally

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
