### PR TITLE
[risk=low][no ticket] Migrate Leo AppsApi calls to new client

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/AppsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/AppsController.java
@@ -67,14 +67,6 @@ public class AppsController implements AppsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<UserAppEnvironment> getApp(String workspaceNamespace, String appName) {
-    DbWorkspace dbWorkspace = workspaceService.lookupWorkspaceByNamespace(workspaceNamespace);
-
-    return ResponseEntity.ok(
-        leonardoApiClient.getAppByNameByProjectId(dbWorkspace.getGoogleProject(), appName));
-  }
-
-  @Override
   public ResponseEntity<EmptyResponse> updateApp(
       String workspaceNamespace, String appName, UserAppEnvironment app) {
     leonardoApiHelper.enforceComputeSecuritySuspension(userProvider.get());

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -103,14 +103,6 @@ public interface LeonardoApiClient {
       throws WorkbenchException;
 
   /**
-   * Gets Leonardo app owned by app name and workspace GCP project
-   *
-   * @param googleProjectId the GCP project the app belongs to
-   * @param appName the name of the app
-   */
-  UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName);
-
-  /**
    * Lists all apps the user creates in the given workspace GCP project
    *
    * @param googleProjectId the GCP project the app belongs to

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -32,7 +32,6 @@ import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.DisksApi;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.GetAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.UpdateDiskRequest;
@@ -675,15 +674,6 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
               leonardoCreateAppRequest);
           return null;
         });
-  }
-
-  @Override
-  public UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName) {
-    AppsApi appsApi = appsApiProvider.get();
-
-    GetAppResponse response =
-        leonardoRetryHandler.run(context -> appsApi.getApp(googleProjectId, appName));
-    return leonardoMapper.toApiApp(response);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -681,9 +681,9 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   public UserAppEnvironment getAppByNameByProjectId(String googleProjectId, String appName) {
     AppsApi appsApi = appsApiProvider.get();
 
-    GetAppResponse leonardoGetAppResponse =
-        leonardoRetryHandler.run((context) -> appsApi.getApp(googleProjectId, appName));
-    return leonardoMapper.toApiApp(leonardoGetAppResponse);
+    GetAppResponse response =
+        leonardoRetryHandler.run(context -> appsApi.getApp(googleProjectId, appName));
+    return leonardoMapper.toApiApp(response);
   }
 
   @Override
@@ -703,7 +703,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
       String googleProjectId, AppsApi appsApi, String leonardoAppRole) {
     List<ListAppResponse> listAppResponses =
         leonardoRetryHandler.run(
-            (context) ->
+            context ->
                 appsApi.listAppByProject(
                     googleProjectId,
                     /* labels= */ null,
@@ -711,7 +711,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
                     /* includeLabels= */ LEONARDO_APP_LABEL_KEYS,
                     leonardoAppRole));
 
-    return listAppResponses.stream().map(leonardoMapper::toApiApp).collect(Collectors.toList());
+    return listAppResponses.stream().map(leonardoMapper::toApiApp).toList();
   }
 
   @Override
