### PR TITLE
[risk=low][no ticket] Terra Name: add CopyRequest.toWorkspaceTerraName and dual-write in UI

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7568,13 +7568,16 @@ components:
     CopyRequest:
       required:
       - newName
-      - toWorkspaceName
       - toWorkspaceNamespace
+      - toWorkspaceTerraName
       type: object
       properties:
         toWorkspaceName:
           type: string
+          description: DEPRECATED due to ambiguity about which workspace name is required here
         toWorkspaceNamespace:
+          type: string
+        toWorkspaceTerraName:
           type: string
         newName:
           type: string

--- a/ui/src/app/components/copy-modal.spec.tsx
+++ b/ui/src/app/components/copy-modal.spec.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import {
   ConceptSetsApi,
+  CopyRequest,
   NotebooksApi,
   ResourceType,
   WorkspaceAccessLevel,
@@ -145,7 +146,7 @@ describe(CopyModal.name, () => {
   const fromCdrVersionId = ownerWorkspace.cdrVersionId;
   const fromAccessTierShortName = ownerWorkspace.accessTierShortName;
   const fromResourceName = 'notebook';
-  const notebookSaveFunction = (copyRequest) => {
+  const notebookSaveFunction = (copyRequest: CopyRequest) => {
     return notebooksApi().copyNotebook(
       fromWorkspaceNamespace,
       fromWorkspaceTerraName,
@@ -296,8 +297,9 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
-        toWorkspaceName: writerWorkspace.terraName,
         toWorkspaceNamespace: writerWorkspace.namespace,
+        toWorkspaceName: writerWorkspace.terraName,
+        toWorkspaceTerraName: writerWorkspace.terraName,
         newName,
       }
     );
@@ -335,8 +337,9 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
-        toWorkspaceName: altCdrWorkspace.terraName,
         toWorkspaceNamespace: altCdrWorkspace.namespace,
+        toWorkspaceName: altCdrWorkspace.terraName,
+        toWorkspaceTerraName: altCdrWorkspace.terraName,
         newName,
       }
     );
@@ -398,8 +401,9 @@ describe(CopyModal.name, () => {
       props.fromWorkspaceTerraName,
       props.fromResourceName,
       {
-        toWorkspaceName: writerWorkspace.terraName,
         toWorkspaceNamespace: writerWorkspace.namespace,
+        toWorkspaceName: writerWorkspace.terraName,
+        toWorkspaceTerraName: writerWorkspace.terraName,
         newName,
       }
     );

--- a/ui/src/app/components/copy-modal.tsx
+++ b/ui/src/app/components/copy-modal.tsx
@@ -5,6 +5,7 @@ import { validate } from 'validate.js';
 import {
   CdrVersionTiersResponse,
   ConceptSet,
+  CopyRequest,
   FileDetail,
   ResourceType,
   Workspace,
@@ -48,7 +49,7 @@ export interface CopyModalProps {
   onClose: Function;
   onCopy: Function;
   resourceType: ResourceType;
-  saveFunction: (CopyRequest) => Promise<FileDetail | ConceptSet>;
+  saveFunction: (cr: CopyRequest) => Promise<FileDetail | ConceptSet>;
 }
 
 interface HocProps extends CopyModalProps, NavigationProps {
@@ -255,8 +256,9 @@ const CopyModal = withCdrVersions()(
       const { saveFunction, resourceType } = this.props;
 
       saveFunction({
-        toWorkspaceName: this.state.destination.terraName,
         toWorkspaceNamespace: this.state.destination.namespace,
+        toWorkspaceName: this.state.destination.terraName,
+        toWorkspaceTerraName: this.state.destination.terraName,
         newName: this.state.newName,
       })
         .then((response) => {


### PR DESCRIPTION
Part 1 of a multi-step process due to release safety: add a new field to the entity object CopyRequest, and update the UI to write to both the old name and the new.

Tested locally by copying a Notebook between workspaces

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
