### PR TITLE
[risk=low][RW-12525] Update GKE App autodelete thresholds

### DIFF
--- a/ui/src/app/components/apps-panel/utils.tsx
+++ b/ui/src/app/components/apps-panel/utils.tsx
@@ -119,7 +119,7 @@ export const defaultSASCreateRequest: CreateAppRequest = {
     diskType: DiskType.STANDARD,
   },
   autodeleteEnabled: true,
-  autodeleteThreshold: 24 * 60, // in minutes, so this is 1 day
+  autodeleteThreshold: 8 * 60, // in minutes, so this is 8 hours
 };
 
 export const defaultAppRequest: Record<AppType, CreateAppRequest> = {

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -20,10 +20,7 @@ import {
   defaultAppRequest,
 } from 'app/components/apps-panel/utils';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
-import {
-  AutodeleteDaysThresholds,
-  findMachineByName,
-} from 'app/utils/machines';
+import { autodeleteOptions, findMachineByName } from 'app/utils/machines';
 import { serverConfigStore } from 'app/utils/stores';
 import { appTypeToString } from 'app/utils/user-apps-utils';
 
@@ -257,11 +254,10 @@ describe(CreateGkeApp.name, () => {
         const { container } = await component(appType);
 
         // must match one of the choices
-        const autodeleteDays = AutodeleteDaysThresholds[1];
-        const autodeleteThreshold = autodeleteDays * 24 * 60;
+        const autodeleteChoice = autodeleteOptions[0];
 
         // sanity check: does not match default
-        expect(autodeleteThreshold).not.toEqual(
+        expect(autodeleteChoice.value).not.toEqual(
           defaultAppRequest[appType].autodeleteThreshold
         );
 
@@ -269,7 +265,7 @@ describe(CreateGkeApp.name, () => {
         const autodeleteOption = await getDropdownOption(
           container,
           autodeleteId,
-          `Idle for ${autodeleteDays} days`
+          autodeleteChoice.label
         );
         await userEvent.click(autodeleteOption);
 
@@ -277,7 +273,10 @@ describe(CreateGkeApp.name, () => {
         await waitFor(() => {
           expect(spyCreateApp).toHaveBeenCalledWith(
             WorkspaceStubVariables.DEFAULT_WORKSPACE_NS,
-            { ...defaultAppRequest[appType], autodeleteThreshold }
+            {
+              ...defaultAppRequest[appType],
+              autodeleteThreshold: autodeleteChoice.value,
+            }
           );
           expect(onClose).toHaveBeenCalledTimes(1);
         });

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -37,7 +37,7 @@ import { AnalysisConfig } from 'app/utils/analysis-config';
 import { getWholeDaysFromNow } from 'app/utils/dates';
 import {
   allMachineTypes,
-  AutodeleteDaysThresholds,
+  autodeleteOptions,
   ComputeType,
   findMachineByName,
   Machine,
@@ -413,10 +413,7 @@ export const CreateGkeApp = ({
               id={`${appTypeToString[appType]}-autodelete-threshold-dropdown`}
               appendTo='self'
               disabled={isAppActive(app) || !createAppRequest.autodeleteEnabled}
-              options={AutodeleteDaysThresholds.map((days) => ({
-                value: days * 24 * 60,
-                label: `Idle for ${days} days`,
-              }))}
+              options={autodeleteOptions}
               value={createAppRequest.autodeleteThreshold}
               onChange={(e) => {
                 setCreateAppRequest((prevState) => ({

--- a/ui/src/app/utils/machines.ts
+++ b/ui/src/app/utils/machines.ts
@@ -1,4 +1,5 @@
 import * as fp from 'lodash/fp';
+import { SelectItem } from 'primereact/selectitem';
 
 import { Disk, DiskType } from 'generated/fetch';
 
@@ -20,16 +21,35 @@ export enum ComputeType {
   Dataproc = 'Dataproc Cluster',
 }
 
+export const DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES = 30;
 export const AutopauseMinuteThresholds = new Map([
-  [30, '30 minutes (default)'],
+  [
+    DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
+    `${DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES} minutes (default)`,
+  ],
   [60 * 8, '8 hours'],
   [5 * 24 * 60, '5 days'],
   [10 * 24 * 60, '10 days'],
 ]);
 
-export const AutodeleteDaysThresholds = [1, 3, 7, 8, 15, 30];
-
-export const DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES = 30;
+export const autodeleteOptions: SelectItem[] = [
+  {
+    value: 60, // minutes
+    label: 'Idle for 1 hour',
+  },
+  {
+    value: 8 * 60,
+    label: 'Idle for 8 hours',
+  },
+  {
+    value: 24 * 60,
+    label: 'Idle for 1 day',
+  },
+  ...[3, 7, 15, 30].map((days) => ({
+    value: days * 24 * 60,
+    label: `Idle for ${days} days`,
+  })),
+];
 
 export interface Machine {
   name: string;


### PR DESCRIPTION
Adds the choices of 1 hour and 8 hours, and makes 8 hours the SAS default.

[x] Confirm that these are desired
[x] Update Leo autodelete monitor

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
