### PR TITLE
[risk=low][RW-10064] Use new Leo disks client in all cases

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
@@ -2,9 +2,7 @@ package org.pmiops.workbench.disks;
 
 import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
 import org.pmiops.workbench.model.Disk;
@@ -45,11 +43,9 @@ public class DiskService {
   public List<Disk> getAllDisksInWorkspaceNamespace(String workspaceNamespace) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
-    List<LeonardoListPersistentDiskResponse> responseList =
+    List<ListPersistentDiskResponse> responseList =
         leonardoNotebooksClient.listDisksByProjectAsService(googleProject);
-    return responseList.stream()
-        .map(leonardoMapper::toApiListDisksResponse)
-        .collect(Collectors.toList());
+    return responseList.stream().map(leonardoMapper::toApiListDisksResponse).toList();
   }
 
   public List<Disk> getOwnedDisksInWorkspace(String workspaceNamespace) {
@@ -60,9 +56,7 @@ public class DiskService {
         leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject);
 
     return PersistentDiskUtils.findTheMostRecentActiveDisks(
-        responseList.stream()
-            .map(leonardoMapper::toApiListDisksResponse)
-            .collect(Collectors.toList()));
+        responseList.stream().map(leonardoMapper::toApiListDisksResponse).toList());
   }
 
   public void updateDisk(String workspaceNamespace, String diskName, Integer diskSize) {

--- a/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.disks;
 
 import java.util.List;
-import java.util.logging.Logger;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
@@ -13,38 +12,37 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DiskService {
-  private static final Logger log = Logger.getLogger(DiskService.class.getName());
   private final LeonardoMapper leonardoMapper;
-  private final LeonardoApiClient leonardoNotebooksClient;
+  private final LeonardoApiClient leonardoApiClient;
   private final WorkspaceService workspaceService;
 
   @Autowired
   public DiskService(
       LeonardoMapper leonardoMapper,
-      LeonardoApiClient leonardoNotebooksClient,
+      LeonardoApiClient leonardoApiClient,
       WorkspaceService workspaceService) {
     this.leonardoMapper = leonardoMapper;
-    this.leonardoNotebooksClient = leonardoNotebooksClient;
+    this.leonardoApiClient = leonardoApiClient;
     this.workspaceService = workspaceService;
   }
 
   public void deleteDisk(String workspaceNamespace, String diskName) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
-    leonardoNotebooksClient.deletePersistentDisk(googleProject, diskName);
+    leonardoApiClient.deletePersistentDisk(googleProject, diskName);
   }
 
   public void deleteDiskAsService(String workspaceNamespace, String diskName) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
-    leonardoNotebooksClient.deletePersistentDiskAsService(googleProject, diskName);
+    leonardoApiClient.deletePersistentDiskAsService(googleProject, diskName);
   }
 
   public List<Disk> getAllDisksInWorkspaceNamespace(String workspaceNamespace) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
     List<ListPersistentDiskResponse> responseList =
-        leonardoNotebooksClient.listDisksByProjectAsService(googleProject);
+        leonardoApiClient.listDisksByProjectAsService(googleProject);
     return responseList.stream().map(leonardoMapper::toApiListDisksResponse).toList();
   }
 
