### PR TITLE
[risk=low][RW-13700] Could not transition from DataProc to GCE when a PD existed

### DIFF
--- a/ui/src/app/utils/analysis-config.spec.tsx
+++ b/ui/src/app/utils/analysis-config.spec.tsx
@@ -979,6 +979,15 @@ describe(canUseExistingDisk.name, () => {
     ).toBeFalsy();
   });
 
+  it('returns true when the detachableType is missing (i.e. if it was previously DataProc)', () => {
+    const existingDisk = { ...stubDisk(), diskType: DiskType.STANDARD };
+    const { size } = existingDisk;
+    const detachableType = undefined;
+    expect(
+      canUseExistingDisk({ detachableType, size }, existingDisk)
+    ).toBeTruthy();
+  });
+
   it('returns false when existingDisk is undefined', () => {
     expect(
       canUseExistingDisk({ detachableType: DiskType.SSD, size: 5 }, undefined)

--- a/ui/src/app/utils/analysis-config.tsx
+++ b/ui/src/app/utils/analysis-config.tsx
@@ -103,16 +103,18 @@ export const fromAnalysisConfig = (analysisConfig: AnalysisConfig): Runtime => {
 
   return runtime;
 };
+
 export const canUseExistingDisk = (
   { detachableType, size }: Partial<DiskConfig>,
   existingDisk: Disk | null
 ) => {
   return (
     !!existingDisk &&
-    detachableType === existingDisk.diskType &&
+    (!detachableType || detachableType === existingDisk.diskType) &&
     size >= existingDisk.size
   );
 };
+
 export const maybeWithExistingDiskName = (
   c: Omit<DiskConfig, 'existingDiskName'>,
   existingDisk: Disk | null
@@ -122,6 +124,7 @@ export const maybeWithExistingDiskName = (
   }
   return { ...c, existingDiskName: null };
 };
+
 export const maybeWithPersistentDisk = (
   runtime: Runtime,
   persistentDisk: Disk | PersistentDiskRequest | null | undefined
@@ -140,6 +143,7 @@ export const maybeWithPersistentDisk = (
     },
   };
 };
+
 // TODO - this is way more complex than it needs to be, and likely has some errors
 export const withAnalysisConfigDefaults = (
   r: AnalysisConfig,
@@ -206,6 +210,7 @@ export const withAnalysisConfigDefaults = (
       r.autopauseThreshold ?? DEFAULT_AUTOPAUSE_THRESHOLD_MINUTES,
   };
 };
+
 export const toAnalysisConfig = (
   runtime: Runtime,
   existingDisk: Disk | null
@@ -227,6 +232,7 @@ export const toAnalysisConfig = (
       gpuConfig,
     };
   };
+
   const toGceWithPdConfig = () => {
     const {
       machineType,
@@ -250,6 +256,7 @@ export const toAnalysisConfig = (
       gpuConfig,
     };
   };
+
   const toDataprocConfig = () => {
     const { dataprocConfig, autopauseThreshold } = runtime;
     const { masterMachineType, masterDiskSize } = dataprocConfig;
@@ -268,6 +275,7 @@ export const toAnalysisConfig = (
       gpuConfig: null,
     };
   };
+
   const toEmptyConfig = () => ({
     computeType: null,
     machine: null,


### PR DESCRIPTION
We did not correctly apply the existing Persistent Disk information when transitioning from DataProc to "Standard VM" (GCE), so it incorrectly attempted to create a new PD.  This is not allowed since one already exists, and it fails with a 400 error.  However we did not display this information to users, so it appeared to be still creating, and would eventually time out.

To repro:
1. on Local/Test or Test, create a Standard VM (GCE) runtime in a CT workspace
2. once it is running, open the Jupyter panel and create a DataProc runtime instead.  This will involve deleting the GCE runtime.  Choose "keep the disk" when prompted.
3. once the DataProc runtime is running, open the workspace **on Test** and attempt to create a GCE runtime.  You should see in the Network tab that the runtime is failing with a 400 error: cannot create a disk when one already exists.
4. open the workspace **on Local-Test on this branch** and create a GCE runtime.  Observe that it succeeds, and the network tab has no 400s.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
