### PR TITLE
[risk=low][no ticket] Remove unused getDisk/getPersistentDisk

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DisksController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DisksController.java
@@ -20,11 +20,6 @@ public class DisksController implements DisksApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Disk> getDisk(String workspaceNamespace, String diskName) {
-    return ResponseEntity.ok(diskService.getDisk(workspaceNamespace, diskName));
-  }
-
-  @Override
   public ResponseEntity<EmptyResponse> deleteDisk(String workspaceNamespace, String diskName) {
     diskService.deleteDisk(workspaceNamespace, diskName);
     return ResponseEntity.ok(new EmptyResponse());

--- a/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
@@ -7,7 +7,6 @@ import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.model.Disk;
-import org.pmiops.workbench.model.DiskStatus;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,20 +49,6 @@ public class DiskService {
     return responseList.stream()
         .map(leonardoMapper::toApiListDisksResponse)
         .collect(Collectors.toList());
-  }
-
-  public Disk getDisk(String workspaceNamespace, String diskName) {
-    String googleProject =
-        workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
-    Disk disk =
-        leonardoMapper.toApiGetDiskResponse(
-            leonardoNotebooksClient.getPersistentDisk(googleProject, diskName));
-
-    if (DiskStatus.FAILED.equals(disk.getStatus())) {
-      log.warning(
-          String.format("Observed failed PD %s in workspace %s", diskName, workspaceNamespace));
-    }
-    return disk;
   }
 
   public List<Disk> getOwnedDisksInWorkspace(String workspaceNamespace) {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListRuntimeResponse;
@@ -69,10 +68,6 @@ public interface LeonardoApiClient {
   /** Create a new data synchronization Welder storage link on a Gke APP. */
   StorageLink createStorageLinkForApp(
       String googleProject, String appName, StorageLink storageLink);
-
-  /** Gets information about a persistent disk */
-  LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
-      throws WorkbenchException;
 
   /** Deletes a persistent disk */
   void deletePersistentDisk(String googleProject, String diskName) throws WorkbenchException;

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -40,7 +40,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoAppType;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateAppRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoCreateRuntimeRequest;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
@@ -475,18 +474,6 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     ProxyApi proxyApi = proxyApiProvider.get();
     return notebooksRetryHandler.run(
         (context) -> proxyApi.welderCreateStorageLink(storageLink, googleProject, runtime));
-  }
-
-  @Override
-  public LeonardoGetPersistentDiskResponse getPersistentDisk(String googleProject, String diskName)
-      throws WorkbenchException {
-    DisksApi disksApi = disksApiProvider.get();
-    try {
-      return leonardoRetryHandler.runAndThrowChecked(
-          (context) -> disksApi.getDisk(googleProject, diskName));
-    } catch (ApiException e) {
-      throw ExceptionUtils.convertLeonardoException(e);
-    }
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -114,13 +114,6 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "gceRuntime", ignore = true)
-  Disk toApiGetDiskResponse(LeonardoGetPersistentDiskResponse disk);
-
-  @Mapping(target = "creator", source = "auditInfo.creator")
-  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
-  @Mapping(target = "appType", ignore = true)
-  @Mapping(target = "gceRuntime", ignore = true)
   Disk toApiListDisksResponse(LeonardoListPersistentDiskResponse disk);
 
   @AfterMapping

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -26,7 +26,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoGceConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGceWithPdConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
@@ -115,12 +114,6 @@ public interface LeonardoMapper {
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "gceRuntime", ignore = true)
   Disk toApiListDisksResponse(LeonardoListPersistentDiskResponse disk);
-
-  @AfterMapping
-  default void getDiskAfterMapper(
-      @MappingTarget Disk disk, LeonardoGetPersistentDiskResponse leoGetDiskResponse) {
-    setDiskEnvironmentType(disk, leoGetDiskResponse.getLabels());
-  }
 
   @AfterMapping
   default void listDisksAfterMapper(

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -1149,37 +1149,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /v1/workspaces/{workspaceNamespace}/disks/{diskName}:
-    get:
-      tags:
-      - disks
-      summary: Get the user's workspace persistent disk by name.
-      operationId: getDisk
-      parameters:
-      - name: workspaceNamespace
-        in: path
-        description: The Workspace namespace
-        required: true
-        schema:
-          type: string
-      - name: diskName
-        in: path
-        description: diskName
-        required: true
-        schema:
-          type: string
-      responses:
-        200:
-          description: The persistent disk for this user and workspace.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Disk'
-        404:
-          description: No persistent disk exists for this user and workspace.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
     delete:
       tags:
       - disks

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -26,18 +26,12 @@ import org.pmiops.workbench.disks.DiskService;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiHelper;
-import org.pmiops.workbench.leonardo.model.LeonardoAuditInfo;
-import org.pmiops.workbench.leonardo.model.LeonardoCloudContext;
-import org.pmiops.workbench.leonardo.model.LeonardoCloudProvider;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
-import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoUpdateDiskRequest;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.DiskStatus;
-import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.utils.mappers.LeonardoMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -107,69 +101,6 @@ public class DisksControllerTest {
             .setName(WORKSPACE_NAME)
             .setFirecloudName(WORKSPACE_ID);
     doReturn(testWorkspace).when(mockWorkspaceService).lookupWorkspaceByNamespace((WORKSPACE_NS));
-  }
-
-  @Test
-  public void test_getDisk() {
-    String createDate = "2021-08-06T16:57:29.827954Z";
-    String pdName = "pdName";
-    LeonardoGetPersistentDiskResponse getResponse =
-        new LeonardoGetPersistentDiskResponse()
-            .name(pdName)
-            .size(300)
-            .diskType(LeonardoDiskType.STANDARD)
-            .status(LeonardoDiskStatus.READY)
-            .auditInfo(new LeonardoAuditInfo().createdDate(createDate).creator(user.getUsername()))
-            .cloudContext(
-                new LeonardoCloudContext()
-                    .cloudProvider(LeonardoCloudProvider.GCP)
-                    .cloudResource(GOOGLE_PROJECT_ID));
-
-    Disk disk =
-        new Disk()
-            .name(pdName)
-            .size(300)
-            .diskType(DiskType.STANDARD)
-            .status(DiskStatus.READY)
-            .createdDate(createDate)
-            .creator(user.getUsername())
-            .gceRuntime(true);
-
-    when(mockLeonardoApiClient.getPersistentDisk(GOOGLE_PROJECT_ID, pdName))
-        .thenReturn(getResponse);
-    assertThat(disksController.getDisk(WORKSPACE_NS, pdName).getBody()).isEqualTo(disk);
-  }
-
-  @Test
-  public void test_getDisk_nullProject() {
-    String createDate = "2021-08-06T16:57:29.827954Z";
-    String pdName = "pdName";
-    LeonardoGetPersistentDiskResponse getResponse =
-        new LeonardoGetPersistentDiskResponse()
-            .name(pdName)
-            .size(300)
-            .diskType(LeonardoDiskType.STANDARD)
-            .status(LeonardoDiskStatus.READY)
-            .auditInfo(new LeonardoAuditInfo().createdDate(createDate).creator(user.getUsername()))
-            .cloudContext(
-                new LeonardoCloudContext()
-                    .cloudProvider(LeonardoCloudProvider.GCP)
-                    .cloudResource(GOOGLE_PROJECT_ID));
-
-    when(mockLeonardoApiClient.getPersistentDisk(GOOGLE_PROJECT_ID, pdName))
-        .thenReturn(getResponse);
-
-    when(mockWorkspaceService.lookupWorkspaceByNamespace(null)).thenThrow(new NotFoundException());
-
-    assertThrows(NotFoundException.class, () -> disksController.getDisk(null, pdName));
-  }
-
-  @Test
-  public void test_getDisk_nullDisk() {
-    when(mockLeonardoApiClient.getPersistentDisk(GOOGLE_PROJECT_ID, null))
-        .thenThrow(new NotFoundException());
-
-    assertThrows(NotFoundException.class, () -> disksController.getDisk(WORKSPACE_NS, null));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -23,7 +23,6 @@ import org.pmiops.workbench.leonardo.model.LeonardoCloudProvider;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskStatus;
 import org.pmiops.workbench.leonardo.model.LeonardoDiskType;
 import org.pmiops.workbench.leonardo.model.LeonardoGetAppResponse;
-import org.pmiops.workbench.leonardo.model.LeonardoGetPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesError;
 import org.pmiops.workbench.leonardo.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.leonardo.model.LeonardoListAppResponse;
@@ -223,31 +222,6 @@ public class LeonardoMapperTest {
     Map<String, String> rstudioLabel = new HashMap<>();
     rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
     assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse.labels(rstudioLabel)))
-        .isEqualTo(disk.appType(AppType.RSTUDIO).gceRuntime(false));
-  }
-
-  @Test
-  public void testToApiDiskFromGetDiskResponse() {
-    LeonardoGetPersistentDiskResponse getPersistentDiskResponse =
-        new LeonardoGetPersistentDiskResponse()
-            .diskType(LeonardoDiskType.SSD)
-            .auditInfo(leonardoAuditInfo)
-            .status(LeonardoDiskStatus.READY);
-
-    Disk disk =
-        new Disk()
-            .diskType(DiskType.SSD)
-            .gceRuntime(true)
-            .creator(leonardoAuditInfo.getCreator())
-            .dateAccessed(leonardoAuditInfo.getDateAccessed())
-            .createdDate(leonardoAuditInfo.getCreatedDate())
-            .status(DiskStatus.READY);
-    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse)).isEqualTo(disk);
-
-    // RSTUDIO
-    Map<String, String> rstudioLabel = new HashMap<>();
-    rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
-    assertThat(mapper.toApiGetDiskResponse(getPersistentDiskResponse.labels(rstudioLabel)))
         .isEqualTo(disk.appType(AppType.RSTUDIO).gceRuntime(false));
   }
 }


### PR DESCRIPTION
The UI only calls the list-all-disks-in-workspace endpoint.  We're not using this one.

Tested locally by interacting with disks

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