@@ -720,7 +720,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     AppsApi appsApi = appsApiProvider.get();
 
     leonardoRetryHandler.run(
-        (context) -> {
+        context -> {
           appsApi.deleteApp(dbWorkspace.getGoogleProject(), appName, deleteDisk);
           return null;
         });
@@ -744,7 +744,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     AppsApi appsApiAsService = serviceAppsApiProvider.get();
     List<ListAppResponse> apps =
         leonardoRetryHandler.run(
-            (context) ->
+            context ->
                 appsApiAsService.listApp(
                     /* labels= */ LEONARDO_LABEL_CREATED_BY + "=" + userEmail,
                     /* includeDeleted= */ false,

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoConfig.java
@@ -7,11 +7,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient;
+import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.DisksApi;
 import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.legacy_leonardo_client.api.AppsApi;
 import org.pmiops.workbench.legacy_leonardo_client.api.ResourcesApi;
 import org.pmiops.workbench.legacy_leonardo_client.api.RuntimesApi;
 import org.pmiops.workbench.legacy_leonardo_client.api.ServiceInfoApi;
@@ -196,9 +196,7 @@ public class LeonardoConfig {
 
   @Bean(name = USER_APPS_API)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public AppsApi appsApi(
-      @Qualifier(LEGACY_USER_LEONARDO_CLIENT)
-          org.pmiops.workbench.legacy_leonardo_client.ApiClient apiClient) {
+  public AppsApi appsApi(@Qualifier(USER_LEONARDO_CLIENT) ApiClient apiClient) {
     AppsApi api = new AppsApi();
     api.setApiClient(apiClient);
     return api;
@@ -206,9 +204,7 @@ public class LeonardoConfig {
 
   @Bean(name = SERVICE_APPS_API)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public AppsApi serviceAppsApi(
-      @Qualifier(LEGACY_SERVICE_LEONARDO_CLIENT)
-          org.pmiops.workbench.legacy_leonardo_client.ApiClient apiClient) {
+  public AppsApi serviceAppsApi(@Qualifier(SERVICE_LEONARDO_CLIENT) ApiClient apiClient) {
     AppsApi api = new AppsApi();
     api.setApiClient(apiClient);
     return api;

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -216,7 +216,7 @@ public interface LeonardoMapper {
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "cloudContextToGoogleProject")
-  @Mapping(target = "appType", source = "labels")
+  @Mapping(target = "appType", source = "labels", qualifiedByName = "mapAppType")
   @Mapping(target = "autopauseThreshold", ignore = true)
   UserAppEnvironment toApiApp(GetAppResponse app);
 
@@ -227,7 +227,7 @@ public interface LeonardoMapper {
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "cloudContextToGoogleProject")
-  @Mapping(target = "appType", source = "labels")
+  @Mapping(target = "appType", source = "labels", qualifiedByName = "mapAppType")
   @Mapping(target = "autopauseThreshold", ignore = true)
   UserAppEnvironment toApiApp(ListAppResponse app);
 
@@ -252,6 +252,7 @@ public interface LeonardoMapper {
   @ValueMapping(source = "BALANCED", target = MappingConstants.NULL)
   DiskType toDiskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType diskType);
 
+  @Named("mapAppType")
   default AppType mapAppType(@Nullable Object appLabels) {
     return LeonardoLabelHelper.maybeMapLeonardoLabelsToGkeApp(appLabels)
         .orElseThrow(

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -7,8 +7,11 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AllowedChartName;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.GetAppResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -18,8 +21,6 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.ValueMapping;
 import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAllowedChartName;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAppType;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoClusterError;
@@ -29,11 +30,9 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoKubernetesRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoMachineConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeImage;
@@ -99,8 +98,9 @@ public interface LeonardoMapper {
   @Mapping(target = "labels", ignore = true)
   PersistentDiskRequest diskConfigToPersistentDiskRequest(LeonardoDiskConfig leonardoDiskConfig);
 
-  LeonardoPersistentDiskRequest toLeonardoPersistentDiskRequest(
-      PersistentDiskRequest persistentDiskRequest);
+  @Mapping(target = "additionalProperties", ignore = true)
+  org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest
+      toLeonardoPersistentDiskRequest(PersistentDiskRequest persistentDiskRequest);
 
   @Mapping(target = "bootDiskSize", ignore = true)
   @Mapping(target = "cloudService", constant = "GCE")
@@ -212,10 +212,10 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "legacy_cloudContextToGoogleProject")
+      qualifiedByName = "cloudContextToGoogleProject")
   @Mapping(target = "autopauseThreshold", ignore = true)
   @Mapping(target = "appType", ignore = true)
-  UserAppEnvironment toApiApp(LeonardoGetAppResponse app);
+  UserAppEnvironment toApiApp(GetAppResponse app);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
@@ -224,24 +224,27 @@ public interface LeonardoMapper {
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
-      qualifiedByName = "legacy_cloudContextToGoogleProject")
+      qualifiedByName = "cloudContextToGoogleProject")
   @Mapping(target = "appType", ignore = true)
-  UserAppEnvironment toApiApp(LeonardoListAppResponse app);
+  UserAppEnvironment toApiApp(ListAppResponse app);
 
   KubernetesRuntimeConfig toKubernetesRuntimeConfig(
-      LeonardoKubernetesRuntimeConfig leonardoKubernetesRuntimeConfig);
+      org.broadinstitute.dsde.workbench.client.leonardo.model.KubernetesRuntimeConfig
+          leonardoKubernetesRuntimeConfig);
 
-  LeonardoKubernetesRuntimeConfig toLeonardoKubernetesRuntimeConfig(
-      KubernetesRuntimeConfig kubernetesRuntimeConfig);
+  @Mapping(target = "additionalProperties", ignore = true)
+  org.broadinstitute.dsde.workbench.client.leonardo.model.KubernetesRuntimeConfig
+      toLeonardoKubernetesRuntimeConfig(KubernetesRuntimeConfig kubernetesRuntimeConfig);
 
   // SAS and RStudio apps are implemented as ALLOWED Helm Charts
   @ValueMapping(source = "RSTUDIO", target = "ALLOWED")
   @ValueMapping(source = "SAS", target = "ALLOWED")
-  LeonardoAppType toLeonardoAppType(AppType appType);
+  org.broadinstitute.dsde.workbench.client.leonardo.model.AppType toLeonardoAppType(
+      AppType appType);
 
   // Cromwell is not an ALLOWED Helm Chart in Leonardo
   @ValueMapping(source = "CROMWELL", target = MappingConstants.NULL)
-  LeonardoAllowedChartName toLeonardoAllowedChartName(AppType appType);
+  AllowedChartName toLeonardoAllowedChartName(AppType appType);
 
   @ValueMapping(source = "BALANCED", target = MappingConstants.NULL)
   DiskType toDiskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType diskType);

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AllowedChartName;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.GetAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.mapstruct.AfterMapping;
@@ -207,18 +206,6 @@ public interface LeonardoMapper {
         leonardoListRuntimeResponse.getRuntimeConfig(),
         leonardoListRuntimeResponse.getDiskConfig());
   }
-
-  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
-  @Mapping(target = "creator", source = "auditInfo.creator")
-  @Mapping(target = "appName", source = "appName")
-  @Mapping(
-      target = "googleProject",
-      source = "cloudContext",
-      qualifiedByName = "cloudContextToGoogleProject")
-  @Mapping(target = "appType", source = "labels", qualifiedByName = "mapAppType")
-  @Mapping(target = "autopauseThreshold", ignore = true)
-  UserAppEnvironment toApiApp(GetAppResponse app);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -25,12 +25,9 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoClusterError;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskStatus;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListAppResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoMachineConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
@@ -159,28 +156,30 @@ public interface LeonardoMapper {
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "toolDockerImage", source = "runtimeImages")
-  @Mapping(target = "configurationType", ignore = true)
-  @Mapping(target = "gceConfig", ignore = true)
-  @Mapping(target = "gceWithPdConfig", ignore = true)
-  @Mapping(target = "dataprocConfig", ignore = true)
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "legacy_cloudContextToGoogleProject")
+  // these 4 set by getRuntimeAfterMapper()
+  @Mapping(target = "configurationType", ignore = true)
+  @Mapping(target = "gceConfig", ignore = true)
+  @Mapping(target = "gceWithPdConfig", ignore = true)
+  @Mapping(target = "dataprocConfig", ignore = true)
   Runtime toApiRuntime(LeonardoGetRuntimeResponse runtime);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "autopauseThreshold", ignore = true)
-  @Mapping(target = "toolDockerImage", ignore = true)
-  @Mapping(target = "configurationType", ignore = true)
-  @Mapping(target = "gceConfig", ignore = true)
-  @Mapping(target = "gceWithPdConfig", ignore = true)
-  @Mapping(target = "dataprocConfig", ignore = true)
-  @Mapping(target = "errors", ignore = true)
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "legacy_cloudContextToGoogleProject")
+  @Mapping(target = "autopauseThreshold", ignore = true)
+  @Mapping(target = "toolDockerImage", ignore = true)
+  @Mapping(target = "errors", ignore = true)
+  // these 4 set by getRuntimeAfterMapper()
+  @Mapping(target = "configurationType", ignore = true)
+  @Mapping(target = "gceConfig", ignore = true)
+  @Mapping(target = "gceWithPdConfig", ignore = true)
+  @Mapping(target = "dataprocConfig", ignore = true)
   Runtime toApiRuntime(LeonardoListRuntimeResponse runtime);
 
   RuntimeError toApiRuntimeError(LeonardoClusterError err);
@@ -214,6 +213,7 @@ public interface LeonardoMapper {
       source = "cloudContext",
       qualifiedByName = "cloudContextToGoogleProject")
   @Mapping(target = "autopauseThreshold", ignore = true)
+  // set by getAppAfterMapper()
   @Mapping(target = "appType", ignore = true)
   UserAppEnvironment toApiApp(GetAppResponse app);
 
@@ -225,6 +225,7 @@ public interface LeonardoMapper {
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "cloudContextToGoogleProject")
+  // set by listAppsAfterMapper()
   @Mapping(target = "appType", ignore = true)
   UserAppEnvironment toApiApp(ListAppResponse app);
 
@@ -251,13 +252,13 @@ public interface LeonardoMapper {
 
   @AfterMapping
   default void listAppsAfterMapper(
-      @MappingTarget UserAppEnvironment appEnvironment, LeonardoListAppResponse listAppResponse) {
+      @MappingTarget UserAppEnvironment appEnvironment, ListAppResponse listAppResponse) {
     setAppType(appEnvironment, listAppResponse.getLabels());
   }
 
   @AfterMapping
   default void getAppAfterMapper(
-      @MappingTarget UserAppEnvironment appEnvironment, LeonardoGetAppResponse getAppResponse) {
+      @MappingTarget UserAppEnvironment appEnvironment, GetAppResponse getAppResponse) {
     setAppType(appEnvironment, getAppResponse.getLabels());
   }
 
@@ -325,7 +326,8 @@ public interface LeonardoMapper {
     return RuntimeStatus.fromValue(leonardoRuntimeStatus.toString());
   }
 
-  default DiskStatus toApiDiskStatus(LeonardoDiskStatus leonardoDiskStatus) {
+  default DiskStatus toApiDiskStatus(
+      org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus leonardoDiskStatus) {
     if (leonardoDiskStatus == null) {
       return DiskStatus.UNKNOWN;
     }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -175,13 +175,13 @@ public interface LeonardoMapper {
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "legacy_cloudContextToGoogleProject")
-  @Mapping(target = "autopauseThreshold", ignore = true)
-  @Mapping(target = "toolDockerImage", ignore = true)
-  @Mapping(target = "errors", ignore = true)
   @Mapping(
       target = "configurationType",
       source = "labels",
       qualifiedByName = "mapRuntimeConfigurationLabels")
+  @Mapping(target = "autopauseThreshold", ignore = true)
+  @Mapping(target = "toolDockerImage", ignore = true)
+  @Mapping(target = "errors", ignore = true)
   // these 3 set by listRuntimeAfterMapper()
   @Mapping(target = "gceConfig", ignore = true)
   @Mapping(target = "gceWithPdConfig", ignore = true)

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -943,44 +943,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: app
   /v1/workspaces/{workspaceNamespace}/apps/{appName}:
-    get:
-      tags:
-      - apps
-      summary: Get the user's app by name in a workspace.
-      description: Returns the current user's app by name in a workspace if exists.
-      operationId: getApp
-      parameters:
-      - name: workspaceNamespace
-        in: path
-        description: The Workspace namespace
-        required: true
-        schema:
-          type: string
-      - name: appName
-        in: path
-        description: The name of the user app.
-        required: true
-        schema:
-          type: string
-      responses:
-        200:
-          description: The user app for this user and workspace.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserAppEnvironment'
-        404:
-          description: No user app exists for this user and workspace.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        412:
-          description: Compute is temporarily suspended for security reasons.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
     delete:
       tags:
       - apps

--- a/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/AppsControllerTest.java
@@ -133,12 +133,6 @@ public class AppsControllerTest {
   }
 
   @Test
-  public void testGetAppSuccess() {
-    controller.getApp(WORKSPACE_NS, APP_NAME);
-    verify(mockLeonardoApiClient).getAppByNameByProjectId(GOOGLE_PROJECT_ID, APP_NAME);
-  }
-
-  @Test
   public void testListAppSuccess() {
     controller.listAppsInWorkspace(WORKSPACE_NS);
     verify(mockLeonardoApiClient).listAppsInProjectCreatedByCreator(GOOGLE_PROJECT_ID);

--- a/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
+++ b/api/src/test/java/org/pmiops/workbench/leonardo/LeonardoApiClientTest.java
@@ -368,12 +368,6 @@ public class LeonardoApiClientTest {
   }
 
   @Test
-  public void testGetAppSuccess() throws Exception {
-    leonardoApiClient.getAppByNameByProjectId(GOOGLE_PROJECT_ID, getAppName(AppType.RSTUDIO));
-    verify(mockUserAppsApi).getApp(GOOGLE_PROJECT_ID, getAppName(AppType.RSTUDIO));
-  }
-
-  @Test
   public void testListAppSuccess() throws Exception {
     leonardoApiClient.listAppsInProjectCreatedByCreator(GOOGLE_PROJECT_ID);
     verify(mockUserAppsApi)

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AllowedChartName;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
@@ -19,10 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAllowedChartName;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAppType;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoDiskType;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoPersistentDiskRequest;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
@@ -52,7 +49,8 @@ public class LeonardoMapperTest {
   private org.broadinstitute.dsde.workbench.client.leonardo.model.KubernetesRuntimeConfig
       leonardoKubernetesRuntimeConfig;
   private PersistentDiskRequest persistentDiskRequest;
-  private LeonardoPersistentDiskRequest leonardoPersistentDiskRequest;
+  private org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest
+      leonardoPersistentDiskRequest;
   private AuditInfo leonardoAuditInfo;
   private List<KubernetesError> kubernetesErrors = new ArrayList<>();
   private List<org.broadinstitute.dsde.workbench.client.leonardo.model.KubernetesError>
@@ -84,7 +82,9 @@ public class LeonardoMapperTest {
             .machineType(MACHINE_TYPE);
     persistentDiskRequest = new PersistentDiskRequest().diskType(DiskType.STANDARD).size(10);
     leonardoPersistentDiskRequest =
-        new LeonardoPersistentDiskRequest().diskType(LeonardoDiskType.STANDARD).size(10);
+        new org.broadinstitute.dsde.workbench.client.leonardo.model.PersistentDiskRequest()
+            .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD)
+            .size(10);
     leonardoAuditInfo =
         new AuditInfo()
             .createdDate("2022-10-10")
@@ -144,17 +144,19 @@ public class LeonardoMapperTest {
 
   @Test
   public void testToLeonardoAppType() {
-    assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO)).isEqualTo(LeonardoAppType.ALLOWED);
-    assertThat(mapper.toLeonardoAppType(AppType.SAS)).isEqualTo(LeonardoAppType.ALLOWED);
-    assertThat(mapper.toLeonardoAppType(AppType.CROMWELL)).isEqualTo(LeonardoAppType.CROMWELL);
+    assertThat(mapper.toLeonardoAppType(AppType.RSTUDIO))
+        .isEqualTo(org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.ALLOWED);
+    assertThat(mapper.toLeonardoAppType(AppType.SAS))
+        .isEqualTo(org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.ALLOWED);
+    assertThat(mapper.toLeonardoAppType(AppType.CROMWELL))
+        .isEqualTo(org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.CROMWELL);
   }
 
   @Test
   public void testToLeonardoAllowedAppChart() {
     assertThat(mapper.toLeonardoAllowedChartName(AppType.RSTUDIO))
-        .isEqualTo(LeonardoAllowedChartName.RSTUDIO);
-    assertThat(mapper.toLeonardoAllowedChartName(AppType.SAS))
-        .isEqualTo(LeonardoAllowedChartName.SAS);
+        .isEqualTo(AllowedChartName.RSTUDIO);
+    assertThat(mapper.toLeonardoAllowedChartName(AppType.SAS)).isEqualTo(AllowedChartName.SAS);
     assertThat(mapper.toLeonardoAllowedChartName(AppType.CROMWELL)).isNull();
   }
 

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.AllowedChartName;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.GetAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,29 +155,6 @@ public class LeonardoMapperTest {
         .isEqualTo(AllowedChartName.RSTUDIO);
     assertThat(mapper.toLeonardoAllowedChartName(AppType.SAS)).isEqualTo(AllowedChartName.SAS);
     assertThat(mapper.toLeonardoAllowedChartName(AppType.CROMWELL)).isNull();
-  }
-
-  @ParameterizedTest(name = "appType {0} can be mapped for getApp call")
-  @MethodSource("allAppTypesMap")
-  public void testToAppFromGetResponse(
-      AppType apiAppType,
-      org.broadinstitute.dsde.workbench.client.leonardo.model.AppType leoAppType) {
-    labels.put(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
-
-    GetAppResponse getAppResponse =
-        new GetAppResponse()
-            .appType(leoAppType)
-            .status(org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus.RUNNING)
-            .auditInfo(leonardoAuditInfo)
-            .diskName(DISK_NAME)
-            .kubernetesRuntimeConfig(leonardoKubernetesRuntimeConfig)
-            .appName(APP_NAME)
-            .errors(leonardoKubernetesErrors)
-            .proxyUrls(proxyUrls)
-            .cloudContext(
-                new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(GOOGLE_PROJECT))
-            .labels(labels);
-    assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app.appType(apiAppType));
   }
 
   @ParameterizedTest(name = "appType {0} can be mapped for listApp call")

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
@@ -164,7 +163,7 @@ public class LeonardoMapperTest {
   public void testToAppFromGetResponse(
       AppType apiAppType,
       org.broadinstitute.dsde.workbench.client.leonardo.model.AppType leoAppType) {
-    labels.put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
+    labels.put(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
 
     GetAppResponse getAppResponse =
         new GetAppResponse()
@@ -187,7 +186,7 @@ public class LeonardoMapperTest {
   public void testToAppFromListResponse(
       AppType apiAppType,
       org.broadinstitute.dsde.workbench.client.leonardo.model.AppType leoAppType) {
-    labels.put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
+    labels.put(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
     ListAppResponse listAppResponse =
         new ListAppResponse()
             .appType(leoAppType)

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDis
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
 import org.pmiops.workbench.model.AppStatus;
@@ -58,17 +59,15 @@ public class LeonardoMapperTest {
   private Map<String, String> proxyUrls = new HashMap<>();
   private Map<String, String> labels = new HashMap<>();
 
-  private static Stream<
-          Map.Entry<AppType, org.broadinstitute.dsde.workbench.client.leonardo.model.AppType>>
-      allAppTypesMap() {
+  private static Stream<Arguments> allAppTypesMap() {
     return Stream.of(
-        Map.entry(
+        Arguments.of(
             AppType.CROMWELL,
             org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.CROMWELL),
-        Map.entry(
+        Arguments.of(
             AppType.RSTUDIO,
             org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.ALLOWED),
-        Map.entry(
+        Arguments.of(
             AppType.SAS, org.broadinstitute.dsde.workbench.client.leonardo.model.AppType.ALLOWED));
   }
 
@@ -163,14 +162,13 @@ public class LeonardoMapperTest {
   @ParameterizedTest(name = "appType {0} can be mapped for getApp call")
   @MethodSource("allAppTypesMap")
   public void testToAppFromGetResponse(
-      Map.Entry<AppType, org.broadinstitute.dsde.workbench.client.leonardo.model.AppType>
-          appTypeMapEntry) {
-    labels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appTypeMapEntry.getKey()));
+      AppType apiAppType,
+      org.broadinstitute.dsde.workbench.client.leonardo.model.AppType leoAppType) {
+    labels.put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
 
     GetAppResponse getAppResponse =
         new GetAppResponse()
-            .appType(appTypeMapEntry.getValue())
+            .appType(leoAppType)
             .status(org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus.RUNNING)
             .auditInfo(leonardoAuditInfo)
             .diskName(DISK_NAME)
@@ -181,19 +179,18 @@ public class LeonardoMapperTest {
             .cloudContext(
                 new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(GOOGLE_PROJECT))
             .labels(labels);
-    assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app.appType(appTypeMapEntry.getKey()));
+    assertThat(mapper.toApiApp(getAppResponse)).isEqualTo(app.appType(apiAppType));
   }
 
   @ParameterizedTest(name = "appType {0} can be mapped for listApp call")
   @MethodSource("allAppTypesMap")
   public void testToAppFromListResponse(
-      Map.Entry<AppType, org.broadinstitute.dsde.workbench.client.leonardo.model.AppType>
-          appTypeMapEntry) {
-    labels.put(
-        LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(appTypeMapEntry.getKey()));
+      AppType apiAppType,
+      org.broadinstitute.dsde.workbench.client.leonardo.model.AppType leoAppType) {
+    labels.put(LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(apiAppType));
     ListAppResponse listAppResponse =
         new ListAppResponse()
-            .appType(appTypeMapEntry.getValue())
+            .appType(leoAppType)
             .status(org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus.RUNNING)
             .auditInfo(leonardoAuditInfo)
             .diskName(DISK_NAME)
@@ -204,7 +201,7 @@ public class LeonardoMapperTest {
             .appName(APP_NAME)
             .cloudContext(
                 new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(GOOGLE_PROJECT));
-    assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app.appType(appTypeMapEntry.getKey()));
+    assertThat(mapper.toApiApp(listAppResponse)).isEqualTo(app.appType(apiAppType));
   }
 
   @Test


### PR DESCRIPTION
Tested these calls from local UI to confirm that they function as expected:
* createApp
* listAppsInWorkspace
* deleteApp
* cron checkPersistentDisks (listAppsInProjectAsService)
* WorkspaceAdminController adminListUserAppsInWorkspace (listAppsInProjectAsService)

Removed because unused:
* getApp

TODO - I can't seem to trigger egress locally
* EgressRemediationService stopUserRuntimesAndApps (deleteUserAppsAsService)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
