### PR TITLE
RISK=low RW-12240 remove enableEraCommons from api

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -95,7 +95,6 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -95,7 +95,6 @@
   },
   "access": {
     "enableComplianceTraining": false,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -95,7 +95,6 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -95,7 +95,6 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -96,7 +96,6 @@
   },
   "access": {
     "enableComplianceTraining": false,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": false,
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -95,7 +95,6 @@
   },
   "access": {
     "enableComplianceTraining": true,
-    "enableEraCommons": false,
     "unsafeAllowSelfBypass": true,
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -258,6 +258,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
       case RAS_LINK_LOGIN_GOV -> accessConfig.enableRasLoginGovLinking;
       case RAS_LINK_ID_ME -> accessConfig.enableRasIdMeLinking;
       case IDENTITY -> accessConfig.enableRasLoginGovLinking || accessConfig.enableRasIdMeLinking;
+      case ERA_COMMONS -> false;
       default -> true;
     };
   }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -252,7 +252,6 @@ public class AccessModuleServiceImpl implements AccessModuleService {
     final AccessConfig accessConfig = configProvider.get().access;
 
     return switch (module) {
-      case ERA_COMMONS -> accessConfig.enableEraCommons;
         // RT Compliance training  and CT Compliance training modules are
         // controlled by the same feature flag COMPLIANCE_TRAINING
       case COMPLIANCE_TRAINING, CT_COMPLIANCE_TRAINING -> accessConfig.enableComplianceTraining;

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -265,7 +265,6 @@ public class WorkbenchConfig {
 
     // These booleans control whether each of our core access modules are enabled per environment.
     public boolean enableComplianceTraining;
-    public boolean enableEraCommons;
     public boolean enableRasIdMeLinking;
     public boolean enableRasLoginGovLinking;
     // Which Data User Code of Conduct (DUCC) Agreement version(s) are currently accepted as valid

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -32,7 +32,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(
       target = "complianceTrainingRenewalLookback",
       source = "config.access.renewal.trainingLookbackPeriod")
-  @Mapping(target = "enableEraCommons", source = "config.access.enableEraCommons")
   @Mapping(target = "unsafeAllowSelfBypass", source = "config.access.unsafeAllowSelfBypass")
   @Mapping(
       target = "enableEventDateModifier",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6911,10 +6911,6 @@ components:
         absorbSamlServiceProviderId:
           type: string
           description: The SAML service provider ID for Absorb.
-        enableEraCommons:
-          type: boolean
-          description: Whether the eRA Commons access module is enabled.
-          default: false
         unsafeAllowSelfBypass:
           type: boolean
           description: Whether a user is allowed to self-bypass. Only enabled in test

--- a/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessModuleServiceTest.java
@@ -75,7 +75,6 @@ public class AccessModuleServiceTest {
   public void setup() {
     config = WorkbenchConfig.createEmptyConfig();
     config.access.enableComplianceTraining = true;
-    config.access.enableEraCommons = true;
     config.access.currentDuccVersions = ImmutableList.of(10, 11); // arbitrary for test
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -161,7 +161,6 @@ public class UserServiceAccessTest {
   public void setUp() {
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
     providedWorkbenchConfig.access.enableComplianceTraining = true;
-    providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.access.enableRasLoginGovLinking = true;
     providedWorkbenchConfig.access.currentDuccVersions = ImmutableList.of(1, 2); // arbitrary
     providedWorkbenchConfig.access.renewal.expiryDays = EXPIRATION_DAYS;
@@ -928,7 +927,6 @@ public class UserServiceAccessTest {
     // When eRA flag is disabled, that means user completed eRA Commons
     assertThat(userAccessTierDao.findAll()).isEmpty();
     updateUserWithRetries(this::registerUser);
-    providedWorkbenchConfig.access.enableEraCommons = false;
     providedWorkbenchConfig.access.enableRasLoginGovLinking = false;
     institutionService.updateInstitution(institution.getShortName(), institution);
     accessModuleService.updateBypassTime(dbUser.getUserId(), DbAccessModuleName.ERA_COMMONS, false);
@@ -1105,7 +1103,6 @@ public class UserServiceAccessTest {
 
   @Test
   public void test_updateUserWithRetries_eraFFisOff_CT() {
-    providedWorkbenchConfig.access.enableEraCommons = false;
     assertThat(userAccessTierDao.findAll()).isEmpty();
 
     dbUser = completeRTAndCTRequirements(dbUser);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -157,33 +157,6 @@ public class UserServiceTest {
   }
 
   @Test
-  public void testSyncEraCommonsStatus() {
-    FirecloudNihStatus nihStatus = new FirecloudNihStatus();
-    nihStatus.setLinkedNihUsername("nih-user");
-    // FireCloud stores the NIH status in seconds, not msecs.
-    final long FC_LINK_EXPIRATION_SECONDS = START_INSTANT.toEpochMilli() / 1000;
-    nihStatus.setLinkExpireTime(FC_LINK_EXPIRATION_SECONDS);
-
-    when(mockFireCloudService.getNihStatus()).thenReturn(nihStatus);
-
-    userService.syncEraCommonsStatus();
-
-    DbUser user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(
-        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
-
-    assertThat(user.getEraCommonsLinkExpireTime()).isEqualTo(Timestamp.from(START_INSTANT));
-    assertThat(user.getEraCommonsLinkedNihUsername()).isEqualTo("nih-user");
-
-    // Completion timestamp should not change when the method is called again.
-    tick();
-    userService.syncEraCommonsStatus();
-
-    assertModuleCompletionEqual(
-        DbAccessModuleName.ERA_COMMONS, user, Timestamp.from(START_INSTANT));
-  }
-
-  @Test
   public void testClearsEraCommonsStatus() {
     // Put the test user in a state where eRA commons is completed.
     DbUser testUser = userDao.findUserByUsername(USERNAME);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -142,7 +142,6 @@ public class UserServiceTest {
 
     providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
     providedWorkbenchConfig.access.renewal.expiryDays = 365L;
-    providedWorkbenchConfig.access.enableEraCommons = true;
     providedWorkbenchConfig.termsOfService.minimumAcceptedAouVersion = 5; // arbitrary
     providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays = 17L; // arbitrary
 

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -267,21 +267,6 @@ public class RasLinkServiceTest {
   }
 
   @Test
-  public void testLinkRasSuccess_eRAAlreadyLinked() throws Exception {
-    // ERA is linked before, expect ERA record not update by RAS linking again.
-    Timestamp eRATime = Timestamp.from(Instant.parse("2000-01-01T00:00:00.00Z"));
-    accessModuleService.updateCompletionTime(currentUser, DbAccessModuleName.ERA_COMMONS, eRATime);
-    mockCodeExchangeResponse(TOKEN_RESPONSE_IAL2);
-    mockAccessTokenResponse(USER_INFO_JSON_LOGIN_GOV_WITH_ERA);
-    rasLinkService.linkRasAccount(AUTH_CODE, REDIRECT_URL);
-
-    assertThat(userDao.findUserByUserId(userId).getRasLinkUsername()).isEqualTo(LOGIN_GOV_USERNAME);
-    assertModuleCompletionTime(DbAccessModuleName.IDENTITY, NOW);
-    assertModuleCompletionTime(DbAccessModuleName.RAS_LOGIN_GOV, NOW);
-    assertModuleCompletionTime(DbAccessModuleName.ERA_COMMONS, eRATime);
-  }
-
-  @Test
   public void testLinkRasFail_ial1() throws Exception {
     mockCodeExchangeResponse(TOKEN_RESPONSE_IAL1);
     verify(mockIdentityVerificationService, never()).updateIdentityVerificationSystem(any(), any());

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -191,7 +191,6 @@ public class RasLinkServiceTest {
     public WorkbenchConfig getWorkbenchConfig() {
       WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
       config.access.renewal.expiryDays = 365L;
-      config.access.enableEraCommons = true;
       config.access.enableRasLoginGovLinking = true;
       config.billing.initialCreditsValidityPeriodDays = 57L;
       return config;

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -236,23 +236,6 @@ public class RasLinkServiceTest {
   }
 
   @Test
-  public void testLinkRasIdMeSuccess() throws Exception {
-    mockCodeExchangeResponse(TOKEN_RESPONSE_IAL2);
-    mockAccessTokenResponse(USER_INFO_JSON_ID_ME);
-
-    rasLinkService.linkRasAccount(AUTH_CODE, REDIRECT_URL);
-
-    DbUser expectedUser = userDao.findUserByUserId(userId);
-    assertThat(expectedUser.getRasLinkUsername()).isEqualTo(ID_ME_USERNAME);
-    assertModuleCompletionTime(DbAccessModuleName.IDENTITY, NOW);
-    assertModuleCompletionTime(DbAccessModuleName.ERA_COMMONS, null);
-    verify(mockIdentityVerificationService)
-        .updateIdentityVerificationSystem(expectedUser, DbIdentityVerificationSystem.ID_ME);
-    verify(mockIdentityVerificationService, never())
-        .updateIdentityVerificationSystem(expectedUser, DbIdentityVerificationSystem.LOGIN_GOV);
-  }
-
-  @Test
   public void testLinkRasLoginGovSuccess() throws Exception {
     mockCodeExchangeResponse(TOKEN_RESPONSE_IAL2);
     mockAccessTokenResponse(USER_INFO_JSON_LOGIN_GOV);

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -62,7 +62,6 @@ const defaultServerConfig: ConfigResponse = {
   publicApiKeyForErrorReports: 'notasecret',
   shibbolethUiBaseUrl: 'https://broad-shibboleth-prod.appspot.com/',
   enableComplianceTraining: true,
-  enableEraCommons: false,
   unsafeAllowSelfBypass: false,
   defaultFreeCreditsDollarLimit: 300,
   rasHost: 'https://stsstg.nih.gov/',


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-12240

Depends on https://github.com/all-of-us/workbench/pull/8844

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
