### PR TITLE
[risk=low][no ticket] Better UX for egress on User Admin and Workspace Admin pages

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -139,7 +139,7 @@ public class UserAdminController implements UserAdminApiDelegate {
   }
 
   @Override
-  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  @AuthorityRequired({Authority.SECURITY_ADMIN})
   public ResponseEntity<ListEgressBypassWindowResponse> listEgressBypassWindows(Long userId) {
     return ResponseEntity.ok(
         new ListEgressBypassWindowResponse()

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2372,7 +2372,7 @@ paths:
       tags:
       - userAdmin
       description: |
-        List all of the user's egress bypass windows.  Require RESEARCHER_DATA_VIEW authority
+        List all of the user's egress bypass windows.  Requires SECURITY_ADMIN authority
       operationId: listEgressBypassWindows
       parameters:
       - name: userId

--- a/ui/src/app/pages/admin/institution/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/institution/admin-institution-edit.spec.tsx
@@ -17,6 +17,7 @@ import defaultServerConfig from 'testing/default-server-config';
 import {
   changeInputValue,
   expectTooltip,
+  expectTooltipAbsence,
   waitForNoSpinner,
 } from 'testing/react-test-helpers';
 import {
@@ -85,16 +86,12 @@ const selectDropdownOption = async (
   await userEvent.click(optionElement);
 };
 
-export const expectTooltipAbsence = async (
-  element: HTMLElement,
-  user: UserEvent
-) => {
-  await user.hover(element);
-  expect(
-    screen.queryByText(/Please correct the following errors/i)
-  ).not.toBeInTheDocument();
-  await user.unhover(element);
-};
+const expectSaveTooltipAbsence = async (user: UserEvent) =>
+  expectTooltipAbsence(
+    getSaveButton(),
+    /Please correct the following errors/i,
+    user
+  );
 
 describe('AdminInstitutionEditSpec - edit mode', () => {
   let user: UserEvent;
@@ -371,7 +368,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     // Single correct format Email Address entries
     changeInputValue(getRTAddressInput(), 'correctEmail@domain.com', user);
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should display error in case of invalid email Address Format in Controlled Tier requirement', async () => {
@@ -417,7 +414,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       'correctEmail@domain.com',
       user
     );
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should display error in case of invalid email Domain Format in Registered Tier requirement', async () => {
@@ -426,7 +423,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     // VERILY inst starts with RT DOMAINS
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
 
     // Single Entry with incorrect Email Domain format
     await changeInputValue(getRTDomainInput(), 'invalidEmail@domain', user);
@@ -455,7 +452,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     );
 
     await changeInputValue(getRTDomainInput(), 'domain.com', user);
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should display error in case of invalid email Domain Format in Controlled Tier requirement', async () => {
@@ -498,7 +495,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
     );
 
     await changeInputValue(getCTDomainInput(), 'domain.com', user);
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should ignore empty string in email Domain in Registered Tier requirement', async () => {
@@ -517,7 +514,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       'validEmail.com,\njustSomeRandom.domain'
     );
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should ignore empty string in email Domain in Controlled Tier requirement', async () => {
@@ -537,7 +534,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       'validEmail.com,\njustSomeRandom.domain'
     );
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should ignore whitespaces in email domains in Registered Tier requirement', async () => {
@@ -556,7 +553,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       'someDomain.com,\njustSomeRandom.domain'
     );
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should ignore whitespaces in email domains in Controlled Tier requirement', async () => {
@@ -577,7 +574,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
       'someDomain.com,\njustSomeRandom.domain'
     );
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should allow updating bypassInitialCreditsExpiration from false to true', async () => {
@@ -596,7 +593,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     expect(bypassToggle).toBeChecked();
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 
   it('Should allow updating bypassInitialCreditsExpiration from true to false', async () => {
@@ -615,7 +612,7 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
 
     expect(bypassToggle).not.toBeChecked();
 
-    await expectTooltipAbsence(getSaveButton(), user);
+    await expectSaveTooltipAbsence(user);
   });
 });
 

