### PR TITLE
RW-12240 Remove eraRequired from API

### DIFF
--- a/api/config/institutions_local.json
+++ b/api/config/institutions_local.json
@@ -6,13 +6,11 @@
 		{
 			"accessTierShortName": "registered",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["vumc.org"]
 		},
 		{
 			"accessTierShortName": "controlled",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["vumc.org"]
 		}
 	]
@@ -24,13 +22,11 @@
 		{
 			"accessTierShortName": "registered",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["broadinstitute.org"]
 		},
 		{
 			"accessTierShortName": "controlled",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["broadinstitute.org"]
 		}
 	]
@@ -42,13 +38,11 @@
 		{
 			"accessTierShortName": "registered",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["verily.com", "google.com"]
 		},
 		{
 			"accessTierShortName": "controlled",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["verily.com", "google.com"]
 		}
 	]
@@ -62,13 +56,11 @@
 		{
 			"accessTierShortName": "registered",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["fake-research-aou.org"]
 		},
 		{
 			"accessTierShortName": "controlled",
 			"membershipRequirement": "DOMAINS",
-			"eraRequired": true,
 			"emailDomains": ["fake-research-aou.org"]
 		}
 	]

--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -146,18 +146,10 @@ public class AccessSyncServiceImpl implements AccessSyncService {
     boolean allStandardRequiredModulesCompliant =
         requiredModules.stream()
             .allMatch(moduleName -> accessModuleService.isModuleCompliant(user, moduleName));
-    boolean eraCompliant =
-        accessModuleService.isModuleCompliant(user, DbAccessModuleName.ERA_COMMONS);
 
-    boolean eRARequiredForTier = true;
     boolean institutionalEmailValidForTier = false;
     Optional<Institution> institution = institutionService.getByUser(user);
     if (institution.isPresent()) {
-      // eRA is required when login.gov linking is not enabled or user institution requires that in
-      // tier requirement.
-      eRARequiredForTier =
-          !workbenchConfigProvider.get().access.enableRasLoginGovLinking
-              || institutionService.eRaRequiredForTier(institution.get(), tierShortName);
       institutionalEmailValidForTier =
           institutionService.validateInstitutionalEmail(
               institution.get(), user.getContactEmail(), tierShortName);
@@ -165,7 +157,6 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       log.warning(String.format("Institution not found for user %s", user.getUsername()));
     }
     return !user.getDisabled()
-        && (!eRARequiredForTier || eraCompliant)
         && institutionalEmailValidForTier
         && allStandardRequiredModulesCompliant;
   }

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -326,27 +326,14 @@ public class ProfileController implements ProfileApiDelegate {
     final MailService mail = mailServiceProvider.get();
 
     try {
-      boolean showEraStepInRT =
-          eraRequiredForTier(userInstitution, AccessTierService.REGISTERED_TIER_SHORT_NAME);
-
-      boolean showEraStepInCT =
-          !showEraStepInRT
-              && eraRequiredForTier(userInstitution, AccessTierService.CONTROLLED_TIER_SHORT_NAME);
-
       mail.sendWelcomeEmail(
           user,
           googleUser.getPassword(),
-          userInstitution.getDisplayName(),
-          showEraStepInRT,
-          showEraStepInCT);
+          userInstitution.getDisplayName());
 
     } catch (MessagingException e) {
       throw new WorkbenchException(e);
     }