@@ -53,7 +51,7 @@ public class DiskService {
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
 
     List<ListPersistentDiskResponse> responseList =
-        leonardoNotebooksClient.listPersistentDiskByProjectCreatedByCreator(googleProject);
+        leonardoApiClient.listPersistentDiskByProjectCreatedByCreator(googleProject);
 
     return PersistentDiskUtils.findTheMostRecentActiveDisks(
         responseList.stream().map(leonardoMapper::toApiListDisksResponse).toList());
@@ -62,6 +60,6 @@ public class DiskService {
   public void updateDisk(String workspaceNamespace, String diskName, Integer diskSize) {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
-    leonardoNotebooksClient.updatePersistentDisk(googleProject, diskName, diskSize);
+    leonardoApiClient.updatePersistentDisk(googleProject, diskName, diskSize);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -6,7 +6,6 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDis
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.model.CreateAppRequest;
 import org.pmiops.workbench.model.Runtime;
@@ -138,10 +137,10 @@ public interface LeonardoApiClient {
   int deleteUserAppsAsService(String userEmail);
 
   /** List all persistent disks */
-  List<LeonardoListPersistentDiskResponse> listDisksAsService();
+  List<ListPersistentDiskResponse> listDisksAsService();
 
   /** List all persistent disks in google project */
-  List<LeonardoListPersistentDiskResponse> listDisksByProjectAsService(String googleProject);
+  List<ListPersistentDiskResponse> listDisksByProjectAsService(String googleProject);
 
   void deleteAllResources(String googleProject, boolean deleteDisk);
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoConfig.java
@@ -28,8 +28,7 @@ public class LeonardoConfig {
   public static final String SERVICE_RUNTIMES_API = "svcRuntimesApi";
 
   public static final String USER_DISKS_API = "userDisksApi";
-  public static final String LEGACY_USER_DISKS_API = "legacyUserDisksApi";
-  public static final String LEGACY_SERVICE_DISKS_API = "legacyServiceDisksApi";
+  public static final String SERVICE_DISKS_API = "serviceDisksApi";
 
   public static final String USER_APPS_API = "userAppsApi";
 
@@ -40,6 +39,7 @@ public class LeonardoConfig {
   private static final String SERVICE_NOTEBOOKS_CLIENT = "notebooksSvcApiClient";
   // Identifiers for the new OAS3 APIs from Leonardo. These should be used for runtimes access.
   private static final String USER_LEONARDO_CLIENT = "leonardoApiClient";
+  private static final String SERVICE_LEONARDO_CLIENT = "leonardoServiceApiClient";
   private static final String LEGACY_USER_LEONARDO_CLIENT = "legacyLeonardoApiClient";
   private static final String LEGACY_SERVICE_LEONARDO_CLIENT = "legacyLeonardoServiceApiClient";
 
@@ -105,6 +105,18 @@ public class LeonardoConfig {
     return apiClient;
   }
 
+  @Bean(name = SERVICE_LEONARDO_CLIENT)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ApiClient leoServiceApiClient(LeonardoApiClientFactory factory) {
+    ApiClient apiClient = factory.newApiClient();
+    try {
+      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(NOTEBOOK_SCOPES));
+    } catch (IOException e) {
+      throw new ServerErrorException(e);
+    }
+    return apiClient;
+  }
+
   @Bean(name = SERVICE_NOTEBOOKS_CLIENT)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public org.pmiops.workbench.notebooks.ApiClient workbenchServiceAccountClient(
@@ -128,16 +140,6 @@ public class LeonardoConfig {
     return api;
   }
 
-  @Bean(name = LEGACY_USER_DISKS_API)
-  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public org.pmiops.workbench.legacy_leonardo_client.api.DisksApi legacyDisksApi(
-      @Qualifier(LEGACY_USER_LEONARDO_CLIENT)
-          org.pmiops.workbench.legacy_leonardo_client.ApiClient apiClient) {
-    var api = new org.pmiops.workbench.legacy_leonardo_client.api.DisksApi();
-    api.setApiClient(apiClient);
-    return api;
-  }
-
   @Bean(name = USER_DISKS_API)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public DisksApi disksApi(@Qualifier(USER_LEONARDO_CLIENT) ApiClient apiClient) {
@@ -146,12 +148,10 @@ public class LeonardoConfig {
     return api;
   }
 
-  @Bean(name = LEGACY_SERVICE_DISKS_API)
+  @Bean(name = SERVICE_DISKS_API)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public org.pmiops.workbench.legacy_leonardo_client.api.DisksApi legacyServiceDisksApi(
-      @Qualifier(LEGACY_SERVICE_LEONARDO_CLIENT)
-          org.pmiops.workbench.legacy_leonardo_client.ApiClient apiClient) {
-    var api = new org.pmiops.workbench.legacy_leonardo_client.api.DisksApi();
+  public DisksApi serviceDisksApi(@Qualifier(SERVICE_LEONARDO_CLIENT) ApiClient apiClient) {
+    var api = new DisksApi();
     api.setApiClient(apiClient);
     return api;
   }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.leonardo;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -13,8 +12,8 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.DiskStatus;
@@ -23,11 +22,8 @@ public final class PersistentDiskUtils {
   private static final Logger log = Logger.getLogger(PersistentDiskUtils.class.getName());
 
   // See https://cloud.google.com/compute/pricing
-  private static final Map<LeonardoDiskType, Double> DISK_PRICE_PER_GB_MONTH =
-      ImmutableMap.<LeonardoDiskType, Double>builder()
-          .put(LeonardoDiskType.STANDARD, .04)
-          .put(LeonardoDiskType.SSD, .17)
-          .build();
+  private static final Map<DiskType, Double> DISK_PRICE_PER_GB_MONTH =
+      Map.of(DiskType.STANDARD, .04, DiskType.SSD, .17);
 
   // https://github.com/DataBiosphere/leonardo/blob/3774547f2018e056e9af42142a10ac004cfe1ee8/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala#L60
   private static final Set<DiskStatus> ACTIVE_DISK_STATUSES =
@@ -36,10 +32,10 @@ public final class PersistentDiskUtils {
   private PersistentDiskUtils() {}
 
   // Keep in sync with ui/src/app/utils/machines.ts
-  public static double costPerMonth(LeonardoListPersistentDiskResponse disk, String googleProject) {
+  public static double costPerMonth(ListPersistentDiskResponse disk, String googleProject) {
     Double pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(disk.getDiskType());
     if (pricePerGbMonth == null) {
-      pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(LeonardoDiskType.STANDARD);
+      pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(DiskType.STANDARD);
       log.warning(
           String.format(
               "unknown disk type %s for disk %s/%s, defaulting to standard",

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -4,10 +4,10 @@ import jakarta.annotation.Nullable;
 import jakarta.mail.MessagingException;
 import java.time.Instant;
 import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
 
 public interface MailService {
@@ -43,7 +43,7 @@ public interface MailService {
   void alertUsersUnusedDiskWarningThreshold(
       List<DbUser> users,
       DbWorkspace diskWorkspace,
-      LeonardoListPersistentDiskResponse disk,
+      ListPersistentDiskResponse disk,
       boolean isDiskAttached,
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringSubstitutor;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.EgressAlertRemediationPolicy;
 import org.pmiops.workbench.db.model.DbUser;
@@ -40,7 +41,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
 import org.pmiops.workbench.google.CloudStorageClient;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.leonardo.PersistentDiskUtils;
 import org.pmiops.workbench.mandrill.api.MandrillApi;
@@ -309,7 +309,7 @@ public class MailServiceImpl implements MailService {
   public void alertUsersUnusedDiskWarningThreshold(
       List<DbUser> users,
       DbWorkspace diskWorkspace,
-      LeonardoListPersistentDiskResponse disk,
+      ListPersistentDiskResponse disk,
       boolean isDiskAttached,
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -7,6 +7,8 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -145,7 +147,7 @@ public interface LeonardoMapper {
   LeonardoListRuntimeResponse toListRuntimeResponse(LeonardoGetRuntimeResponse runtime);
 
   @Nullable
-  @Named("cloudContextToGoogleProject")
+  @Named("legacy_cloudContextToGoogleProject")
   default String toGoogleProject(@Nullable LeonardoCloudContext lcc) {
     return Optional.ofNullable(lcc)
         // we don't support LeonardoCloudProvider.AZURE so don't attempt to map it
@@ -154,12 +156,22 @@ public interface LeonardoMapper {
         .orElse(null);
   }
 
+  @Nullable
+  @Named("cloudContextToGoogleProject")
+  default String toGoogleProject(@Nullable CloudContext lcc) {
+    return Optional.ofNullable(lcc)
+        // we don't support LeonardoCloudProvider.AZURE so don't attempt to map it
+        .filter(c -> c.getCloudProvider() == CloudProvider.GCP)
+        .map(CloudContext::getCloudResource)
+        .orElse(null);
+  }
+
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
+      qualifiedByName = "legacy_cloudContextToGoogleProject")
   ListRuntimeResponse toApiListRuntimeResponse(
       LeonardoListRuntimeResponse leonardoListRuntimeResponse);
 
@@ -172,7 +184,7 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
+      qualifiedByName = "legacy_cloudContextToGoogleProject")
   Runtime toApiRuntime(LeonardoGetRuntimeResponse runtime);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
@@ -186,7 +198,7 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
+      qualifiedByName = "legacy_cloudContextToGoogleProject")
   Runtime toApiRuntime(LeonardoListRuntimeResponse runtime);
 
   RuntimeError toApiRuntimeError(LeonardoClusterError err);
@@ -218,7 +230,7 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
+      qualifiedByName = "legacy_cloudContextToGoogleProject")
   @Mapping(target = "autopauseThreshold", ignore = true)
   @Mapping(target = "appType", ignore = true)
   UserAppEnvironment toApiApp(LeonardoGetAppResponse app);
@@ -230,7 +242,7 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
+      qualifiedByName = "legacy_cloudContextToGoogleProject")
   @Mapping(target = "appType", ignore = true)
   UserAppEnvironment toApiApp(LeonardoListAppResponse app);
 

--- a/api/src/test/java/org/pmiops/workbench/disk/DiskServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/disk/DiskServiceTest.java
@@ -6,13 +6,13 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListPersistentDiskResponse;
-import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoListRuntimePDResponse;
+import static org.pmiops.workbench.utils.TestMockFactory.createLeonardoRuntimePDResponse;
+import static org.pmiops.workbench.utils.TestMockFactory.createListPersistentDiskResponse;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,8 +24,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.disks.DiskService;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskStatus;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
@@ -55,31 +53,30 @@ public class DiskServiceTest {
   @Test
   public void test_getAllDisksInWorkspaceNamespace() {
     DbWorkspace dbWorkspace = new DbWorkspace().setGoogleProject(GOOGLE_PROJECT_ID);
-    LeonardoListPersistentDiskResponse firstLPDR =
-        createLeonardoListPersistentDiskResponse(
+    ListPersistentDiskResponse firstLPDR =
+        createListPersistentDiskResponse(
             user.generatePDName(),
-            LeonardoDiskStatus.READY,
+            DiskStatus.READY,
             NOW.minusMillis(200).toString(),
             GOOGLE_PROJECT_ID,
             user,
             AppType.CROMWELL);
-    LeonardoListPersistentDiskResponse secondLPDR =
-        createLeonardoListPersistentDiskResponse(
+    ListPersistentDiskResponse secondLPDR =
+        createListPersistentDiskResponse(
             user.generatePDName(),
-            LeonardoDiskStatus.READY,
+            DiskStatus.READY,
             NOW.minusMillis(20000).toString(),
             GOOGLE_PROJECT_ID,
             user,
             AppType.RSTUDIO);
-    LeonardoListPersistentDiskResponse thirdLPDR =
-        createLeonardoListRuntimePDResponse(
+    ListPersistentDiskResponse thirdLPDR =
+        createLeonardoRuntimePDResponse(
             user.generatePDName(),
-            LeonardoDiskStatus.READY,
+            DiskStatus.READY,
             NOW.minusMillis(2000000).toString(),
             GOOGLE_PROJECT_ID,
             user);
-    List<LeonardoListPersistentDiskResponse> responseList =
-        new ArrayList<>(Arrays.asList(firstLPDR, secondLPDR, thirdLPDR));
+    List<ListPersistentDiskResponse> responseList = List.of(firstLPDR, secondLPDR, thirdLPDR);
     Disk firstDisk = new Disk();
     firstDisk.setName(firstLPDR.getName());
 

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceImplTest.java
@@ -13,9 +13,13 @@ import static org.pmiops.workbench.mail.MailServiceImpl.DETACHED_DISK_STATUS;
 import com.google.common.collect.ImmutableList;
 import jakarta.mail.MessagingException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,9 +32,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
 import org.pmiops.workbench.google.CloudStorageClient;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.mandrill.ApiException;
 import org.pmiops.workbench.mandrill.api.MandrillApi;
 import org.pmiops.workbench.mandrill.model.MandrillApiKeyAndMessage;
@@ -272,14 +273,14 @@ public class MailServiceImplTest {
     Map<String, String> labelsMap = new HashMap<String, String>();
     labelsMap.put("is-runtime", "true");
     mailService.alertUsersUnusedDiskWarningThreshold(
-        ImmutableList.of(user),
+        Collections.singletonList(user),
         new DbWorkspace().setName("my workspace").setCreator(user),
-        new LeonardoListPersistentDiskResponse()
-            .diskType(LeonardoDiskType.SSD)
+        new ListPersistentDiskResponse()
+            .diskType(DiskType.SSD)
             .labels(labelsMap)
             .size(123)
             .auditInfo(
-                new LeonardoAuditInfo()
+                new AuditInfo()
                     .createdDate(
                         FakeClockConfiguration.NOW
                             .toInstant()
@@ -314,14 +315,14 @@ public class MailServiceImplTest {
     Map<String, String> labelsMap = new HashMap<String, String>();
     labelsMap.put("is-runtime", "true");
     mailService.alertUsersUnusedDiskWarningThreshold(
-        ImmutableList.of(user),
+        Collections.singletonList(user),
         new DbWorkspace().setName("my workspace").setCreator(user),
-        new LeonardoListPersistentDiskResponse()
-            .diskType(LeonardoDiskType.SSD)
+        new ListPersistentDiskResponse()
+            .diskType(DiskType.SSD)
             .labels(labelsMap)
             .size(123)
             .auditInfo(
-                new LeonardoAuditInfo()
+                new AuditInfo()
                     .createdDate(
                         FakeClockConfiguration.NOW
                             .toInstant()

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -44,12 +44,8 @@ import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskStatus;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.model.AppType;
@@ -385,32 +381,6 @@ public class TestMockFactory {
     assertThat(normalizeLists(survey1)).isEqualTo(normalizeLists(survey2));
   }
 
-  public static LeonardoListPersistentDiskResponse createLeonardoListPersistentDiskResponse(
-      String pdName,
-      LeonardoDiskStatus status,
-      String date,
-      String googleProjectId,
-      DbUser user,
-      @Nullable AppType appType) {
-    LeonardoListPersistentDiskResponse response =
-        new LeonardoListPersistentDiskResponse()
-            .name(pdName)
-            .size(300)
-            .diskType(LeonardoDiskType.STANDARD)
-            .status(status)
-            .auditInfo(new LeonardoAuditInfo().createdDate(date).creator(user.getUsername()))
-            .cloudContext(
-                new LeonardoCloudContext()
-                    .cloudProvider(LeonardoCloudProvider.GCP)
-                    .cloudResource(googleProjectId));
-    if (appType != null) {
-      Map<String, String> label = new HashMap<>();
-      label.put(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appType));
-      response.labels(label);
-    }
-    return response;
-  }
-
   public static ListPersistentDiskResponse createListPersistentDiskResponse(
       String pdName,
       org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus status,
@@ -433,12 +403,6 @@ public class TestMockFactory {
       response.labels(label);
     }
     return response;
-  }
-
-  public static LeonardoListPersistentDiskResponse createLeonardoListRuntimePDResponse(
-      String pdName, LeonardoDiskStatus status, String date, String googleProjectId, DbUser user) {
-    return createLeonardoListPersistentDiskResponse(
-        pdName, status, date, googleProjectId, user, /*appType*/ null);
   }
 
   public static ListPersistentDiskResponse createLeonardoRuntimePDResponse(

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -55,7 +55,7 @@ public class LeonardoMapperTest {
   private PersistentDiskRequest persistentDiskRequest;
   private org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest
       leonardoPersistentDiskRequest;
-  private org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo leonardoAuditInfo;
+  private AuditInfo leonardoAuditInfo;
   private LeonardoAuditInfo legacyLeonardoAuditInfo;
   private List<KubernetesError> kubernetesErrors = new ArrayList<>();
   private List<LeonardoKubernetesError> leonardoKubernetesErrors = new ArrayList<>();
@@ -212,9 +212,9 @@ public class LeonardoMapperTest {
         new Disk()
             .diskType(DiskType.SSD)
             .gceRuntime(true)
-            .creator(legacyLeonardoAuditInfo.getCreator())
-            .dateAccessed(legacyLeonardoAuditInfo.getDateAccessed())
-            .createdDate(legacyLeonardoAuditInfo.getCreatedDate())
+            .creator(leonardoAuditInfo.getCreator())
+            .dateAccessed(leonardoAuditInfo.getDateAccessed())
+            .createdDate(leonardoAuditInfo.getCreatedDate())
             .status(DiskStatus.READY);
     assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse)).isEqualTo(disk);
 

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -21,12 +21,10 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAppType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesError;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListAppResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
@@ -55,8 +53,9 @@ public class LeonardoMapperTest {
   private KubernetesRuntimeConfig kubernetesRuntimeConfig;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
-  private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
-  private AuditInfo leonardoAuditInfo;
+  private org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest
+      leonardoPersistentDiskRequest;
+  private org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo leonardoAuditInfo;
   private LeonardoAuditInfo legacyLeonardoAuditInfo;
   private List<KubernetesError> kubernetesErrors = new ArrayList<>();
   private List<LeonardoKubernetesError> leonardoKubernetesErrors = new ArrayList<>();
@@ -78,14 +77,16 @@ public class LeonardoMapperTest {
         new LeonardoKubernetesRuntimeConfig().autoscalingEnabled(false).machineType(MACHINE_TYPE);
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
-        new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
-    legacyLeonardoAuditInfo =
-        new LeonardoAuditInfo()
+        new org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest()
+            .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD)
+            .size(10);
+    leonardoAuditInfo =
+        new AuditInfo()
             .createdDate("2022-10-10")
             .creator("bob@gmail.com")
             .dateAccessed("2022-10-10");
-    leonardoAuditInfo =
-        new AuditInfo()
+    legacyLeonardoAuditInfo =
+        new LeonardoAuditInfo()
             .createdDate("2022-10-10")
             .creator("bob@gmail.com")
             .dateAccessed("2022-10-10");
@@ -132,12 +133,6 @@ public class LeonardoMapperTest {
   }
 
   @Test
-  public void testToPersistentDiskRequest() {
-    assertThat(mapper.toPersistentDiskRequest(leonardoPersistentDiskRequest))
-        .isEqualTo(persistentDiskRequest);
-  }
-
-  @Test
   public void testToLeoPersistentDiskRequest() {
     assertThat(mapper.toLeonardoPersistentDiskRequest(persistentDiskRequest))
         .isEqualTo(leonardoPersistentDiskRequest);
@@ -161,8 +156,7 @@ public class LeonardoMapperTest {
 
   @ParameterizedTest(name = "appType {0} can be mapped for getApp call")
   @MethodSource("allAppTypesMap")
-  public void testToAppFromGetResponse(Map.Entry<AppType, LeonardoAppType> appTypeMapEntry)
-      throws Exception {
+  public void testToAppFromGetResponse(Map.Entry<AppType, LeonardoAppType> appTypeMapEntry) {
     labels.put(
         LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appTypeMapEntry.getKey()));
     LeonardoGetAppResponse getAppResponse =

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -21,10 +21,12 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAppType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesError;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListAppResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
@@ -53,8 +55,7 @@ public class LeonardoMapperTest {
   private KubernetesRuntimeConfig kubernetesRuntimeConfig;
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
-  private org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest
-      leonardoPersistentDiskRequest;
+  private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
   private AuditInfo leonardoAuditInfo;
   private LeonardoAuditInfo legacyLeonardoAuditInfo;
   private List<KubernetesError> kubernetesErrors = new ArrayList<>();
@@ -77,9 +78,7 @@ public class LeonardoMapperTest {
         new LeonardoKubernetesRuntimeConfig().autoscalingEnabled(false).machineType(MACHINE_TYPE);
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
-        new org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest()
-            .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD)
-            .size(10);
+        new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
     leonardoAuditInfo =
         new AuditInfo()
             .createdDate("2022-10-10")

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,13 +21,11 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAppType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskStatus;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesError;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListAppResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
@@ -56,7 +56,8 @@ public class LeonardoMapperTest {
   private LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
   private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
-  private LeonardoAuditInfo leonardoAuditInfo;
+  private AuditInfo leonardoAuditInfo;
+  private LeonardoAuditInfo legacyLeonardoAuditInfo;
   private List<KubernetesError> kubernetesErrors = new ArrayList<>();
   private List<LeonardoKubernetesError> leonardoKubernetesErrors = new ArrayList<>();
   private Map<String, String> proxyUrls = new HashMap<>();
@@ -78,8 +79,13 @@ public class LeonardoMapperTest {
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
         new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
-    leonardoAuditInfo =
+    legacyLeonardoAuditInfo =
         new LeonardoAuditInfo()
+            .createdDate("2022-10-10")
+            .creator("bob@gmail.com")
+            .dateAccessed("2022-10-10");
+    leonardoAuditInfo =
+        new AuditInfo()
             .createdDate("2022-10-10")
             .creator("bob@gmail.com")
             .dateAccessed("2022-10-10");
@@ -163,7 +169,7 @@ public class LeonardoMapperTest {
         new LeonardoGetAppResponse()
             .appType(appTypeMapEntry.getValue())
             .status(LeonardoAppStatus.RUNNING)
-            .auditInfo(leonardoAuditInfo)
+            .auditInfo(legacyLeonardoAuditInfo)
             .diskName(DISK_NAME)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
             .appName(APP_NAME)
@@ -186,7 +192,7 @@ public class LeonardoMapperTest {
         new LeonardoListAppResponse()
             .appType(appTypeMapEntry.getValue())
             .status(LeonardoAppStatus.RUNNING)
-            .auditInfo(leonardoAuditInfo)
+            .auditInfo(legacyLeonardoAuditInfo)
             .diskName(DISK_NAME)
             .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
             .errors(leonardoKubernetesErrors)
@@ -202,19 +208,19 @@ public class LeonardoMapperTest {
 
   @Test
   public void testToApiDiskFromListDiskResponse() {
-    LeonardoListPersistentDiskResponse listPersistentDiskResponse =
-        new LeonardoListPersistentDiskResponse()
-            .diskType(LeonardoDiskType.SSD)
+    ListPersistentDiskResponse listPersistentDiskResponse =
+        new ListPersistentDiskResponse()
+            .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.SSD)
             .auditInfo(leonardoAuditInfo)
-            .status(LeonardoDiskStatus.READY);
+            .status(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.READY);
 
     Disk disk =
         new Disk()
             .diskType(DiskType.SSD)
             .gceRuntime(true)
-            .creator(leonardoAuditInfo.getCreator())
-            .dateAccessed(leonardoAuditInfo.getDateAccessed())
-            .createdDate(leonardoAuditInfo.getCreatedDate())
+            .creator(legacyLeonardoAuditInfo.getCreator())
+            .dateAccessed(legacyLeonardoAuditInfo.getDateAccessed())
+            .createdDate(legacyLeonardoAuditInfo.getCreatedDate())
             .status(DiskStatus.READY);
     assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse)).isEqualTo(disk);
 

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/ListDisks.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/ListDisks.java
@@ -17,13 +17,13 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudServiceImpl;
 import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
 import org.pmiops.workbench.google.GoogleConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListPersistentDiskResponse;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoApiClientFactory;
 import org.pmiops.workbench.leonardo.LeonardoApiClientImpl;
@@ -60,12 +60,12 @@ public class ListDisks extends Tool {
   private static Options options = new Options().addOption(outputFileOpt);
 
   // Leonardo supports Azure but we do not, so we know this is always a Google Project
-  private String getGoogleProject(LeonardoListPersistentDiskResponse response) {
+  private String getGoogleProject(ListPersistentDiskResponse response) {
     return response.getCloudContext().getCloudResource();
   }
 
   private ListDisksRow toDiskRow(
-      LeonardoListPersistentDiskResponse response,
+      ListPersistentDiskResponse response,
       String workspaceNamespace,
       String workspaceDisplayName,
       String workspaceTerraName,
@@ -107,7 +107,7 @@ public class ListDisks extends Tool {
 
     log.info("Step 1 of 3: Retrieving disk information from Leonardo");
 
-    List<LeonardoListPersistentDiskResponse> disks = leonardoApiClient.listDisksAsService();
+    List<ListPersistentDiskResponse> disks = leonardoApiClient.listDisksAsService();
 
     log.info("Step 2 of 3: Associating disk information with RWB workspaces");
 


### PR DESCRIPTION
Tested by observing normal functionality of these endpoints which now use the new DisksApi:
* deleteDisk()
* updateDisk()
* listOwnedDisksInWorkspace()
* adminDeleteDisk()
* listDisksInWorkspace()
* cron - checkPersistentDisks
* ListDisks tool

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