--- a/ui/src/app/pages/admin/user/admin-user-egress-bypass.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-egress-bypass.spec.tsx
@@ -5,27 +5,113 @@ import * as React from 'react';
 import { UserAdminApi } from 'generated/fetch';
 
 import { render, screen } from '@testing-library/react';
-import { registerApiClient } from 'app/services/swagger-fetch-clients';
+import userEvent from '@testing-library/user-event';
+import {
+  registerApiClient,
+  userAdminApi,
+} from 'app/services/swagger-fetch-clients';
 
+import {
+  expectButtonElementDisabled,
+  expectButtonElementEnabled,
+  expectTooltip,
+  expectTooltipAbsence,
+} from 'testing/react-test-helpers';
+import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import { UserAdminApiStub } from 'testing/stubs/user-admin-api-stub';
 
-import { AdminUserEgressBypass } from './admin-user-egress-bypass';
+import {
+  AdminUserEgressBypass,
+  AdminUserEgressBypassProps,
+  MAX_BYPASS_DESCRIPTION,
+  MIN_BYPASS_DESCRIPTION,
+} from './admin-user-egress-bypass';
 
-describe('AdminUserEgressBypassSpec', () => {
-  const defaultProps = {
-    userId: 123,
+const getCreateWindowSpy = () =>
+  jest.spyOn(userAdminApi(), 'createEgressBypassWindow');
+
+const getBypassReasonText = () =>
+  screen.getByRole('textbox', {
+    name: /Enter description for large file download request./i,
+  });
+
+const getBypassButton = () =>
+  screen.getByRole('button', {
+    name: 'Temporarily Enable Large File Downloads',
+  });
+
+describe(AdminUserEgressBypass.name, () => {
+  const defaultProps: AdminUserEgressBypassProps = {
+    targetUserId: ProfileStubVariables.PROFILE_STUB.userId,
   };
 
-  const component = () => {
-    return render(<AdminUserEgressBypass {...defaultProps} />);
-  };
+  const component = (overrideProps?: Partial<AdminUserEgressBypassProps>) =>
+    render(
+      <AdminUserEgressBypass {...{ ...defaultProps, ...overrideProps }} />
+    );
 
   beforeEach(() => {
     registerApiClient(UserAdminApi, new UserAdminApiStub());
   });
 
-  it('should render', async () => {
+  it('should allow egress bypass', async () => {
+    const user = userEvent.setup();
+    const createWindowSpy = getCreateWindowSpy();
+
     component();
-    expect(screen.getByText('Enable Large File Downloads')).toBeInTheDocument();
+
+    const byPassDescription = 'test bypass reason';
+
+    await user.click(getBypassReasonText());
+    await user.paste(byPassDescription);
+
+    const bypassButton = getBypassButton();
+
+    await expectTooltipAbsence(
+      bypassButton,
+      /Required to enable large file downloads/i,
+      user
+    );
+    expectButtonElementEnabled(bypassButton);
+
+    await user.click(bypassButton);
+
+    expect(createWindowSpy).toHaveBeenCalledWith(
+      ProfileStubVariables.PROFILE_STUB.userId,
+      {
+        startTime: expect.any(Number),
+        byPassDescription,
+      }
+    );
+  });
+
+  it('should disallow egress bypass with a too short reason', async () => {
+    const user = userEvent.setup();
+
+    component();
+
+    const tooShort = 'a'.repeat(MIN_BYPASS_DESCRIPTION - 1);
+
+    await user.click(getBypassReasonText());
+    await user.paste(tooShort);
+
+    const bypassButton = getBypassButton();
+    await expectTooltip(bypassButton, /Request Reason/i, user);
+    expectButtonElementDisabled(bypassButton);
+  });
+
+  it('should disallow egress bypass with a too long reason', async () => {
+    const user = userEvent.setup();
+
+    component();
+
+    const tooShort = 'a'.repeat(MAX_BYPASS_DESCRIPTION + 1);
+
+    await user.click(getBypassReasonText());
+    await user.paste(tooShort);
+
+    const bypassButton = getBypassButton();
+    await expectTooltip(bypassButton, /Request Reason/i, user);
+    expectButtonElementDisabled(bypassButton);
   });
 });

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -36,6 +36,7 @@ import {
 import {
   AuthorityGuardedAction,
   hasAuthorityForAction,
+  renderIfAuthorized,
 } from 'app/utils/authorities';
 import {
   checkInstitutionalEmail,
@@ -220,7 +221,7 @@ const EditableFields = ({
   // Show the link to  redirect to institution detail page,
   // if the LOGGED IN USER has Institution admin authority and
   // institution name is populated
-  const showGoToInstitutionLink: Boolean =
+  const showGoToInstitutionLink =
     hasAuthorityForAction(profile, AuthorityGuardedAction.INSTITUTION_ADMIN) &&
     !!updatedProfile.verifiedInstitutionalAffiliation?.institutionShortName;
 
@@ -453,6 +454,8 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
   const {
     config: { gsuiteDomain },
   } = useStore(serverConfigStore);
+  const { profile } = useStore(profileStore);
+
   const { usernameWithoutGsuiteDomain } = useParams<MatchParams>();
   const [oldProfile, setOldProfile] = useState<Profile>(null);
   const [updatedProfile, setUpdatedProfile] = useState<Profile>(null);
@@ -754,16 +757,31 @@ export const AdminUserProfile = (spinnerProps: WithSpinnerOverlayProps) => {
             <h2>Egress event history</h2>
           </FlexRow>
           <FlexRow>
-            <EgressEventsTable
-              displayPageSize={10}
-              sourceUserEmail={updatedProfile.username}
-            />
+            {renderIfAuthorized(
+              profile,
+              AuthorityGuardedAction.EGRESS_EVENTS,
+              () => (
+                <EgressEventsTable
+                  displayPageSize={10}
+                  sourceUserEmail={updatedProfile.username}
+                />
+              )
+            )}
           </FlexRow>
           <FlexRow>
             <h2>Egress bypass requests for large file downloads</h2>
           </FlexRow>
           <FlexRow>
-            <AdminUserEgressBypass userId={updatedProfile.userId} />
+            {renderIfAuthorized(
+              profile,
+              AuthorityGuardedAction.EGRESS_BYPASS,
+              () => (
+                <AdminUserEgressBypass
+                  {...{ profile }}
+                  targetUserId={updatedProfile.userId}
+                />
+              )
+            )}
           </FlexRow>
         </FlexColumn>
       )}

--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -16,7 +16,11 @@ import { EgressEventsTable } from 'app/pages/admin/egress-events-table';
 import { DisksTable } from 'app/pages/admin/workspace/disks-table';
 import { workspaceAdminApi } from 'app/services/swagger-fetch-clients';
 import { hasNewValidProps } from 'app/utils';
-import { MatchParams } from 'app/utils/stores';
+import {
+  AuthorityGuardedAction,
+  renderIfAuthorized,
+} from 'app/utils/authorities';
+import { MatchParams, profileStore } from 'app/utils/stores';
 
 import { AdminLockWorkspace } from './admin-lock-workspace';
 import { BasicInformation } from './basic-information';
@@ -112,6 +116,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
   }
 
   render() {
+    const { profile } = profileStore.get();
     const {
       cloudStorageTraffic,
       loadingWorkspace,
@@ -167,10 +172,16 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
                   onDelete={() => this.populateFederatedWorkspaceInformation()}
                 />
                 <h2>Egress event history</h2>
-                <EgressEventsTable
-                  displayPageSize={10}
-                  sourceWorkspaceNamespace={workspace.namespace}
-                />
+                {renderIfAuthorized(
+                  profile,
+                  AuthorityGuardedAction.EGRESS_EVENTS,
+                  () => (
+                    <EgressEventsTable
+                      displayPageSize={10}
+                      sourceWorkspaceNamespace={workspace.namespace}
+                    />
+                  )
+                )}
                 <h2>Disks</h2>
                 <DisksTable sourceWorkspaceNamespace={workspace.namespace} />
               </>

--- a/ui/src/app/utils/authorities.tsx
+++ b/ui/src/app/utils/authorities.tsx
@@ -2,9 +2,12 @@
 
 import { Authority, Profile } from 'generated/fetch';
 
+import { switchCase } from '@terra-ui-packages/core-utils';
+
 // Admin actions guarded by a particular Authority
-enum AuthorityGuardedAction {
+export enum AuthorityGuardedAction {
   EGRESS_EVENTS,
+  EGRESS_BYPASS,
   SHOW_ADMIN_MENU,
   USER_ADMIN,
   USER_AUDIT,
@@ -25,6 +28,7 @@ const adminMenuAuthorities: Set<Authority> = new Set([
 
 const authorityByPage: Map<AuthorityGuardedAction, Authority> = new Map([
   [AuthorityGuardedAction.EGRESS_EVENTS, Authority.SECURITY_ADMIN],
+  [AuthorityGuardedAction.EGRESS_BYPASS, Authority.SECURITY_ADMIN],
   [AuthorityGuardedAction.USER_ADMIN, Authority.ACCESS_CONTROL_ADMIN],
   [AuthorityGuardedAction.USER_AUDIT, Authority.ACCESS_CONTROL_ADMIN],
   [AuthorityGuardedAction.WORKSPACE_ADMIN, Authority.RESEARCHER_DATA_VIEW],
@@ -33,7 +37,7 @@ const authorityByPage: Map<AuthorityGuardedAction, Authority> = new Map([
   [AuthorityGuardedAction.INSTITUTION_ADMIN, Authority.INSTITUTION_ADMIN],
 ]);
 
-const hasAuthorityForAction = (
+export const hasAuthorityForAction = (
   profile: Profile,
   action: AuthorityGuardedAction
 ): boolean => {
@@ -50,4 +54,25 @@ const hasAuthorityForAction = (
   return profile.authorities.includes(authorityByPage.get(action));
 };
 
-export { AuthorityGuardedAction, hasAuthorityForAction };
+// incomplete.  please add as needed.
+export const noAccessText = (action: AuthorityGuardedAction) => {
+  const actionDescription = switchCase(
+    action,
+    [AuthorityGuardedAction.EGRESS_BYPASS, () => 'make egress bypass requests'],
+    [AuthorityGuardedAction.EGRESS_EVENTS, () => 'view egress events']
+  );
+  return `You do not have permission to ${actionDescription}. ${authorityByPage.get(
+    action
+  )} authority is required.`;
+};
+
+export const renderIfAuthorized = (
+  profile: Profile,
+  action: AuthorityGuardedAction,
+  render: () => JSX.Element
+): JSX.Element =>
+  hasAuthorityForAction(profile, action) ? (
+    render()
+  ) : (
+    <div>{noAccessText(action)}</div>
+  );

--- a/ui/src/testing/react-test-helpers.tsx
+++ b/ui/src/testing/react-test-helpers.tsx
@@ -174,3 +174,13 @@ export const expectTooltip = async (
   await user.unhover(element);
   expect(screen.queryByText(message)).not.toBeInTheDocument();
 };
+
+export const expectTooltipAbsence = async (
+  element: HTMLElement,
+  message: Matcher,
+  user: UserEvent
+) => {
+  await user.hover(element);
+  expect(screen.queryByText(message)).not.toBeInTheDocument();
+  await user.unhover(element);
+};


### PR DESCRIPTION
We use a specific Authority for egress which differs from Workspace Admin and User Admin.  Prevent API calls from these UI pages when the user doesn't have the right authority.  This is strictly a UX improvement, because the API already correctly prevented access.


### User Admin
<img width="719" alt="User" src="https://github.com/user-attachments/assets/cfafc916-0b95-4d67-a0d5-385ee89fe492">


### Workspace Admin
<img width="646" alt="Workspace" src="https://github.com/user-attachments/assets/761f718c-c1f8-4c29-80fd-dc556b6b7756">


#### Also fix the button size - it was cutting off the text
<img width="428" alt="Button" src="https://github.com/user-attachments/assets/f9a5a10a-804d-4fa7-bad2-7eec0b5274c2">



Users with the correct Authority continue to have access to list-egress-events, list-egress-windows, and bypass-egress.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