-  }
-
-  private boolean eraRequiredForTier(Institution institution, String tierShortName) {
-    return institutionService.eRaRequiredForTier(institution, tierShortName);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/ProfileController.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.pmiops.workbench.absorb.ApiException;
-import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.auth.UserAuthentication;
@@ -326,10 +325,7 @@ public class ProfileController implements ProfileApiDelegate {
     final MailService mail = mailServiceProvider.get();
 
     try {
-      mail.sendWelcomeEmail(
-          user,
-          googleUser.getPassword(),
-          userInstitution.getDisplayName());
+      mail.sendWelcomeEmail(user, googleUser.getPassword(), userInstitution.getDisplayName());
 
     } catch (MessagingException e) {
       throw new WorkbenchException(e);

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -25,7 +25,6 @@ public class DbInstitutionTierRequirement {
   private long institutionTierRequirementId;
   private DbInstitution institution;
   private DbAccessTier accessTier;
-  private boolean eraRequired;
   private MembershipRequirement membershipRequirement;
 
   @Id
@@ -60,16 +59,6 @@ public class DbInstitutionTierRequirement {
 
   public DbInstitutionTierRequirement setAccessTier(DbAccessTier accessTier) {
     this.accessTier = accessTier;
-    return this;
-  }
-
-  @Column(name = "era_required")
-  public boolean getEraRequired() {
-    return eraRequired;
-  }
-
-  public DbInstitutionTierRequirement setEraRequired(boolean eraRequired) {
-    this.eraRequired = eraRequired;
     return this;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -81,6 +81,11 @@ public class DbInstitutionTierRequirement {
     return this;
   }
 
+  // remove when we remove the field from DB
+  @Column(name = "era_required")
+  public boolean getEraRequired() {
+    return eraRequired;
+  }
   /**
    * Omits ID field from equality so equivalent objects match regardless of whether they are
    * actually present in the DB.

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -26,6 +26,7 @@ public class DbInstitutionTierRequirement {
   private DbInstitution institution;
   private DbAccessTier accessTier;
   private MembershipRequirement membershipRequirement;
+  private boolean eraRequired; //remove when we remove the field from DB
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -74,6 +75,11 @@ public class DbInstitutionTierRequirement {
     return this;
   }
 
+  //remove when we remove the field from DB
+  public DbInstitutionTierRequirement setEraRequired(boolean eraRequired) {
+    this.eraRequired = false;
+    return this;
+  }
   /**
    * Omits ID field from equality so equivalent objects match regardless of whether they are
    * actually present in the DB.

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -86,6 +86,7 @@ public class DbInstitutionTierRequirement {
   public boolean getEraRequired() {
     return eraRequired;
   }
+
   /**
    * Omits ID field from equality so equivalent objects match regardless of whether they are
    * actually present in the DB.

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbInstitutionTierRequirement.java
@@ -26,7 +26,7 @@ public class DbInstitutionTierRequirement {
   private DbInstitution institution;
   private DbAccessTier accessTier;
   private MembershipRequirement membershipRequirement;
-  private boolean eraRequired; //remove when we remove the field from DB
+  private boolean eraRequired; // remove when we remove the field from DB
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -75,11 +75,12 @@ public class DbInstitutionTierRequirement {
     return this;
   }
 
-  //remove when we remove the field from DB
+  // remove when we remove the field from DB
   public DbInstitutionTierRequirement setEraRequired(boolean eraRequired) {
     this.eraRequired = false;
     return this;
   }
+
   /**
    * Omits ID field from equality so equivalent objects match regardless of whether they are
    * actually present in the DB.

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -122,6 +122,7 @@ public interface InstitutionService {
    * @return the list of {@link InstitutionTierConfig} for each tier.
    */
   List<InstitutionTierConfig> getTierConfigs(String institutionShortName);
+
   /**
    * Returns the access tiers that the user's institution allow the user to join.
    *

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -122,10 +122,6 @@ public interface InstitutionService {
    * @return the list of {@link InstitutionTierConfig} for each tier.
    */
   List<InstitutionTierConfig> getTierConfigs(String institutionShortName);
-
-  /** Returns {@code true} if eRA commons is required for given tier. */
-  boolean eRaRequiredForTier(Institution institution, String accessTierShortName);
-
   /**
    * Returns the access tiers that the user's institution allow the user to join.
    *

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -223,13 +223,6 @@ public class InstitutionServiceImpl implements InstitutionService {
   }
 
   @Override
-  public boolean eRaRequiredForTier(Institution institution, String accessTierShortName) {
-    Optional<InstitutionTierConfig> tierConfig =
-        getTierConfigByTier(institution, accessTierShortName);
-    return tierConfig.isPresent() && Boolean.TRUE.equals(tierConfig.get().isEraRequired());
-  }
-
-  @Override
   public boolean validateInstitutionalEmail(
       Institution institution, String contactEmail, String accessTierShortName) {
     try {
@@ -419,7 +412,6 @@ public class InstitutionServiceImpl implements InstitutionService {
                   userTierEligibilities.add(
                       new UserTierEligibility()
                           .accessTierShortName(tierName)
-                          .eraRequired(t.isEraRequired())
                           .eligible(
                               validateInstitutionalEmail(
                                   institution.get(), user.getContactEmail(), tierName))));

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionTierConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionTierConfigMapper.java
@@ -30,6 +30,7 @@ public interface InstitutionTierConfigMapper {
   @Mapping(target = "institution", ignore = true)
   @Mapping(target = "accessTier", ignore = true)
   @Mapping(target = "institutionTierRequirementId", ignore = true)
+  @Mapping(target = "eraRequired", ignore = true)
   DbInstitutionTierRequirement tierConfigToDbTierRequirement(
       InstitutionTierConfig source,
       @Context DbInstitution dbInstitution,

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionTierConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionTierConfigMapper.java
@@ -44,6 +44,7 @@ public interface InstitutionTierConfigMapper {
       @Context List<DbAccessTier> dbAccessTiers) {
     dbInstitutionTierRequirement
         .setInstitution(dbInstitution)
+        .setEraRequired(false)
         .setAccessTier(
             AccessUtils.getAccessTierByShortNameOrThrow(
                 dbAccessTiers, source.getAccessTierShortName()));

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -12,10 +12,7 @@ import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 
 public interface MailService {
 
-  void sendWelcomeEmail(
-      final DbUser user,
-      final String password,
-      final String institutionName)
+  void sendWelcomeEmail(final DbUser user, final String password, final String institutionName)
       throws MessagingException;
 
   void sendInstitutionUserInstructions(

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -15,9 +15,7 @@ public interface MailService {
   void sendWelcomeEmail(
       final DbUser user,
       final String password,
-      final String institutionName,
-      final Boolean showEraStepInRt,
-      final Boolean showEraStepInCt)
+      final String institutionName)
       throws MessagingException;
 
   void sendInstitutionUserInstructions(

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -146,15 +146,13 @@ public class MailServiceImpl implements MailService {
   public void sendWelcomeEmail(
       final DbUser user,
       final String password,
-      final String institutionName,
-      final Boolean showEraStepInRt,
-      final Boolean showEraStepInCt)
+      final String institutionName)
       throws MessagingException {
     final String htmlMessage =
         buildHtml(
             WELCOME_RESOURCE,
             welcomeMessageSubstitutionMap(
-                password, user.getUsername(), institutionName, showEraStepInRt, showEraStepInCt));
+                password, user.getUsername()));
 
     sendWithRetries(
         Collections.singletonList(user.getContactEmail()),
@@ -519,10 +517,7 @@ public class MailServiceImpl implements MailService {
 
   private Map<EmailSubstitutionField, String> welcomeMessageSubstitutionMap(
       final String password,
-      final String username,
-      final String institutionName,
-      final Boolean showEraStepInRT,
-      final Boolean showEraStepInCT) {
+      final String username) {
     final CloudStorageClient cloudStorageClient = cloudStorageClientProvider.get();
     return new ImmutableMap.Builder<EmailSubstitutionField, String>()
         .put(EmailSubstitutionField.USERNAME, username)
@@ -534,8 +529,6 @@ public class MailServiceImpl implements MailService {
         .put(EmailSubstitutionField.BULLET_1, cloudStorageClient.getImageUrl("bullet_1.png"))
         .put(EmailSubstitutionField.BULLET_2, cloudStorageClient.getImageUrl("bullet_2.png"))
         .put(EmailSubstitutionField.BULLET_3, cloudStorageClient.getImageUrl("bullet_3.png"))
-        .put(EmailSubstitutionField.RT_STEPS, getRTSteps(showEraStepInRT))
-        .put(EmailSubstitutionField.CT_STEPS, getCTSteps(showEraStepInCT, institutionName))
         .build();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -144,15 +144,10 @@ public class MailServiceImpl implements MailService {
 
   @Override
   public void sendWelcomeEmail(
-      final DbUser user,
-      final String password,
-      final String institutionName)
+      final DbUser user, final String password, final String institutionName)
       throws MessagingException {
     final String htmlMessage =
-        buildHtml(
-            WELCOME_RESOURCE,
-            welcomeMessageSubstitutionMap(
-                password, user.getUsername()));
+        buildHtml(WELCOME_RESOURCE, welcomeMessageSubstitutionMap(password, user.getUsername()));
 
     sendWithRetries(
         Collections.singletonList(user.getContactEmail()),
@@ -516,8 +511,7 @@ public class MailServiceImpl implements MailService {
   }
 
   private Map<EmailSubstitutionField, String> welcomeMessageSubstitutionMap(
-      final String password,
-      final String username) {
+      final String password, final String username) {
     final CloudStorageClient cloudStorageClient = cloudStorageClientProvider.get();
     return new ImmutableMap.Builder<EmailSubstitutionField, String>()
         .put(EmailSubstitutionField.USERNAME, username)

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9911,10 +9911,6 @@ components:
           description: The short unique name for the access tier.
         membershipRequirement:
           $ref: '#/components/schemas/InstitutionMembershipRequirement'
-        eraRequired:
-          type: boolean
-          description: Whether eRA commons is required for members in the institution
-            for this tier.
         emailDomains:
           type: array
           items:
@@ -12905,9 +12901,6 @@ components:
             User eligibility for tiers is based on their contact emails and their institution's tier
             requirements. This does not mean the user has access to these tiers; to gain
             access, the user must still complete all the necessary access requirement steps for each tier.
-        eraRequired:
-          type: boolean
-          description: If eRA Commons linking is required for this access tier.
     DemographicSurveyV2:
       type: object
       properties:

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1016,7 +1016,8 @@ public class UserServiceAccessTest {
 
     updateInstitutionTier(ctTierConfig);
 
-    accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.CT_COMPLIANCE_TRAINING, false);
+    accessModuleService.updateBypassTime(
+        dbUser.getUserId(), DbAccessModuleName.CT_COMPLIANCE_TRAINING, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -274,18 +274,6 @@ public class UserServiceAccessTest {
         });
   }
 
-  // ERA Commons is not subject to annual renewal.
-
-  @Test
-  public void test_updateUserWithRetries_era_unbypassed_noncompliant() {
-    testUnregistration(
-        user -> {
-          accessModuleService.updateBypassTime(
-              dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
-          return userDao.save(user);
-        });
-  }
-
   // Two Factor Auth (2FA) is not subject to annual renewal.
 
   @Test
@@ -936,25 +924,6 @@ public class UserServiceAccessTest {
   }
 
   @Test
-  public void testInstitutionRequirement_loginGovFlagDisabled() {
-    // User not complete eRA, but it is optional for that institution
-    assertThat(userAccessTierDao.findAll()).isEmpty();
-    providedWorkbenchConfig.access.enableEraCommons = true;
-    providedWorkbenchConfig.access.enableRasLoginGovLinking = true;
-    updateUserWithRetries(this::registerUser);
-    institutionService.updateInstitution(institution.getShortName(), institution);
-    accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
-    accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
-    dbUser = updateUserAccessTiers();
-    assertRegisteredTierEnabled(dbUser);
-
-    // Now login.gov flag disabled, eRA is always required.
-    providedWorkbenchConfig.access.enableRasLoginGovLinking = false;
-    dbUser = updateUserAccessTiers();
-    assertRegisteredTierDisabled(dbUser);
-  }
-
-  @Test
   public void testInstitutionRequirement_optionalEra_loginGovFlagEnabled_eRAFlagDisabled() {
     // When eRA flag is disabled, that means user completed eRA Commons
     assertThat(userAccessTierDao.findAll()).isEmpty();
@@ -1047,7 +1016,7 @@ public class UserServiceAccessTest {
 
     updateInstitutionTier(ctTierConfig);
 
-    accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
+    accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.CT_COMPLIANCE_TRAINING, false);
     dbUser = updateUserAccessTiers();
 
     assertRegisteredTierEnabled(dbUser);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1043,8 +1043,6 @@ public class UserServiceAccessTest {
 
     dbUser = completeRTAndCTRequirements(dbUser);
 
-    // Setting eraRequired to false for RT just so user can still have access to RT even after NOT
-    // bypassing era
     updateInstitutionTier(rtTierConfig);
 
     updateInstitutionTier(ctTierConfig);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -942,9 +942,7 @@ public class UserServiceAccessTest {
     providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.access.enableRasLoginGovLinking = true;
     updateUserWithRetries(this::registerUser);
-    institutionService.updateInstitution(
-        institution.getShortName(),
-        institution);
+    institutionService.updateInstitution(institution.getShortName(), institution);
     accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();
@@ -963,9 +961,7 @@ public class UserServiceAccessTest {
     updateUserWithRetries(this::registerUser);
     providedWorkbenchConfig.access.enableEraCommons = false;
     providedWorkbenchConfig.access.enableRasLoginGovLinking = false;
-    institutionService.updateInstitution(
-        institution.getShortName(),
-        institution);
+    institutionService.updateInstitution(institution.getShortName(), institution);
     accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
     accessModuleService.updateCompletionTime(dbUser, DbAccessModuleName.ERA_COMMONS, null);
     dbUser = updateUserAccessTiers();

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -265,12 +265,10 @@ public class ProfileControllerTest extends BaseControllerTest {
     rtAddressesConfig =
         new InstitutionTierConfig()
             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-            .eraRequired(false)
             .accessTierShortName(registeredTier.getShortName());
     rtDomainsConfig =
         new InstitutionTierConfig()
             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-            .eraRequired(false)
             .accessTierShortName(registeredTier.getShortName());
 
     Profile profile = new Profile();
@@ -1003,7 +1001,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     when(mockDirectoryService.resetUserPassword(anyString())).thenReturn(googleUser);
     doThrow(new MessagingException("exception"))
         .when(mockMailService)
-        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any());
 
     ResponseEntity<Void> response =
         profileController.resendWelcomeEmail(
@@ -1011,7 +1009,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     // called twice, once during account creation, once on resend
     verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 
@@ -1021,7 +1019,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     when(mockDirectoryService.resetUserPassword(anyString())).thenReturn(googleUser);
     doNothing()
         .when(mockMailService)
-        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any());
 
     ResponseEntity<Void> response =
         profileController.resendWelcomeEmail(
@@ -1029,7 +1027,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     // called twice, once during account creation, once on resend
     verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any(), anyBoolean(), anyBoolean());
+        .sendWelcomeEmail(any(), any(), any());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 
@@ -1037,7 +1035,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void sendUserInstructions_none() throws MessagingException {
     // default Institution in this test class has no instructions
     createAccountAndDbUserWithAffiliation();
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any());
 
     // don't send the user instructions email if there are no instructions
     verifyNoMoreInteractions(mockMailService);
@@ -1056,7 +1054,7 @@ public class ProfileControllerTest extends BaseControllerTest {
     institutionService.setInstitutionUserInstructions(instructions);
 
     createAccountAndDbUserWithAffiliation(verifiedInstitutionalAffiliation);
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any());
     verify(mockMailService)
         .sendInstitutionUserInstructions(
             CONTACT_EMAIL, instructions.getInstructions(), FULL_USER_NAME);
@@ -1077,7 +1075,7 @@ public class ProfileControllerTest extends BaseControllerTest {
         verifiedInstitutionalAffiliation.getInstitutionShortName());
 
     createAccountAndDbUserWithAffiliation(verifiedInstitutionalAffiliation);
-    verify(mockMailService).sendWelcomeEmail(any(), any(), any(), any(), any());
+    verify(mockMailService).sendWelcomeEmail(any(), any(), any());
 
     // don't send the user instructions email if the instructions have been deleted
     verifyNoMoreInteractions(mockMailService);

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.api;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1008,8 +1007,7 @@ public class ProfileControllerTest extends BaseControllerTest {
             new ResendWelcomeEmailRequest().username(dbUser.getUsername()).creationNonce(NONCE));
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     // called twice, once during account creation, once on resend
-    verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any());
+    verify(mockMailService, times(2)).sendWelcomeEmail(any(), any(), any());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 
@@ -1017,17 +1015,14 @@ public class ProfileControllerTest extends BaseControllerTest {
   public void resendWelcomeEmail_OK() throws MessagingException {
     createAccountAndDbUserWithAffiliation();
     when(mockDirectoryService.resetUserPassword(anyString())).thenReturn(googleUser);
-    doNothing()
-        .when(mockMailService)
-        .sendWelcomeEmail(any(), any(), any());
+    doNothing().when(mockMailService).sendWelcomeEmail(any(), any(), any());
 
     ResponseEntity<Void> response =
         profileController.resendWelcomeEmail(
             new ResendWelcomeEmailRequest().username(dbUser.getUsername()).creationNonce(NONCE));
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     // called twice, once during account creation, once on resend
-    verify(mockMailService, times(2))
-        .sendWelcomeEmail(any(), any(), any());
+    verify(mockMailService, times(2)).sendWelcomeEmail(any(), any(), any());
     verify(mockDirectoryService, times(1)).resetUserPassword(anyString());
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InstitutionTierRequirementDaoTest.java
@@ -53,15 +53,13 @@ public class InstitutionTierRequirementDaoTest {
             new DbInstitutionTierRequirement()
                 .setAccessTier(registeredTier)
                 .setInstitution(testInst)
-                .setMembershipRequirement(MembershipRequirement.DOMAINS)
-                .setEraRequired(true));
+                .setMembershipRequirement(MembershipRequirement.DOMAINS));
     final DbInstitutionTierRequirement ctRequirement =
         institutionTierRequirementDao.save(
             new DbInstitutionTierRequirement()
                 .setAccessTier(controlledTier)
                 .setInstitution(testInst)
-                .setMembershipRequirement(MembershipRequirement.ADDRESSES)
-                .setEraRequired(true));
+                .setMembershipRequirement(MembershipRequirement.ADDRESSES));
 
     assertThat(institutionTierRequirementDao.getByInstitution(testInst))
         .containsExactly(rtRequirement, ctRequirement);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -151,8 +151,6 @@ public class UserServiceTest {
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();
     when(mockInstitutionService.getByUser(user)).thenReturn(Optional.of(institution));
-    when(mockInstitutionService.eRaRequiredForTier(institution, REGISTERED_TIER_SHORT_NAME))
-        .thenReturn(false);
     when(mockInstitutionService.validateInstitutionalEmail(
             institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME))
         .thenReturn(true);

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -860,13 +860,11 @@ public class ReportingQueryServiceTest {
         new DbInstitutionTierRequirement()
             .setAccessTier(registeredTier)
             .setInstitution(institution)
-            .setMembershipRequirement(MembershipRequirement.ADDRESSES)
-            .setEraRequired(true));
+            .setMembershipRequirement(MembershipRequirement.ADDRESSES));
     institutionTierRequirementDao.save(
         new DbInstitutionTierRequirement()
             .setAccessTier(controlledTier)
             .setInstitution(institution)
-            .setMembershipRequirement(MembershipRequirement.DOMAINS)
-            .setEraRequired(false));
+            .setMembershipRequirement(MembershipRequirement.DOMAINS));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionMapperTest.java
@@ -41,7 +41,6 @@ public class InstitutionMapperTest {
             new InstitutionTierConfig()
                 .accessTierShortName(TIER_NAME)
                 .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                .eraRequired(true)
                 .emailDomains(sortedModelDomains)
                 .emailAddresses(sortedModelAddresses));
   }

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionServiceTest.java
@@ -115,7 +115,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY)
             .bypassInitialCreditsExpiration(true);
@@ -136,7 +135,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName("non exist tier"))
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
@@ -152,7 +150,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-                    .eraRequired(false)
                     .accessTierShortName("non exist tier"))
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
@@ -167,7 +164,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY);
 
@@ -288,7 +284,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName())
                     .emailDomains(ImmutableList.of("broad.org", "google.com"))
                     .emailAddresses(ImmutableList.of("joel@broad.org", "joel@google.com")))
@@ -305,7 +300,6 @@ public class InstitutionServiceTest {
                 ImmutableList.of(
                     rtTierConfig
                         .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                        .eraRequired(false)
                         .accessTierShortName(registeredTier.getShortName())
                         .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                         .emailAddresses(ImmutableList.of("joel@broad.org", "joel@verily.com"))))
@@ -320,7 +314,6 @@ public class InstitutionServiceTest {
             ImmutableList.of(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName())
                     .emailAddresses(ImmutableList.of())));
     final Institution instWithoutEmailsRoundTrip =
@@ -337,7 +330,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY)
             .bypassInitialCreditsExpiration(true);
@@ -348,7 +340,6 @@ public class InstitutionServiceTest {
             ImmutableList.of(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName())));
     assertThat(
             service
@@ -375,7 +366,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName()))
             .organizationTypeEnum(OrganizationType.INDUSTRY)
             .bypassInitialCreditsExpiration(true);
@@ -386,7 +376,6 @@ public class InstitutionServiceTest {
             ImmutableList.of(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName())));
     assertThat(
             service
@@ -406,7 +395,6 @@ public class InstitutionServiceTest {
             .addTierConfigsItem(
                 rtTierConfig
                     .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(false)
                     .accessTierShortName(registeredTier.getShortName())
                     .emailDomains(ImmutableList.of("broad.org", "broad.org", "google.com"))
                     .emailAddresses(
@@ -442,7 +430,6 @@ public class InstitutionServiceTest {
                 ImmutableList.of(
                     rtTierConfig
                         .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                        .eraRequired(false)
                         .accessTierShortName(registeredTier.getShortName())
                         .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                         .emailAddresses(ImmutableList.of("joel@broad.org", "joel@verily.com"))))
@@ -523,7 +510,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                             .emailAddresses(
@@ -551,7 +537,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                             .emailAddresses(
@@ -579,7 +564,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                             .emailAddresses(
@@ -601,7 +585,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                             .emailAddresses(
@@ -635,7 +618,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com"))
                             .emailAddresses(
@@ -664,7 +646,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("BROAD.org", "verily.COM"))
                             .emailAddresses(
@@ -835,7 +816,6 @@ public class InstitutionServiceTest {
                       ImmutableList.of(
                           rtTierConfig
                               .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                              .eraRequired(false)
                               .accessTierShortName(registeredTier.getShortName())
                               .emailAddresses(
                                   ImmutableList.of(
@@ -857,7 +837,6 @@ public class InstitutionServiceTest {
                       ImmutableList.of(
                           rtTierConfig
                               .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                              .eraRequired(false)
                               .accessTierShortName(registeredTier.getShortName())))
                   .organizationTypeEnum(OrganizationType.OTHER);
           service.createInstitution(institution_withOtherOrganizationType);
@@ -873,7 +852,6 @@ public class InstitutionServiceTest {
                 ImmutableList.of(
                     rtTierConfig
                         .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                        .eraRequired(false)
                         .accessTierShortName(registeredTier.getShortName())))
             .organizationTypeEnum(OrganizationType.OTHER)
             .organizationTypeOtherText("Some text")
@@ -891,7 +869,6 @@ public class InstitutionServiceTest {
                 List.of(
                     rtTierConfig
                         .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                        .eraRequired(false)
                         .accessTierShortName(registeredTier.getShortName())))
             .organizationTypeEnum(OrganizationType.INDUSTRY)
             .userInstructions("Some user instructions")
@@ -906,51 +883,6 @@ public class InstitutionServiceTest {
             service.updateInstitution(
                 institutionWithUserInstructions.getShortName(), institutionNoUserInstruction))
         .hasValue(expectedUpdateInstitution);
-  }
-
-  @Test
-  public void testERARequired_tierRequirementNotExist() {
-    final Institution existingInst =
-        new Institution()
-            .shortName("existingInst")
-            .displayName("existingInst")
-            .organizationTypeEnum(OrganizationType.INDUSTRY);
-
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
-        .isEqualTo(false);
-  }
-
-  @Test
-  public void testERARequired_booleanIsNull() {
-    final Institution existingInst =
-        new Institution()
-            .shortName("existingInst")
-            .displayName("existingInst")
-            .addTierConfigsItem(
-                rtTierConfig
-                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .accessTierShortName(registeredTier.getShortName()))
-            .organizationTypeEnum(OrganizationType.INDUSTRY);
-
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
-        .isEqualTo(false);
-  }
-
-  @Test
-  public void testERARequired() {
-    final Institution existingInst =
-        new Institution()
-            .shortName("existingInst")
-            .displayName("existingInst")
-            .addTierConfigsItem(
-                rtTierConfig
-                    .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                    .eraRequired(true)
-                    .accessTierShortName(registeredTier.getShortName()))
-            .organizationTypeEnum(OrganizationType.INDUSTRY);
-
-    assertThat(service.eRaRequiredForTier(existingInst, REGISTERED_TIER_SHORT_NAME))
-        .isEqualTo(true);
   }
 
   @Test
@@ -971,7 +903,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com")))));
     final DbUser user = createUser("user@broad.org");
@@ -980,7 +911,6 @@ public class InstitutionServiceTest {
         .containsExactly(
             new UserTierEligibility()
                 .accessTierShortName(registeredTier.getShortName())
-                .eraRequired(false)
                 .eligible(true));
   }
 
@@ -996,12 +926,10 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com")),
                         ctTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(true)
                             .accessTierShortName(controlledTier.getShortName())
                             .emailAddresses(ImmutableList.of("user@broad.org")))));
     final DbUser user = createUser("user@broad.org");
@@ -1010,11 +938,9 @@ public class InstitutionServiceTest {
         .containsExactly(
             new UserTierEligibility()
                 .accessTierShortName(registeredTier.getShortName())
-                .eraRequired(false)
                 .eligible(true),
             new UserTierEligibility()
                 .accessTierShortName(controlledTier.getShortName())
-                .eraRequired(true)
                 .eligible(true));
   }
 
@@ -1030,12 +956,10 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com")),
                         ctTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(false)
                             .accessTierShortName(controlledTier.getShortName())
                             .emailAddresses(ImmutableList.of("user2@broad.org")))));
     final DbUser user = createUser("user@broad.org");
@@ -1044,11 +968,9 @@ public class InstitutionServiceTest {
         .containsExactly(
             new UserTierEligibility()
                 .accessTierShortName(registeredTier.getShortName())
-                .eraRequired(false)
                 .eligible(true),
             new UserTierEligibility()
                 .accessTierShortName(controlledTier.getShortName())
-                .eraRequired(false)
                 .eligible(false));
   }
 
@@ -1064,12 +986,10 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailDomains(ImmutableList.of("broad.org", "verily.com")),
                         ctTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName()))));
     final DbUser user = createUser("user@broad.org");
     createAffiliation(user, inst.getShortName());
@@ -1077,7 +997,6 @@ public class InstitutionServiceTest {
         .containsExactly(
             new UserTierEligibility()
                 .accessTierShortName(registeredTier.getShortName())
-                .eraRequired(false)
                 .eligible(true));
   }
 
@@ -1093,7 +1012,6 @@ public class InstitutionServiceTest {
                     ImmutableList.of(
                         rtTierConfig
                             .membershipRequirement(InstitutionMembershipRequirement.ADDRESSES)
-                            .eraRequired(false)
                             .accessTierShortName(registeredTier.getShortName())
                             .emailAddresses(ImmutableList.of("user@broad.org")))));
     final DbUser user = createUser("user2@broad.org");
@@ -1102,7 +1020,6 @@ public class InstitutionServiceTest {
         .containsExactly(
             new UserTierEligibility()
                 .accessTierShortName(registeredTier.getShortName())
-                .eraRequired(false)
                 .eligible(false));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/institution/InstitutionTierConfigMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/InstitutionTierConfigMapperTest.java
@@ -52,26 +52,22 @@ public class InstitutionTierConfigMapperTest {
     InstitutionTierConfig rtTierConfig =
         new InstitutionTierConfig()
             .accessTierShortName(RT_ACCESS_TIER_SHORT_NAME)
-            .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-            .eraRequired(true);
+            .membershipRequirement(InstitutionMembershipRequirement.DOMAINS);
     InstitutionTierConfig ctTierConfig =
         new InstitutionTierConfig()
             .accessTierShortName(CT_ACCESS_TIER_SHORT_NAME)
-            .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS)
-            .eraRequired(false);
+            .membershipRequirement(InstitutionMembershipRequirement.NO_ACCESS);
 
     final List<DbInstitutionTierRequirement> expectedResult =
         ImmutableList.of(
             new DbInstitutionTierRequirement()
                 .setAccessTier(RT_ACCESS_TIER)
                 .setInstitution(dbInst)
-                .setMembershipRequirement(MembershipRequirement.DOMAINS)
-                .setEraRequired(true),
+                .setMembershipRequirement(MembershipRequirement.DOMAINS),
             new DbInstitutionTierRequirement()
                 .setAccessTier(CT_ACCESS_TIER)
                 .setInstitution(dbInst)
-                .setMembershipRequirement(MembershipRequirement.NO_ACCESS)
-                .setEraRequired(false));
+                .setMembershipRequirement(MembershipRequirement.NO_ACCESS));
 
     assertThat(
             mapper.tierConfigsToDbTierRequirements(
@@ -198,14 +194,12 @@ public class InstitutionTierConfigMapperTest {
         new DbInstitutionTierRequirement()
             .setAccessTier(RT_ACCESS_TIER)
             .setInstitution(dbInst)
-            .setMembershipRequirement(MembershipRequirement.DOMAINS)
-            .setEraRequired(true);
+            .setMembershipRequirement(MembershipRequirement.DOMAINS);
 
     InstitutionTierConfig expectedTierConfig =
         new InstitutionTierConfig()
             .accessTierShortName(RT_ACCESS_TIER_SHORT_NAME)
             .membershipRequirement(InstitutionMembershipRequirement.DOMAINS)
-            .eraRequired(true)
             .emailAddresses(emailAddresses);
     assertThat(mapper.dbToTierConfigModel(tierRequirement, new TreeSet<>(emailAddresses), null))
         .isEqualTo(expectedTierConfig);

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
@@ -98,7 +98,7 @@ public class MailServiceImplTest {
     when(mockMandrillApi.send(any())).thenReturn(msgStatuses);
     assertThrows(
         MessagingException.class,
-        () -> mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME, true, true));
+        () -> mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME));
     verify(mockMandrillApi, times(1)).send(any());
   }
 
@@ -107,7 +107,7 @@ public class MailServiceImplTest {
     doThrow(ApiException.class).when(mockMandrillApi).send(any());
     assertThrows(
         MessagingException.class,
-        () -> mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME, true, true));
+        () -> mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME));
     verify(mockMandrillApi, times(3)).send(any());
   }
 
@@ -117,7 +117,7 @@ public class MailServiceImplTest {
     ServerErrorException exception =
         assertThrows(
             ServerErrorException.class,
-            () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME, true, true));
+            () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME));
     assertThat(exception.getMessage()).isEqualTo("Email: Nota valid email is invalid.");
   }
 
@@ -126,7 +126,7 @@ public class MailServiceImplTest {
     DbUser user = createDbUser().setContactEmail(INVALID_EMAIL);
     assertThrows(
         ServerErrorException.class,
-        () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME, true, false));
+        () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME));
   }
 
   @Test
@@ -134,24 +134,24 @@ public class MailServiceImplTest {
     DbUser user = createDbUser().setContactEmail(INVALID_EMAIL);
     assertThrows(
         ServerErrorException.class,
-        () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME, false, false));
+        () -> mailService.sendWelcomeEmail(user, PASSWORD, INSTITUTION_NAME));
   }
 
   @Test
   public void testSendWelcomeEmailRTAndCT() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME, true, true);
+    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 
   @Test
   public void testSendWelcomeEmailOnlyRT() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME, true, false);
+    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 
   @Test
   public void testSendWelcomeEmailNoRtAndCt() throws MessagingException, ApiException {
-    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME, false, false);
+    mailService.sendWelcomeEmail(createDbUser(), PASSWORD, INSTITUTION_NAME);
     verify(mockMandrillApi, times(1)).send(any(MandrillApiKeyAndMessage.class));
   }
 

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -66,12 +66,10 @@ describe('CTAvailableBannerMaybe', () => {
     const newTierEligibilities: UserTierEligibility[] = [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: false,
         eligible: true,
       },
       {
         accessTierShortName: AccessTierShortNames.Controlled,
-        eraRequired: false,
         eligible: true,
       },
     ];
@@ -113,7 +111,6 @@ describe('CTAvailableBannerMaybe', () => {
     const newTierEligibilities: UserTierEligibility[] = [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: false,
         eligible: true,
       },
     ];

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -942,49 +942,6 @@ describe('DataAccessRequirements', () => {
     expect(spyCompliance).toHaveBeenCalledTimes(0);
   });
 
-  it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
-    let { container } = component();
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeTruthy();
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    ({ container } = component());
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeFalsy();
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-          },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    ({ container } = component());
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeTruthy();
-  });
-
   it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
     let { container } = component();
 
@@ -1188,42 +1145,6 @@ describe('DataAccessRequirements', () => {
           AccessModule.CT_COMPLIANCE_TRAINING
         )
       ).toBeTruthy();
-    }
-  );
-
-  it(
-    'Should not display eraCommons module in CT card ' +
-      'when eraCommons is disabled via the environment config',
-    async () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableEraCommons: false },
-      });
-
-      let { container } = component();
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eligible: false,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eligible: true,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      ({ container } = component());
-
-      expect(
-        findModule(findControlledTierCard(container), AccessModule.ERA_COMMONS)
-      ).toBeFalsy();
     }
   );
 

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -875,12 +875,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: true,
           },
         ],
@@ -955,7 +953,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
           },
         ],
       },
@@ -967,18 +964,15 @@ describe('DataAccessRequirements', () => {
 
     expect(findModule(container, AccessModule.ERA_COMMONS)).toBeFalsy();
 
-    // Ignore eraRequired if the accessTier is Controlled
     profileStore.set({
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: false,
           },
         ],
       },
@@ -1000,7 +994,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
           },
         ],
       },
@@ -1027,7 +1020,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
           },
         ],
       },
@@ -1054,7 +1046,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1081,7 +1072,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1109,7 +1099,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1146,7 +1135,6 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: false,
             },
           ],
@@ -1178,12 +1166,10 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: true,
             },
             {
               accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: false,
               // User not eligible for CT i.e user email doesnt match
               // Institution's Controlled Tier email list
               eligible: false,
@@ -1221,12 +1207,10 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: false,
             },
             {
               accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
               eligible: true,
             },
           ],
@@ -1294,12 +1278,10 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: false,
             },
             {
               accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
               eligible: true,
             },
           ],
@@ -1328,12 +1310,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1358,7 +1338,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
         ],
@@ -1383,12 +1362,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1428,12 +1405,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1479,12 +1454,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1520,12 +1493,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -18,7 +18,6 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { profileApi, userAdminApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import { AccessTierShortNames } from 'app/utils/access-tiers';
 import {
   buildRasRedirectUrl,
   DARPageMode,
@@ -393,27 +392,6 @@ const selfBypass = async (
   reloadProfile();
 };
 
-const isEraCommonsModuleRequiredByInstitution = (
-  profile: Profile,
-  moduleNames: AccessModule
-): boolean => {
-  // Remove the eRA Commons module when the flag to enable RAS is set and the user's
-  // institution does not require eRA Commons for RT.
-
-  if (moduleNames !== AccessModule.ERA_COMMONS) {
-    return true;
-  }
-  const { enableRasLoginGovLinking } = serverConfigStore.get().config;
-  if (!enableRasLoginGovLinking) {
-    return true;
-  }
-
-  return fp.flow(
-    fp.filter({ accessTierShortName: AccessTierShortNames.Registered }),
-    fp.some('eraRequired')
-  )(profile.tierEligibilities);
-};
-
 // exported for test
 export const getEligibleModules = (
   modules: AccessModule[],
@@ -423,9 +401,6 @@ export const getEligibleModules = (
     fp.filter((module: AccessModule) => isEligibleModule(module, profile)),
     fp.map(getAccessModuleConfig),
     fp.filter((moduleConfig) => moduleConfig.isEnabledInEnvironment),
-    fp.filter((moduleConfig) =>
-      isEraCommonsModuleRequiredByInstitution(profile, moduleConfig.name)
-    ),
     fp.map((moduleConfig) => moduleConfig.name)
   )(modules);
 

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -95,7 +95,6 @@ export const defaultTierConfig = (
 ): InstitutionTierConfig => ({
   accessTierShortName: accessTier,
   membershipRequirement: InstitutionMembershipRequirement.NO_ACCESS,
-  eraRequired: false,
   emailAddresses: [],
   emailDomains: [],
 });

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -20,7 +20,6 @@ export const VUMC: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['vumc.org'],
     },
   ],
@@ -37,7 +36,6 @@ export const BROAD: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.ADDRESSES,
-      eraRequired: true,
       emailAddresses: [BROAD_ADDR_1, BROAD_ADDR_2],
     },
   ],
@@ -52,13 +50,11 @@ export const VERILY: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['verily.com', 'google.com'],
     },
     {
       accessTierShortName: 'controlled',
       membershipRequirement: InstitutionMembershipRequirement.ADDRESSES,
-      eraRequired: true,
       emailAddresses: ['foo@verily.com'],
     },
   ],
@@ -74,7 +70,6 @@ export const VERILY_WITHOUT_CT: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['verily.com', 'google.com'],
     },
   ],

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -66,11 +66,9 @@ export class ProfileStubVariables {
     tierEligibilities: [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: true,
       },
       {
         accessTierShortName: AccessTierShortNames.Controlled,
-        eraRequired: false,
       },
     ],
   };


### PR DESCRIPTION
1. Remove `eraRequired` from workbench api
2. Update UI to remove `eraRequired` as well

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
