### PR TITLE
[risk=low][RW-11664] Allow increasing GKE App disk size at app creation time

### DIFF
--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -1,11 +1,27 @@
 import * as React from 'react';
 
-import { AppsApi, AppStatus, BillingStatus } from 'generated/fetch';
+import {
+  AppsApi,
+  AppStatus,
+  AppType,
+  BillingStatus,
+  CreateAppRequest,
+  Disk,
+  DisksApi,
+} from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { defaultCromwellCreateRequest } from 'app/components/apps-panel/utils';
-import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import {
+  appMaxDiskSize,
+  appMinDiskSize,
+  defaultCromwellCreateRequest,
+} from 'app/components/apps-panel/utils';
+import {
+  appsApi,
+  disksApi,
+  registerApiClient,
+} from 'app/services/swagger-fetch-clients';
 
 import {
   expectButtonElementDisabled,
@@ -15,6 +31,7 @@ import {
   AppsApiStub,
   createListAppsCromwellResponse,
 } from 'testing/stubs/apps-api-stub';
+import { DisksApiStub } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
 
@@ -24,10 +41,11 @@ import {
 } from './create-gke-app-button';
 
 describe(CreateGkeAppButton.name, () => {
+  const workspaceNamespace = 'aou-rw-test-1';
   const defaultProps: CreateGKEAppButtonProps = {
     createAppRequest: defaultCromwellCreateRequest,
     existingApp: null,
-    workspaceNamespace: 'aou-rw-test-1',
+    workspaceNamespace,
     onDismiss: () => {},
     username: ProfileStubVariables.PROFILE_STUB.username,
     billingStatus: BillingStatus.ACTIVE,
@@ -53,8 +71,21 @@ describe(CreateGkeAppButton.name, () => {
     createEnabledStatuses
   );
 
+  // can't declare spies yet because the API is not registered
+
+  const getCreateSpy = () =>
+    jest
+      .spyOn(appsApi(), 'createApp')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+
+  const getUpdateDiskSpy = () =>
+    jest
+      .spyOn(disksApi(), 'updateDisk')
+      .mockImplementation((): Promise<any> => Promise.resolve());
+
   beforeEach(() => {
     registerApiClient(AppsApi, new AppsApiStub());
+    registerApiClient(DisksApi, new DisksApiStub());
     user = userEvent.setup();
   });
   afterEach(() => {
@@ -63,9 +94,8 @@ describe(CreateGkeAppButton.name, () => {
 
   describe('should allow creating a GKE app for certain app statuses', () => {
     test.each(createEnabledStatuses)('Status %s', async (appStatus) => {
-      const createSpy = jest
-        .spyOn(appsApi(), 'createApp')
-        .mockImplementation((): Promise<any> => Promise.resolve());
+      const createSpy = getCreateSpy();
+      const updateDiskSpy = getUpdateDiskSpy();
 
       await component({
         createAppRequest: defaultCromwellCreateRequest,
@@ -80,8 +110,12 @@ describe(CreateGkeAppButton.name, () => {
 
       button.click();
       await waitFor(() => {
-        expect(createSpy).toHaveBeenCalled();
+        expect(createSpy).toHaveBeenCalledWith(
+          workspaceNamespace,
+          defaultCromwellCreateRequest
+        );
       });
+      expect(updateDiskSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -118,6 +152,171 @@ describe(CreateGkeAppButton.name, () => {
 
     await screen.findByText(
       'You have either run out of initial credits or have an inactive billing account.'
+    );
+  });
+
+  it('should not allow creating a GKE app with a disk that is too small.', async () => {
+    // Cromwell chosen arbitrarily
+    const tooSmall = appMinDiskSize[AppType.CROMWELL] - 1;
+    await component({
+      createAppRequest: {
+        ...defaultCromwellCreateRequest,
+        persistentDiskRequest: {
+          ...defaultCromwellCreateRequest.persistentDiskRequest,
+          size: tooSmall,
+        },
+      },
+    });
+    const button = await waitFor(() => {
+      const createButton = findCreateButton();
+      expectButtonElementDisabled(createButton);
+      return createButton;
+    });
+
+    await user.pointer([{ pointerName: 'mouse', target: button }]);
+
+    await screen.findByText(
+      /Disk cannot be more than 1000 GB or less than 50 GB/
+    );
+  });
+
+  it('should not allow creating a GKE app with a disk that is too large.', async () => {
+    const tooLarge = appMaxDiskSize + 1;
+    await component({
+      createAppRequest: {
+        ...defaultCromwellCreateRequest,
+        persistentDiskRequest: {
+          ...defaultCromwellCreateRequest.persistentDiskRequest,
+          size: tooLarge,
+        },
+      },
+    });
+    const button = await waitFor(() => {
+      const createButton = findCreateButton();
+      expectButtonElementDisabled(createButton);
+      return createButton;
+    });
+
+    await user.pointer([{ pointerName: 'mouse', target: button }]);
+
+    await screen.findByText(
+      /Disk cannot be more than 1000 GB or less than 50 GB/
+    );
+  });
+
+  it('should allow creating a GKE app with an existing disk.', async () => {
+    const createSpy = getCreateSpy();
+    const updateDiskSpy = getUpdateDiskSpy();
+
+    const existingDiskSize = appMinDiskSize[AppType.CROMWELL] + 10;
+    const diskName = 'arbitrary';
+
+    const existingDisk: Disk = {
+      size: existingDiskSize,
+      name: diskName,
+      blockSize: 1000,
+      diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+    };
+    const createAppRequest: CreateAppRequest = {
+      ...defaultCromwellCreateRequest,
+      persistentDiskRequest: {
+        ...defaultCromwellCreateRequest.persistentDiskRequest,
+        name: diskName,
+        size: existingDiskSize,
+      },
+    };
+    await component({ existingDisk, createAppRequest });
+    const button = await waitFor(() => {
+      const createButton = findCreateButton();
+      expectButtonElementEnabled(createButton);
+      return createButton;
+    });
+
+    button.click();
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        workspaceNamespace,
+        createAppRequest
+      );
+    });
+    expect(updateDiskSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not allow creating a GKE app with a smaller disk.', async () => {
+    const existingDiskSize = appMinDiskSize[AppType.CROMWELL] + 10;
+    const smallerDiskSize = existingDiskSize - 1;
+    const diskName = 'arbitrary';
+
+    const existingDisk: Disk = {
+      size: existingDiskSize,
+      name: diskName,
+      blockSize: 1000,
+      diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+    };
+    await component({
+      existingDisk,
+      createAppRequest: {
+        ...defaultCromwellCreateRequest,
+        persistentDiskRequest: {
+          ...defaultCromwellCreateRequest.persistentDiskRequest,
+          name: diskName,
+          size: smallerDiskSize,
+        },
+      },
+    });
+    const button = await waitFor(() => {
+      const createButton = findCreateButton();
+      expectButtonElementDisabled(createButton);
+      return createButton;
+    });
+
+    await user.pointer([{ pointerName: 'mouse', target: button }]);
+
+    await screen.findByText(
+      /Preventing creation because this would cause data loss./
+    );
+  });
+
+  it('should allow creating a GKE app with a larger disk.', async () => {
+    const createSpy = getCreateSpy();
+    const updateDiskSpy = getUpdateDiskSpy();
+
+    const existingDiskSize = appMinDiskSize[AppType.CROMWELL] + 10;
+    const largerDiskSize = existingDiskSize + 10;
+    const diskName = 'arbitrary';
+
+    const existingDisk: Disk = {
+      size: existingDiskSize,
+      name: diskName,
+      blockSize: 1000,
+      diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+    };
+    const createAppRequest: CreateAppRequest = {
+      ...defaultCromwellCreateRequest,
+      persistentDiskRequest: {
+        ...defaultCromwellCreateRequest.persistentDiskRequest,
+        name: diskName,
+        size: largerDiskSize,
+      },
+    };
+    await component({ existingDisk, createAppRequest });
+    const button = await waitFor(() => {
+      const createButton = findCreateButton();
+      expectButtonElementEnabled(createButton);
+      return createButton;
+    });
+
+    button.click();
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        workspaceNamespace,
+        createAppRequest
+      );
+    });
+    expect(updateDiskSpy).toHaveBeenCalledWith(
+      workspaceNamespace,
+      diskName,
+      largerDiskSize
     );
   });
 });

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -26,6 +26,7 @@ import {
 import {
   expectButtonElementDisabled,
   expectButtonElementEnabled,
+  expectTooltip,
 } from 'testing/react-test-helpers';
 import {
   AppsApiStub,
@@ -125,15 +126,18 @@ describe(CreateGkeAppButton.name, () => {
         createAppRequest: defaultCromwellCreateRequest,
         existingApp: createListAppsCromwellResponse({ status: appStatus }),
       });
+
       const button = await waitFor(() => {
         const createButton = findCreateButton();
         expectButtonElementDisabled(createButton);
         return createButton;
       });
 
-      await user.pointer([{ pointerName: 'mouse', target: button }]);
-
-      await screen.findByText(`A Cromwell app exists or is being created`);
+      await expectTooltip(
+        button,
+        'A Cromwell app exists or is being created',
+        user
+      );
     });
   });
 
@@ -142,16 +146,17 @@ describe(CreateGkeAppButton.name, () => {
       createAppRequest: defaultCromwellCreateRequest,
       billingStatus: BillingStatus.INACTIVE,
     });
+
     const button = await waitFor(() => {
       const createButton = findCreateButton();
       expectButtonElementDisabled(createButton);
       return createButton;
     });
 
-    await user.pointer([{ pointerName: 'mouse', target: button }]);
-
-    await screen.findByText(
-      'You have either run out of initial credits or have an inactive billing account.'
+    await expectTooltip(
+      button,
+      'You have either run out of initial credits or have an inactive billing account.',
+      user
     );
   });
 
@@ -167,16 +172,17 @@ describe(CreateGkeAppButton.name, () => {
         },
       },
     });
+
     const button = await waitFor(() => {
       const createButton = findCreateButton();
       expectButtonElementDisabled(createButton);
       return createButton;
     });
 
-    await user.pointer([{ pointerName: 'mouse', target: button }]);
-
-    await screen.findByText(
-      /Disk cannot be more than 1000 GB or less than 50 GB/
+    await expectTooltip(
+      button,
+      'Disk cannot be more than 1000 GB or less than 50 GB',
+      user
     );
   });
 
@@ -191,16 +197,17 @@ describe(CreateGkeAppButton.name, () => {
         },
       },
     });
+
     const button = await waitFor(() => {
       const createButton = findCreateButton();
       expectButtonElementDisabled(createButton);
       return createButton;
     });
 
-    await user.pointer([{ pointerName: 'mouse', target: button }]);
-
-    await screen.findByText(
-      /Disk cannot be more than 1000 GB or less than 50 GB/
+    await expectTooltip(
+      button,
+      'Disk cannot be more than 1000 GB or less than 50 GB',
+      user
     );
   });
 
@@ -264,16 +271,17 @@ describe(CreateGkeAppButton.name, () => {
         },
       },
     });
