### PR TITLE
[RW-9601][risk=no] Add zone to Disk object so that it will be read over from Leo.

### DIFF
--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7162,6 +7162,7 @@ components:
       - diskType
       - name
       - size
+      - zone
       type: object
       properties:
         name:
@@ -7194,6 +7195,10 @@ components:
           type: string
           description: timestamp for the date this runtime was last accessed in ISO
             8601 format. This is null if it has not been deleted yet.
+        zone:
+          type: string
+          description: >
+            The GCP zone of the GCE VM. For example, us-east1-a or europe-west2-c.
       description: The configuration of a persistent disk, returned in disk responses
     WorkspaceListResponse:
       required:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7197,8 +7197,7 @@ components:
             8601 format. This is null if it has not been deleted yet.
         zone:
           type: string
-          description: >
-            The GCP zone of the GCE VM. For example, us-east1-a or europe-west2-c.
+          description: The GCP zone of the GCE VM. For example, us-east1-a or europe-west2-c.
       description: The configuration of a persistent disk, returned in disk responses
     WorkspaceListResponse:
       required:

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -223,6 +223,7 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       blockSize: 1000,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+      zone: 'us-central1-a',
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,
@@ -259,6 +260,7 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       blockSize: 1000,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+      zone: 'us-central1-a',
     };
     await component({
       existingDisk,
@@ -298,6 +300,7 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       blockSize: 1000,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+      zone: 'us-central1-a',
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -663,6 +663,7 @@ describe(RuntimeConfigurationPanel.name, () => {
       name: 'my-existing-disk',
       blockSize: 1,
       gceRuntime: true,
+      zone: 'us-central1-a',
     };
   };
 

--- a/ui/src/app/utils/analysis-config.spec.tsx
+++ b/ui/src/app/utils/analysis-config.spec.tsx
@@ -117,6 +117,7 @@ const defaultAnalysisConfig: AnalysisConfig = {
     diskType: defaultDiskType,
     gceRuntime: true,
     blockSize: 1,
+    zone: 'us-central1-a',
   },
   dataprocConfig,
   autopauseThreshold: 100,
@@ -432,6 +433,7 @@ describe(toAnalysisConfig.name, () => {
       size: persistentDisk.size - 1, // equal or smaller will match
       name: 'my favorite disk',
       blockSize: undefined, // not important here, but required
+      zone: 'us-central1-a',
     };
 
     const expectedDiskConfig = {
@@ -468,6 +470,7 @@ describe(toAnalysisConfig.name, () => {
       size: persistentDisk.size + 1, // too big, will not match
       name: 'my favorite disk',
       blockSize: undefined, // not important here, but required
+      zone: 'us-central1-a',
     };
 
     const expectedDiskConfig = {
@@ -504,6 +507,7 @@ describe(toAnalysisConfig.name, () => {
       size: persistentDisk.size,
       name: 'my favorite disk',
       blockSize: undefined, // not important here, but required
+      zone: 'us-central1-a',
     };
 
     const expectedDiskConfig = {
@@ -691,6 +695,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);
@@ -708,6 +713,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);
@@ -728,6 +734,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);
@@ -748,6 +755,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: undefined,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);
@@ -870,6 +878,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);
@@ -889,6 +898,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         blockSize: 0,
         name: 'whatever',
+        zone: 'us-central1-a',
       };
 
       const outConfig = withAnalysisConfigDefaults(inputConfig, inputDisk);

--- a/ui/src/app/utils/runtime-hooks.spec.tsx
+++ b/ui/src/app/utils/runtime-hooks.spec.tsx
@@ -226,6 +226,7 @@ describe(useCustomRuntime.name, () => {
       name: 'my-existing-disk',
       blockSize: 1,
       gceRuntime: true,
+      zone: 'us-central1-a',
     };
     setCurrentDisk(existingDisk);
     const newRuntime = defaultGceRuntimeWithPd();

--- a/ui/src/testing/stubs/disks-api-stub.ts
+++ b/ui/src/testing/stubs/disks-api-stub.ts
@@ -14,6 +14,7 @@ export const stubDisk = (): Disk => ({
   gceRuntime: true,
   name: 'stub-disk',
   blockSize: 1,
+  zone: 'us-central1-a',
 });
 
 export const mockJupyterDisk = (): Disk => ({
@@ -26,6 +27,7 @@ export const mockJupyterDisk = (): Disk => ({
   appType: null,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  zone: 'us-central1-a',
 });
 
 export const mockCromwellDisk = (): Disk => ({
@@ -38,6 +40,7 @@ export const mockCromwellDisk = (): Disk => ({
   appType: AppType.CROMWELL,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  zone: 'us-central1-a',
 });
 
 export const mockRStudioDisk = (): Disk => ({
@@ -50,6 +53,7 @@ export const mockRStudioDisk = (): Disk => ({
   appType: AppType.RSTUDIO,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  zone: 'us-central1-a',
 });
 
 export class DisksApiStub extends DisksApi {


### PR DESCRIPTION
### Background:
I am in the process of adding functionality for users to be able to change their zone for a Jupyter environment. That ticket is getting fairly long and complex, so I am breaking this change into its own PR.

### The Problem
This PR adds the zone attribute to the Disk object. This attribute is needed, because of a potential zone discrepancy issue. The zone that a user selects for their Jupyter environment will also be the zone of the associated persistent disk. If a user deletes their Jupyter environment and keeps their disk, they will encounter an error if they try to create a Jupyter environment with a different zone.

### The Solution
Once zone can be read from a persistent disk, we can force future Jupyter environments to be created with the same environment and tell the user that if they want a different zone, they will need to delete their persistent disk. 

### Potential Future Work
There is a chance that we can copy a disk to a different zone in the future and avoid the problem described above, but we are not looking into that right now. 

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
