### PR TITLE
RW-12240 Remove eraRequired from UI

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -94,7 +94,7 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": true,
+    "enableEraCommons": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -94,7 +94,7 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": true,
+    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -94,7 +94,7 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": true,
+    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -95,7 +95,7 @@
   },
   "access": {
     "enableComplianceTraining": false,
-    "enableEraCommons": true,
+    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -94,7 +94,7 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": true,
+    "enableEraCommons": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -1548,7 +1548,7 @@ public class ProfileControllerTest extends BaseControllerTest {
 
     // this is now unbypassed
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.DATA_USER_CODE_OF_CONDUCT)).isNull();
-    // these 3 are now bypassed
+    // these 2 are now bypassed
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.COMPLIANCE_TRAINING)).isNotNull();
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.TWO_FACTOR_AUTH)).isNotNull();
 
@@ -1571,7 +1571,6 @@ public class ProfileControllerTest extends BaseControllerTest {
             any(),
             any());
 
-    // ERA and 2FA once in request 2
     verify(mockUserServiceAuditor)
         .fireAdministrativeBypassTime(
             eq(dbUser.getUserId()), eq(BypassTimeTargetProperty.TWO_FACTOR_AUTH), any(), any());

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -69,7 +69,6 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.CloudStorageClient;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -1122,25 +1122,6 @@ public class ProfileControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testSyncEraCommons() {
-    FirecloudNihStatus nihStatus = new FirecloudNihStatus();
-    String linkedUsername = "linked";
-    nihStatus.setLinkedNihUsername(linkedUsername);
-    nihStatus.setLinkExpireTime(TIMESTAMP.getTime());
-    when(mockFireCloudService.getNihStatus()).thenReturn(nihStatus);
-
-    createAccountAndDbUserWithAffiliation();
-
-    profileController.syncEraCommonsStatus();
-    final DbUser user = userDao.findUserByUsername(FULL_USER_NAME);
-    assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo(linkedUsername);
-    assertThat(user.getEraCommonsLinkExpireTime()).isNotNull();
-    assertThat(
-            getCompletionEpochMillis(profileController.getMe().getBody(), AccessModule.ERA_COMMONS))
-        .isNotNull();
-  }
-
-  @Test
   public void testDeleteProfile() {
     createAccountAndDbUserWithAffiliation();
 
@@ -1531,7 +1512,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     // user has no bypasses at test start
     assertThat(getBypassEpochMillis(original, AccessModule.DATA_USER_CODE_OF_CONDUCT)).isNull();
     assertThat(getBypassEpochMillis(original, AccessModule.COMPLIANCE_TRAINING)).isNull();
-    assertThat(getBypassEpochMillis(original, AccessModule.ERA_COMMONS)).isNull();
     assertThat(getBypassEpochMillis(original, AccessModule.TWO_FACTOR_AUTH)).isNull();
 
     final List<AccessBypassRequest> bypasses1 =
@@ -1552,7 +1532,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     // remains unbypassed because the flag was set to false
     assertThat(getBypassEpochMillis(retrieved1, AccessModule.COMPLIANCE_TRAINING)).isNull();
     // unchanged: unbypassed
-    assertThat(getBypassEpochMillis(retrieved1, AccessModule.ERA_COMMONS)).isNull();
     assertThat(getBypassEpochMillis(retrieved1, AccessModule.TWO_FACTOR_AUTH)).isNull();
 
     final List<AccessBypassRequest> bypasses2 =
@@ -1563,7 +1542,6 @@ public class ProfileControllerTest extends BaseControllerTest {
                 .bypassed(false),
             // bypass
             new AccessBypassRequest().moduleName(AccessModule.COMPLIANCE_TRAINING).bypassed(true),
-            new AccessBypassRequest().moduleName(AccessModule.ERA_COMMONS).bypassed(true),
             new AccessBypassRequest().moduleName(AccessModule.TWO_FACTOR_AUTH).bypassed(true));
 
     final AccountPropertyUpdate request2 = request1.accessBypassRequests(bypasses2);
@@ -1573,7 +1551,6 @@ public class ProfileControllerTest extends BaseControllerTest {
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.DATA_USER_CODE_OF_CONDUCT)).isNull();
     // these 3 are now bypassed
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.COMPLIANCE_TRAINING)).isNotNull();
-    assertThat(getBypassEpochMillis(retrieved2, AccessModule.ERA_COMMONS)).isNotNull();
     assertThat(getBypassEpochMillis(retrieved2, AccessModule.TWO_FACTOR_AUTH)).isNotNull();
 
     // TODO(RW-6930): Make Profile contain the new AccessModule block, then read from there.