+
     const button = await waitFor(() => {
       const createButton = findCreateButton();
       expectButtonElementDisabled(createButton);
       return createButton;
     });
 
-    await user.pointer([{ pointerName: 'mouse', target: button }]);
-
-    await screen.findByText(
-      /Preventing creation because this would cause data loss./
+    await expectTooltip(
+      button,
+      /Preventing creation because this would cause data loss./,
+      user
     );
   });
 

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -112,9 +112,6 @@ export function CreateGkeAppButton({
           unattachedDiskExists(existingApp, existingDisk) &&
           createAppRequest.persistentDiskRequest.size > existingDisk.size
         ) {
-          // confirm not called in unit test:
-          // - no unattached disk
-          // - disk size is not increasing
           await disksApi().updateDisk(
             workspaceNamespace,
             existingDisk.name,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.tsx
@@ -5,6 +5,7 @@ import {
   AppType,
   BillingStatus,
   CreateAppRequest,
+  Disk,
   UserAppEnvironment,
 } from 'generated/fetch';
 
@@ -17,12 +18,14 @@ import {
 import { Button } from 'app/components/buttons';
 import { TooltipTrigger } from 'app/components/popups';
 import { SUPPORT_EMAIL } from 'app/components/support';
+import { disksApi } from 'app/services/swagger-fetch-clients';
 import { ApiErrorResponse, fetchWithErrorModal } from 'app/utils/errors';
 import { NotificationStore } from 'app/utils/stores';
 import {
   appTypeToString,
   createUserApp,
   isDiskSizeValid,
+  unattachedDiskExists,
 } from 'app/utils/user-apps-utils';
 
 export interface CreateGKEAppButtonProps {
@@ -32,6 +35,7 @@ export interface CreateGKEAppButtonProps {
   onDismiss: () => void;
   username: string;
   billingStatus: BillingStatus;
+  existingDisk?: Disk;
   style?: CSSProperties;
 }
 
@@ -42,14 +46,21 @@ export function CreateGkeAppButton({
   onDismiss,
   username,
   billingStatus,
+  existingDisk,
   style,
 }: CreateGKEAppButtonProps) {
   const [creatingApp, setCreatingApp] = useState(false);
+
+  const wouldDecreaseDiskSize =
+    !!existingDisk &&
+    createAppRequest.persistentDiskRequest.size < existingDisk.size;
+
   const createEnabled =
     !creatingApp &&
     !isAppActive(existingApp) &&
     billingStatus === BillingStatus.ACTIVE &&
-    isDiskSizeValid(createAppRequest);
+    isDiskSizeValid(createAppRequest) &&
+    !wouldDecreaseDiskSize;
 
   const appTypeString = appTypeToString[createAppRequest.appType];
 
@@ -76,6 +87,13 @@ export function CreateGkeAppButton({
         } GB`,
     ],
     [
+      wouldDecreaseDiskSize,
+      () =>
+        `The specified disk size (${createAppRequest.persistentDiskRequest.size} GB) is smaller than ` +
+        `the existing unattached persistent disk size of ${existingDisk.size} GB. ` +
+        'Preventing creation because this would cause data loss.',
+    ],
+    [
       billingStatus !== BillingStatus.ACTIVE,
       () =>
         'You have either run out of initial credits or have an inactive billing account.',
@@ -87,7 +105,24 @@ export function CreateGkeAppButton({
   const onCreate = () => {
     setCreatingApp(true);
     fetchWithErrorModal(
-      () => createUserApp(workspaceNamespace, createAppRequest),
+      async () => {
+        // if we need to update the disk before creation, wait for that to finish.
+        // TODO: can we remove this after RW-11634 ?
+        if (
+          unattachedDiskExists(existingApp, existingDisk) &&
+          createAppRequest.persistentDiskRequest.size > existingDisk.size
+        ) {
+          // confirm not called in unit test:
+          // - no unattached disk
+          // - disk size is not increasing
+          await disksApi().updateDisk(
+            workspaceNamespace,
+            existingDisk.name,
+            createAppRequest.persistentDiskRequest.size
+          );
+        }
+        return createUserApp(workspaceNamespace, createAppRequest);
+      },
       {
         customErrorResponseFormatter: (error: ApiErrorResponse) =>
           (error?.originalResponse?.status === 409 && conflictError) ||

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -12,7 +12,7 @@ import {
   WorkspaceAccessLevel,
 } from 'generated/fetch';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import {
   appMaxDiskSize,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -96,7 +96,7 @@ const otherAppType: Record<AppType, AppType> = {
   [AppType.SAS]: AppType.CROMWELL,
 };
 
-// tests for behavior common to all GKE Apps.  For app-specific tests, see e.g. create-cromwell-spec
+// tests for behavior common to all GKE Apps.  For app-type-specific tests, see e.g. create-cromwell-spec
 describe(CreateGkeApp.name, () => {
   let disksApiStub: DisksApiStub;
   let user: UserEvent;
@@ -652,7 +652,7 @@ describe(CreateGkeApp.name, () => {
         });
       });
 
-      it(`Should not not allow disk size less than minimum for ${appType}`, async () => {
+      it(`Should not allow disk size less than minimum for ${appType}`, async () => {
         // Arrange
         await component(appType);
         const minAppSize = appMinDiskSize[appType];
@@ -680,7 +680,7 @@ describe(CreateGkeApp.name, () => {
         );
       });
 
-      it(`Should not not allow disk size more than maximum for ${appType}`, async () => {
+      it(`Should not allow disk size more than maximum for ${appType}`, async () => {
         // Arrange
         await component(appType);
         const createButton = `${appTypeToString[appType]} cloud environment create button`;
@@ -713,7 +713,7 @@ describe(CreateGkeApp.name, () => {
         expectButtonElementDisabled(screen.queryByLabelText(createButton));
       });
 
-      it('Should disable disk size input if App exist', async () => {
+      it('Should disable disk size input if App exists', async () => {
         // Arrange
         const disk = stubDisk();
 
@@ -728,7 +728,7 @@ describe(CreateGkeApp.name, () => {
         ).toBeTruthy();
       });
 
-      it('Should disable disk size input if App does not exist but PD is present', async () => {
+      it('Should enable disk size input if App does not exist but PD is present', async () => {
         // Arrange
         const disk = stubDisk();
         await component(appType, { disk });
@@ -736,14 +736,7 @@ describe(CreateGkeApp.name, () => {
         // Assert
         expect(
           spinDiskElement('gke-app-disk').attributes.getNamedItem('disabled')
-        ).toBeTruthy();
-        fireEvent.mouseOver(spinDiskElement('gke-app-disk'));
-        expect(
-          screen.getByText(
-            'Cannot modify existing disk. To update the disk size please delete the disk and ' +
-              'create a new environment.'
-          )
-        ).toBeInTheDocument();
+        ).toBeFalsy();
       });
     }
   );

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -232,9 +232,9 @@ export const CreateGkeApp = ({
       {toUIAppType[appType]} environment, which is in{' '}
       {fromUserAppStatusWithFallback(app?.status)} state.
       <br />
-      To make changes to the disk, please delete the environment. If you choose
-      to retain the disk, you will be able to increase its size while retaining
-      the existing data when creating a new environment.
+      To make changes to the disk, please delete the environment and choose the
+      option to retain the disk. When re-creating your environment, you will be
+      able to increase the disk size.
     </>
   );
 

--- a/ui/src/app/utils/user-apps-utils.tsx
+++ b/ui/src/app/utils/user-apps-utils.tsx
@@ -75,7 +75,9 @@ const localizeUserApp = (
     appType,
   });
 
-const appJustTurnedRunningFromProvisioning = (listAppsResponse) => {
+const appJustTurnedRunningFromProvisioning = (
+  listAppsResponse: ListAppsResponse
+) => {
   // Note: We do not call localize for CROMWELL
   // We want app that are transitioning from PROVISIONING to RUNNING
   const appsJustStartedRunning = userAppsStore
@@ -96,7 +98,7 @@ const appJustTurnedRunningFromProvisioning = (listAppsResponse) => {
   return appsJustStartedRunning;
 };
 
-const callLocalizeIfApplicable = (listAppsResponse) => {
+const callLocalizeIfApplicable = (listAppsResponse: ListAppsResponse) => {
   // If userAppsStore is not updated lets wait for it to be updated before checking
   if (!!userAppsStore.get() && userAppsStore.get().userApps === undefined) {
     return null;
@@ -241,7 +243,7 @@ export const openAppInIframe = (
   ]);
 };
 
-export const isDiskSizeValid = (appRequest) =>
+export const isDiskSizeValid = (appRequest: CreateAppRequest) =>
   appRequest.persistentDiskRequest.size <= appMaxDiskSize &&
   appRequest.persistentDiskRequest.size >= appMinDiskSize[appRequest.appType];
 


### PR DESCRIPTION
Partial completion of RW-11664:
✅ can increase unattached PD size and attach to newly created app
❌ does not allow changing PD size for running app - that will need a Leo change

Because the second part requires significant effort, we may choose to deprioritize it.  This PR should unblock users.

Tested locally by creating RStudio apps, saving files to the PD, and after recreating the app with an increased disk size:
* observed that the saved files were retained
* observed that I had access to a larger home folder by creating large files in excess of the previous limit

Updated the disk size tooltip when an app is currently running.
<img width="435" alt="Running App" src="https://github.com/user-attachments/assets/fcec16ab-4195-44a6-bf47-e3f048c12cce">

Creation is blocked when disk size is decreased.  That requires deletion of the disk, which the user may continue to do explicitly.
<img width="418" alt="Too Small" src="https://github.com/user-attachments/assets/e2db60ab-238f-45fb-bd10-f58bd1555297">



---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