@@ -1596,9 +1573,6 @@ public class ProfileControllerTest extends BaseControllerTest {
             any());
 
     // ERA and 2FA once in request 2
-    verify(mockUserServiceAuditor)
-        .fireAdministrativeBypassTime(
-            eq(dbUser.getUserId()), eq(BypassTimeTargetProperty.ERA_COMMONS), any(), any());
     verify(mockUserServiceAuditor)
         .fireAdministrativeBypassTime(
             eq(dbUser.getUserId()), eq(BypassTimeTargetProperty.TWO_FACTOR_AUTH), any(), any());

--- a/ui/src/app/components/ct-available-banner-maybe.spec.tsx
+++ b/ui/src/app/components/ct-available-banner-maybe.spec.tsx
@@ -66,12 +66,10 @@ describe('CTAvailableBannerMaybe', () => {
     const newTierEligibilities: UserTierEligibility[] = [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: false,
         eligible: true,
       },
       {
         accessTierShortName: AccessTierShortNames.Controlled,
-        eraRequired: false,
         eligible: true,
       },
     ];
@@ -113,7 +111,6 @@ describe('CTAvailableBannerMaybe', () => {
     const newTierEligibilities: UserTierEligibility[] = [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: false,
         eligible: true,
       },
     ];

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -420,7 +420,7 @@ describe('DataAccessRequirements', () => {
   });
 
   it(
-    'should return the second enabled module (ERA, not RAS) from getFocusedModule' +
+    'should return the second enabled module (COMPLIANCE_TRAINING, not RAS) from getFocusedModule' +
       ' when the first module (2FA) has been completed and RAS is disabled',
     () => {
       serverConfigStore.set({
@@ -453,7 +453,7 @@ describe('DataAccessRequirements', () => {
       );
 
       // update this if the order changes
-      expect(activeModule).toEqual(AccessModule.ERA_COMMONS);
+      expect(activeModule).toEqual(AccessModule.COMPLIANCE_TRAINING);
 
       // 2FA (module 0) is complete, so enabled #1 is active
       expect(activeModule).toEqual(enabledModules[1]);
@@ -472,7 +472,6 @@ describe('DataAccessRequirements', () => {
             moduleName: AccessModule.TWO_FACTOR_AUTH,
             completionEpochMillis: 1,
           },
-          { moduleName: AccessModule.ERA_COMMONS, completionEpochMillis: 1 },
           {
             moduleName: AccessModule.IDENTITY,
             completionEpochMillis: 1,
@@ -491,8 +490,8 @@ describe('DataAccessRequirements', () => {
       DARPageMode.INITIAL_REGISTRATION
     );
 
-    expect(activeModule).toEqual(initialRequiredModules[3]);
-    expect(activeModule).toEqual(enabledModules[3]);
+    expect(activeModule).toEqual(initialRequiredModules[2]);
+    expect(activeModule).toEqual(enabledModules[2]);
 
     // update this if the order changes
     expect(activeModule).toEqual(AccessModule.COMPLIANCE_TRAINING);
@@ -899,7 +898,6 @@ describe('DataAccessRequirements', () => {
   it('should sync incomplete external modules', async () => {
     // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
     const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
-    const spyERA = jest.spyOn(profileApi(), 'syncEraCommonsStatus');
     const spyCompliance = jest.spyOn(
       profileApi(),
       'syncComplianceTrainingStatus'
@@ -908,7 +906,6 @@ describe('DataAccessRequirements', () => {
     component();
 
     expect(spy2FA).toHaveBeenCalledTimes(1);
-    expect(spyERA).toHaveBeenCalledTimes(1);
     expect(spyCompliance).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -896,7 +896,7 @@ describe('DataAccessRequirements', () => {
   // regression tests for RW-7384: sync external modules to gain access
 
   it('should sync incomplete external modules', async () => {
-    // profile contains no completed modules, so we sync all (2FA, ERA, Compliance)
+    // profile contains no completed modules, so we sync all (2FA, Compliance)
     const spy2FA = jest.spyOn(profileApi(), 'syncTwoFactorAuthStatus');
     const spyCompliance = jest.spyOn(
       profileApi(),

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -875,12 +875,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: true,
           },
         ],
@@ -944,53 +942,6 @@ describe('DataAccessRequirements', () => {
     expect(spyCompliance).toHaveBeenCalledTimes(0);
   });
 
-  it('Should not show Era Commons Module for Registered Tier if the institution does not require eRa', async () => {
-    let { container } = component();
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeTruthy();
-
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    ({ container } = component());
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeFalsy();
-
-    // Ignore eraRequired if the accessTier is Controlled
-    profileStore.set({
-      profile: {
-        ...ProfileStubVariables.PROFILE_STUB,
-        tierEligibilities: [
-          {
-            accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
-          },
-          {
-            accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: false,
-          },
-        ],
-      },
-      load,
-      reload,
-      updateCache,
-    });
-    ({ container } = component());
-
-    expect(findModule(container, AccessModule.ERA_COMMONS)).toBeTruthy();
-  });
-
   it('Should display Institution has signed agreement when the user has a Tier Eligibility object for CT', async () => {
     let { container } = component();
 
@@ -1000,7 +951,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
           },
         ],
       },
@@ -1027,7 +977,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
           },
         ],
       },
@@ -1054,7 +1003,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1081,7 +1029,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1109,7 +1056,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1146,7 +1092,6 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: false,
             },
           ],
@@ -1178,12 +1123,10 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: true,
             },
             {
               accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: false,
               // User not eligible for CT i.e user email doesnt match
               // Institution's Controlled Tier email list
               eligible: false,
@@ -1202,44 +1145,6 @@ describe('DataAccessRequirements', () => {
           AccessModule.CT_COMPLIANCE_TRAINING
         )
       ).toBeTruthy();
-    }
-  );
-
-  it(
-    'Should not display eraCommons module in CT card ' +
-      'when eraCommons is disabled via the environment config',
-    async () => {
-      serverConfigStore.set({
-        config: { ...defaultServerConfig, enableEraCommons: false },
-      });
-
-      let { container } = component();
-
-      profileStore.set({
-        profile: {
-          ...ProfileStubVariables.PROFILE_STUB,
-          tierEligibilities: [
-            {
-              accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
-              eligible: false,
-            },
-            {
-              accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
-              eligible: true,
-            },
-          ],
-        },
-        load,
-        reload,
-        updateCache,
-      });
-      ({ container } = component());
-
-      expect(
-        findModule(findControlledTierCard(container), AccessModule.ERA_COMMONS)
-      ).toBeFalsy();
     }
   );
 
@@ -1294,12 +1199,10 @@ describe('DataAccessRequirements', () => {
           tierEligibilities: [
             {
               accessTierShortName: AccessTierShortNames.Registered,
-              eraRequired: false,
               eligible: false,
             },
             {
               accessTierShortName: AccessTierShortNames.Controlled,
-              eraRequired: true,
               eligible: true,
             },
           ],
@@ -1328,12 +1231,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: false,
           },
         ],
@@ -1358,7 +1259,6 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
         ],
@@ -1383,12 +1283,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1428,12 +1326,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1479,12 +1375,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],
@@ -1520,12 +1414,10 @@ describe('DataAccessRequirements', () => {
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
-            eraRequired: false,
             eligible: false,
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            eraRequired: true,
             eligible: true,
           },
         ],

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -18,7 +18,6 @@ import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { profileApi, userAdminApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
-import { AccessTierShortNames } from 'app/utils/access-tiers';
 import {
   buildRasRedirectUrl,
   DARPageMode,
@@ -393,27 +392,6 @@ const selfBypass = async (
   reloadProfile();
 };
 
-const isEraCommonsModuleRequiredByInstitution = (
-  profile: Profile,
-  moduleNames: AccessModule
-): boolean => {
-  // Remove the eRA Commons module when the flag to enable RAS is set and the user's
-  // institution does not require eRA Commons for RT.
-
-  if (moduleNames !== AccessModule.ERA_COMMONS) {
-    return true;
-  }
-  const { enableRasLoginGovLinking } = serverConfigStore.get().config;
-  if (!enableRasLoginGovLinking) {
-    return true;
-  }
-
-  return fp.flow(
-    fp.filter({ accessTierShortName: AccessTierShortNames.Registered }),
-    fp.some('eraRequired')
-  )(profile.tierEligibilities);
-};
-
 // exported for test
 export const getEligibleModules = (
   modules: AccessModule[],
@@ -423,9 +401,6 @@ export const getEligibleModules = (
     fp.filter((module: AccessModule) => isEligibleModule(module, profile)),
     fp.map(getAccessModuleConfig),
     fp.filter((moduleConfig) => moduleConfig.isEnabledInEnvironment),
-    fp.filter((moduleConfig) =>
-      isEraCommonsModuleRequiredByInstitution(profile, moduleConfig.name)
-    ),
     fp.map((moduleConfig) => moduleConfig.name)
   )(modules);
 

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -304,7 +304,6 @@ const RenewalRequirementsText = () => (
 export const initialRtModules = [
   AccessModule.TWO_FACTOR_AUTH,
   AccessModule.IDENTITY,
-  AccessModule.ERA_COMMONS,
   AccessModule.COMPLIANCE_TRAINING,
 ];
 export const renewalRtModules = [

--- a/ui/src/app/pages/admin/user/admin-user-bypass.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.spec.tsx
@@ -46,7 +46,6 @@ describe('AdminUserBypassSpec', () => {
         'rt-compliance-training-toggle',
         'ct-compliance-training-toggle',
         'ducc-toggle',
-        'era-commons-toggle',
         'two-factor-auth-toggle',
         'identity-toggle',
         'profile-confirmation-toggle',

--- a/ui/src/app/pages/admin/user/admin-user-bypass.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-bypass.spec.tsx
@@ -30,7 +30,7 @@ describe('AdminUserBypassSpec', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        enableEraCommons: true,
+        enableEraCommons: false,
         enableRasLoginGovLinking: true,
         enableComplianceTraining: true,
       },

--- a/ui/src/app/pages/admin/user/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-common.tsx
@@ -607,7 +607,6 @@ export const ErrorsTooltip = ({ errors, children }: ErrorsTooltipProps) => {
 // list the access modules in the desired order
 export const orderedAccessModules: Array<AccessModule> = [
   AccessModule.TWO_FACTOR_AUTH,
-  AccessModule.ERA_COMMONS,
   AccessModule.COMPLIANCE_TRAINING,
   AccessModule.CT_COMPLIANCE_TRAINING,
   AccessModule.DATA_USER_CODE_OF_CONDUCT,

--- a/ui/src/app/pages/admin/user/admin-user-profile.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.spec.tsx
@@ -550,14 +550,6 @@ describe('AdminUserProfile', () => {
       },
     ],
     [
-      AccessRenewalStatus.BYPASSED,
-      AccessModule.ERA_COMMONS,
-      {
-        moduleName: AccessModule.ERA_COMMONS,
-        bypassEpochMillis: 1,
-      },
-    ],
-    [
       AccessRenewalStatus.EXPIRING_SOON,
       AccessModule.PROFILE_CONFIRMATION,
       {

--- a/ui/src/app/pages/admin/user/admin-user-table.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-table.spec.tsx
@@ -31,7 +31,7 @@ describe('AdminUserTable', () => {
         gsuiteDomain: 'fake-research-aou.org',
         projectId: 'aaa',
         publicApiKeyForErrorReports: 'aaa',
-        enableEraCommons: true,
+        enableEraCommons: false,
       },
     });
     props = {

--- a/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
+++ b/ui/src/app/pages/data/cohort/modifier-page.spec.tsx
@@ -42,7 +42,7 @@ describe('ModifierPage', () => {
         gsuiteDomain: 'fake-research-aou.org',
         projectId: 'aaa',
         publicApiKeyForErrorReports: 'aaa',
-        enableEraCommons: true,
+        enableEraCommons: false,
       },
     });
     cdrVersionStore.set(cdrVersionTiersResponse);

--- a/ui/src/app/pages/homepage/homepage.spec.tsx
+++ b/ui/src/app/pages/homepage/homepage.spec.tsx
@@ -63,7 +63,7 @@ describe('HomepageComponent', () => {
         gsuiteDomain: 'fake-research-aou.org',
         projectId: 'aaa',
         publicApiKeyForErrorReports: 'aaa',
-        enableEraCommons: true,
+        enableEraCommons: false,
       },
     });
     cdrVersionStore.set(cdrVersionTiersResponse);

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -81,7 +81,7 @@ describe('WorkspaceAbout', () => {
         gsuiteDomain: 'fake-research-aou.org',
         projectId: 'aaa',
         publicApiKeyForErrorReports: 'aaa',
-        enableEraCommons: true,
+        enableEraCommons: false,
       },
     });
     cdrVersionStore.set(cdrVersionTiersResponse);

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -95,7 +95,6 @@ export const defaultTierConfig = (
 ): InstitutionTierConfig => ({
   accessTierShortName: accessTier,
   membershipRequirement: InstitutionMembershipRequirement.NO_ACCESS,
-  eraRequired: false,
   emailAddresses: [],
   emailDomains: [],
 });

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -62,7 +62,7 @@ const defaultServerConfig: ConfigResponse = {
   publicApiKeyForErrorReports: 'notasecret',
   shibbolethUiBaseUrl: 'https://broad-shibboleth-prod.appspot.com/',
   enableComplianceTraining: true,
-  enableEraCommons: true,
+  enableEraCommons: false,
   unsafeAllowSelfBypass: false,
   defaultFreeCreditsDollarLimit: 300,
   rasHost: 'https://stsstg.nih.gov/',

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -20,7 +20,6 @@ export const VUMC: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['vumc.org'],
     },
   ],
@@ -37,7 +36,6 @@ export const BROAD: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.ADDRESSES,
-      eraRequired: true,
       emailAddresses: [BROAD_ADDR_1, BROAD_ADDR_2],
     },
   ],
@@ -52,13 +50,11 @@ export const VERILY: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['verily.com', 'google.com'],
     },
     {
       accessTierShortName: 'controlled',
       membershipRequirement: InstitutionMembershipRequirement.ADDRESSES,
-      eraRequired: true,
       emailAddresses: ['foo@verily.com'],
     },
   ],
@@ -74,7 +70,6 @@ export const VERILY_WITHOUT_CT: Institution = {
     {
       accessTierShortName: 'registered',
       membershipRequirement: InstitutionMembershipRequirement.DOMAINS,
-      eraRequired: true,
       emailDomains: ['verily.com', 'google.com'],
     },
   ],

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -66,11 +66,9 @@ export class ProfileStubVariables {
     tierEligibilities: [
       {
         accessTierShortName: AccessTierShortNames.Registered,
-        eraRequired: true,
       },
       {
         accessTierShortName: AccessTierShortNames.Controlled,
-        eraRequired: false,
       },
     ],
   };


### PR DESCRIPTION
Remove `eraRequired` from UI
![Screenshot 2024-09-30 at 2 07 29 PM](https://github.com/user-attachments/assets/d8c29184-069e-49ac-93a9-3334161e89e3)


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
