### PR TITLE
[RW-13732][risk=no] Added api changes for user initial credit bypass

### DIFF
--- a/api/db/changelog/db.changelog-237-add-default-user-initial-credits-expiration-bypassed.xml
+++ b/api/db/changelog/db.changelog-237-add-default-user-initial-credits-expiration-bypassed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="evrii" id="db.changelog-237-add-default-user-initial-credits-expiration-bypassed">
+    <addDefaultValue tableName="user_initial_credits_expiration" columnName="bypassed" defaultValueBoolean="false"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -244,6 +244,7 @@
   <include file="changelog/db.changelog-234-add-institution-initial-credit-expiration-bypass.xml"/>
   <include file="changelog/db.changelog-235-replace-workspace-billing-status.xml"/>
   <include file="changelog/db.changelog-236-add-uses-tanagra.xml"/>
+  <include file="changelog/db.changelog-237-add-default-user-initial-credits-expiration-bypassed.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -16,11 +16,11 @@ import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Institution;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +36,7 @@ public class AccessSyncServiceImpl implements AccessSyncService {
   private final AccessModuleService accessModuleService;
   private final InstitutionService institutionService;
   private final UserDao userDao;
-  private final UserService userService;
+  private final InitialCreditsExpirationService initialCreditsExpirationServiceImpl;
   private final UserServiceAuditor userServiceAuditor;
 
   @Autowired
@@ -46,14 +46,14 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       AccessModuleService accessModuleService,
       InstitutionService institutionService,
       UserDao userDao,
-      UserService userService,
+      InitialCreditsExpirationService initialCreditsExpirationServiceImpl,
       UserServiceAuditor userServiceAuditor) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.accessTierService = accessTierService;
     this.accessModuleService = accessModuleService;
     this.institutionService = institutionService;
     this.userDao = userDao;
-    this.userService = userService;
+    this.initialCreditsExpirationServiceImpl = initialCreditsExpirationServiceImpl;
     this.userServiceAuditor = userServiceAuditor;
   }
 
@@ -97,7 +97,7 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       if (previousAccessTiers.isEmpty()
           && !newAccessTiers.isEmpty()
           && null == maybeCreditsExpiration) {
-        userService.createInitialCreditsExpiration(dbUser);
+        initialCreditsExpirationServiceImpl.createInitialCreditsExpiration(dbUser);
       }
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -6,19 +6,17 @@ import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForContr
 import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForRegisteredTierAccess;
 
 import jakarta.inject.Provider;
-import java.sql.Timestamp;
-import java.time.Clock;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.javers.common.collections.Lists;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
@@ -38,8 +36,8 @@ public class AccessSyncServiceImpl implements AccessSyncService {
   private final AccessModuleService accessModuleService;
   private final InstitutionService institutionService;
   private final UserDao userDao;
+  private final UserService userService;
   private final UserServiceAuditor userServiceAuditor;
-  private final Clock clock;
 
   @Autowired
   public AccessSyncServiceImpl(
@@ -48,15 +46,15 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       AccessModuleService accessModuleService,
       InstitutionService institutionService,
       UserDao userDao,
-      UserServiceAuditor userServiceAuditor,
-      Clock clock) {
+      UserService userService,
+      UserServiceAuditor userServiceAuditor) {
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.accessTierService = accessTierService;
     this.accessModuleService = accessModuleService;
     this.institutionService = institutionService;
     this.userDao = userDao;
+    this.userService = userService;
     this.userServiceAuditor = userServiceAuditor;
-    this.clock = clock;
   }
 
   /**
@@ -90,8 +88,6 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       DbUser dbUser, List<DbAccessTier> previousAccessTiers, List<DbAccessTier> newAccessTiers) {
     boolean enableInitialCreditsExpiration =
         workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration;
-    long initialCreditsValidityPeriodDays =
-        workbenchConfigProvider.get().billing.initialCreditsValidityPeriodDays;
 
     if (enableInitialCreditsExpiration) {
       DbUserInitialCreditsExpiration maybeCreditsExpiration =
@@ -101,15 +97,7 @@ public class AccessSyncServiceImpl implements AccessSyncService {
       if (previousAccessTiers.isEmpty()
           && !newAccessTiers.isEmpty()
           && null == maybeCreditsExpiration) {
-
-        Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-        Timestamp expirationTime =
-            new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(initialCreditsValidityPeriodDays));
-        dbUser.setUserInitialCreditsExpiration(
-            new DbUserInitialCreditsExpiration()
-                .setUser(dbUser)
-                .setCreditStartTime(now)
-                .setExpirationTime(expirationTime));
+        userService.createInitialCreditsExpiration(dbUser);
       }
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
@@ -172,8 +171,4 @@ public interface UserService {
   void signOut(DbUser user);
 
   boolean isServiceAccount(DbUser user);
-
-  DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user);
-
-  void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -11,6 +11,7 @@ import org.pmiops.workbench.db.model.DbAddress;
 import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.Degree;
@@ -171,4 +172,8 @@ public interface UserService {
   void signOut(DbUser user);
 
   boolean isServiceAccount(DbUser user);
+
+  DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user);
+
+  void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -37,8 +37,6 @@ import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
-import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
-import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration.NotificationStatus;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -740,33 +738,6 @@ public class UserServiceImpl implements UserService {
   @Override
   public void signOut(DbUser user) {
     directoryService.signOut(user.getUsername());
-  }
-
-  @Override
-  public DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user) {
-    long initialCreditsValidityPeriodDays =
-        configProvider.get().billing.initialCreditsValidityPeriodDays;
-    Timestamp now = clockNow();
-    Timestamp expirationTime =
-        new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(initialCreditsValidityPeriodDays));
-    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
-        new DbUserInitialCreditsExpiration()
-            .setCreditStartTime(now)
-            .setExpirationTime(expirationTime)
-            .setUser(user)
-            .setNotificationStatus(NotificationStatus.NO_NOTIFICATION_SENT);
-    user.setUserInitialCreditsExpiration(userInitialCreditsExpiration);
-    return userInitialCreditsExpiration;
-  }
-
-  @Override
-  public void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed) {
-    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
-        user.getUserInitialCreditsExpiration();
-    if (userInitialCreditsExpiration == null) {
-      userInitialCreditsExpiration = createInitialCreditsExpiration(user);
-    }
-    userInitialCreditsExpiration.setBypassed(isBypassed);
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -37,6 +37,8 @@ import org.pmiops.workbench.db.model.DbDemographicSurvey;
 import org.pmiops.workbench.db.model.DbDemographicSurveyV2;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration.NotificationStatus;
 import org.pmiops.workbench.db.model.DbUserTermsOfService;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -738,6 +740,33 @@ public class UserServiceImpl implements UserService {
   @Override
   public void signOut(DbUser user) {
     directoryService.signOut(user.getUsername());
+  }
+
+  @Override
+  public DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user) {
+    long initialCreditsValidityPeriodDays =
+        configProvider.get().billing.initialCreditsValidityPeriodDays;
+    Timestamp now = clockNow();
+    Timestamp expirationTime =
+        new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(initialCreditsValidityPeriodDays));
+    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
+        new DbUserInitialCreditsExpiration()
+            .setCreditStartTime(now)
+            .setExpirationTime(expirationTime)
+            .setUser(user)
+            .setNotificationStatus(NotificationStatus.NO_NOTIFICATION_SENT);
+    user.setUserInitialCreditsExpiration(userInitialCreditsExpiration);
+    return userInitialCreditsExpiration;
+  }
+
+  @Override
+  public void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed) {
+    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
+        user.getUserInitialCreditsExpiration();
+    if (userInitialCreditsExpiration == null) {
+      userInitialCreditsExpiration = createInitialCreditsExpiration(user);
+    }
+    userInitialCreditsExpiration.setBypassed(isBypassed);
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationService.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 
 public interface InitialCreditsExpirationService {
   Optional<Timestamp> getCreditsExpiration(DbUser user);
@@ -11,4 +12,8 @@ public interface InitialCreditsExpirationService {
   void checkCreditsExpirationForUserIDs(List<Long> userIdsList);
 
   boolean haveCreditsExpired(DbUser user);
+
+  DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user);
+
+  void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed);
 }

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -6,6 +6,7 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
@@ -77,6 +78,34 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
         .orElse(false);
   }
 
+  @Override
+  public DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user) {
+    long initialCreditsValidityPeriodDays =
+        workbenchConfigProvider.get().billing.initialCreditsValidityPeriodDays;
+    Timestamp now = clockNow();
+    Timestamp expirationTime =
+        new Timestamp(now.getTime() + TimeUnit.DAYS.toMillis(initialCreditsValidityPeriodDays));
+    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
+        new DbUserInitialCreditsExpiration()
+            .setCreditStartTime(now)
+            .setExpirationTime(expirationTime)
+            .setUser(user)
+            .setNotificationStatus(NotificationStatus.NO_NOTIFICATION_SENT);
+    user.setUserInitialCreditsExpiration(userInitialCreditsExpiration);
+    return userInitialCreditsExpiration;
+  }
+
+  @Override
+  public void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed) {
+    DbUserInitialCreditsExpiration userInitialCreditsExpiration =
+        user.getUserInitialCreditsExpiration();
+    if (userInitialCreditsExpiration == null) {
+      userInitialCreditsExpiration = createInitialCreditsExpiration(user);
+    }
+    userInitialCreditsExpiration.setBypassed(isBypassed);
+  }
+
+
   private void checkExpiration(DbUser user) {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
@@ -137,5 +166,9 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
     } catch (WorkbenchException e) {
       logger.error("Failed to delete apps and runtimes for workspace {}", namespace, e);
     }
+  }
+
+  private Timestamp clockNow() {
+    return new Timestamp(clock.instant().toEpochMilli());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsExpirationServiceImpl.java
@@ -105,7 +105,6 @@ public class InitialCreditsExpirationServiceImpl implements InitialCreditsExpira
     userInitialCreditsExpiration.setBypassed(isBypassed);
   }
 
-
   private void checkExpiration(DbUser user) {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();

--- a/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
@@ -9,7 +9,9 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(config = MapStructConfig.class)
 public interface PublicInstitutionDetailsMapper {
-  @Mapping(target = "institutionalInitialCreditsExpirationBypassed", source = "dbObject.bypassInitialCreditsExpiration")
+  @Mapping(
+      target = "institutionalInitialCreditsExpirationBypassed",
+      source = "dbObject.bypassInitialCreditsExpiration")
   PublicInstitutionDetails dbToModel(
       DbInstitution dbObject, MembershipRequirement registeredTierMembershipRequirement);
 }

--- a/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapper.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.institution;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.pmiops.workbench.db.model.DbInstitution;
 import org.pmiops.workbench.db.model.DbInstitutionTierRequirement.MembershipRequirement;
 import org.pmiops.workbench.model.PublicInstitutionDetails;
@@ -8,6 +9,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 
 @Mapper(config = MapStructConfig.class)
 public interface PublicInstitutionDetailsMapper {
+  @Mapping(target = "institutionalInitialCreditsExpirationBypassed", source = "dbObject.bypassInitialCreditsExpiration")
   PublicInstitutionDetails dbToModel(
       DbInstitution dbObject, MembershipRequirement registeredTierMembershipRequirement);
 }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -46,6 +46,10 @@ public interface ProfileMapper {
       target = "initialCreditsExpirationEpochMillis",
       source = "dbUser",
       qualifiedByName = "getInitialCreditsExpiration")
+  @Mapping(
+      source = "dbUser.userInitialCreditsExpiration.bypassed",
+      target = "initialCreditsExpirationBypassed",
+      defaultValue = "false")
   Profile toModel(
       DbUser dbUser,
       @Context InitialCreditsExpirationService expirationService,

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -257,7 +257,7 @@ public class ProfileService {
         configProvider.get().featureFlags.enableInitialCreditsExpiration;
 
     if (enableInitialCreditsExpiration) {
-      userService.setInitialCreditsExpirationBypassed(
+      initialCreditsExpirationService.setInitialCreditsExpirationBypassed(
           user,
           Optional.ofNullable(updatedProfile.isInitialCreditsExpirationBypassed()).orElse(false));
     }

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -21,6 +21,7 @@ import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.ProfileAuditor;
 import org.pmiops.workbench.billing.FreeTierBillingService;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.InstitutionDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserService;
@@ -72,6 +73,7 @@ public class ProfileService {
   private final ProfileAuditor profileAuditor;
   private final ProfileMapper profileMapper;
   private final Provider<DbUser> userProvider;
+  private final Provider<WorkbenchConfig> configProvider;
   private final UserDao userDao;
   private final UserService userService;
   private final UserTermsOfServiceDao userTermsOfServiceDao;
@@ -93,6 +95,7 @@ public class ProfileService {
       ProfileAuditor profileAuditor,
       ProfileMapper profileMapper,
       Provider<DbUser> userProvider,
+      Provider<WorkbenchConfig> configProvider,
       UserDao userDao,
       UserService userService,
       UserTermsOfServiceDao userTermsOfServiceDao,
@@ -112,6 +115,7 @@ public class ProfileService {
     this.profileAuditor = profileAuditor;
     this.profileMapper = profileMapper;
     this.userProvider = userProvider;
+    this.configProvider = configProvider;
     this.userDao = userDao;
     this.userService = userService;
     this.userTermsOfServiceDao = userTermsOfServiceDao;
@@ -248,6 +252,15 @@ public class ProfileService {
     user.setAreaOfResearch(updatedProfile.getAreaOfResearch());
     user.setProfessionalUrl(updatedProfile.getProfessionalUrl());
     user.setAddress(addressMapper.addressToDbAddress(updatedProfile.getAddress()));
+
+    boolean enableInitialCreditsExpiration =
+        configProvider.get().featureFlags.enableInitialCreditsExpiration;
+
+    if (enableInitialCreditsExpiration) {
+      userService.setInitialCreditsExpirationBypassed(
+          user,
+          Optional.ofNullable(updatedProfile.isInitialCreditsExpirationBypassed()).orElse(false));
+    }
     // Address may be null for users who were created before address validation was in place. See
     // RW-5139.
     Optional.ofNullable(user.getAddress()).ifPresent(address -> address.setUser(user));
@@ -561,6 +574,12 @@ public class ProfileService {
         .map(AccountDisabledStatus::isDisabled)
         .ifPresent(updatedProfile::setDisabled);
 
+    boolean enableInitialCreditsExpiration =
+        configProvider.get().featureFlags.enableInitialCreditsExpiration;
+    if (enableInitialCreditsExpiration) {
+      Optional.ofNullable(request.isInitialCreditsExpirationBypassed())
+          .ifPresent(updatedProfile::setInitialCreditsExpirationBypassed);
+    }
     updateProfile(dbUser, Agent.asAdmin(userProvider.get()), updatedProfile, originalProfile);
 
     return getProfile(dbUser);

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileService.java
@@ -577,8 +577,8 @@ public class ProfileService {
     boolean enableInitialCreditsExpiration =
         configProvider.get().featureFlags.enableInitialCreditsExpiration;
     if (enableInitialCreditsExpiration) {
-      Optional.ofNullable(request.isInitialCreditsExpirationBypassed())
-          .ifPresent(updatedProfile::setInitialCreditsExpirationBypassed);
+      updatedProfile.setInitialCreditsExpirationBypassed(
+          request.isInitialCreditsExpirationBypassed());
     }
     updateProfile(dbUser, Agent.asAdmin(userProvider.get()), updatedProfile, originalProfile);
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8527,6 +8527,8 @@ components:
         initialCreditsExpirationBypassed:
           type: boolean
           default: false
+          description: When set to true, the user will not be required to spend their
+            initial credits within the expiration period.
     AccessModuleStatus:
       required:
       - moduleName

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8524,6 +8524,9 @@ components:
           type: integer
           description: Timestamp indicating when the user's initial credits will expire, if applicable
           format: int64
+        initialCreditsExpirationBypassed:
+          type: boolean
+          default: false
     AccessModuleStatus:
       required:
       - moduleName
@@ -9651,6 +9654,7 @@ components:
       - displayName
       - organizationTypeEnum
       - shortName
+      - institutionalInitialCreditsExpirationBypassed
       type: object
       properties:
         shortName:
@@ -9668,6 +9672,10 @@ components:
         requestAccessUrl:
           type: string
           description: Optional url for institution's handling their own access requests
+        institutionalInitialCreditsExpirationBypassed:
+          type: boolean
+          description: Whether the initial credits expiration has been bypassed
+            for all members of this institution
       description: Represents an institution which has been approved to validate researchers
         who wish to use the system. Does not include the sensitive email patterns
         used to validate users.
@@ -11959,6 +11967,10 @@ components:
             $ref: '#/components/schemas/AccessBypassRequest'
         accountDisabledStatus:
           $ref: '#/components/schemas/AccountDisabledStatus'
+        initialCreditsExpirationBypassed:
+          type: boolean
+          description: When set to true, the user will not be required to spend their
+            initial credits within the expiration period.
       description: |
         A group of changes an admin can make to a user in the Edit Information card of the individual-user admin page. Updates to the contact email or the institutional affiliation will be rejected if they do not validate.
     AccessReason:

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -53,8 +53,7 @@ public class AccessSyncServiceTest {
 
   @Mock UserService userService;
 
-  @Mock
-  InitialCreditsExpirationService initialCreditsExpirationService;
+  @Mock InitialCreditsExpirationService initialCreditsExpirationService;
 
   @Mock UserServiceAuditor userServiceAuditor;
 

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -1,9 +1,9 @@
 package org.pmiops.workbench.access;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
@@ -13,9 +13,7 @@ import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import jakarta.inject.Provider;
 import java.sql.Timestamp;
-import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -27,12 +25,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.pmiops.workbench.actionaudit.Agent;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
@@ -52,11 +50,12 @@ public class AccessSyncServiceTest {
 
   @Mock InstitutionService institutionService;
 
+  @Mock UserService userService;
+
   @Mock UserServiceAuditor userServiceAuditor;
 
   Instant now = Instant.parse("2000-01-01T00:00:00.00Z");
 
-  @Spy Clock clock = Clock.fixed(now, ZoneId.systemDefault());
 
   @InjectMocks private AccessSyncServiceImpl accessSyncService;
 
@@ -72,6 +71,7 @@ public class AccessSyncServiceTest {
         workbenchConfigProvider,
         accessModuleService,
         institutionService,
+        userService,
         userServiceAuditor);
     registeredTier = createRegisteredTier();
     when(accessTierService.getAllTiers()).thenReturn(List.of(registeredTier));
@@ -100,14 +100,6 @@ public class AccessSyncServiceTest {
     when(workbenchConfigProvider.get()).thenReturn(workbenchConfig);
   }
 
-  private void assertCreditExpirationEquality(
-      DbUserInitialCreditsExpiration expected, DbUserInitialCreditsExpiration actual) {
-    assertEquals(expected.getUser(), actual.getUser());
-    assertEquals(expected.getCreditStartTime(), actual.getCreditStartTime());
-    assertEquals(expected.getExpirationTime(), actual.getExpirationTime());
-    assertEquals(expected.getExtensionCount(), actual.getExtensionCount());
-  }
-
   @ParameterizedTest
   @CsvSource({"false", "true"})
   public void testUpdateUserAccessTiers_whenRTGranted(boolean enableInitialCreditsExpiration) {
@@ -117,27 +109,10 @@ public class AccessSyncServiceTest {
     List<DbAccessTier> oldAccessTiers = List.of();
     when(accessTierService.getAccessTiersForUser(dbUser)).thenReturn(oldAccessTiers);
 
-    DbUser updatedUser = accessSyncService.updateUserAccessTiers(dbUser, agent);
+    accessSyncService.updateUserAccessTiers(dbUser, agent);
 
-    DbUserInitialCreditsExpiration expected = new DbUserInitialCreditsExpiration();
-
-    expected.setUser(dbUser);
-
-    if (enableInitialCreditsExpiration) {
-      Timestamp now = new Timestamp(clock.instant().toEpochMilli());
-      Timestamp expirationTime =
-          new Timestamp(
-              now.getTime()
-                  + TimeUnit.DAYS.toMillis(
-                      workbenchConfigProvider.get().billing.initialCreditsValidityPeriodDays));
-      expected.setCreditStartTime(now);
-      expected.setExpirationTime(expirationTime);
-      assertCreditExpirationEquality(expected, dbUser.getUserInitialCreditsExpiration());
-    } else {
-      assertNull(dbUser.getUserInitialCreditsExpiration());
-    }
-
-    assertEquals(updatedUser, dbUser);
+    verify(userService, times(enableInitialCreditsExpiration ? 1 : 0))
+        .createInitialCreditsExpiration(dbUser);
   }
 
   @ParameterizedTest

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -34,6 +34,7 @@ import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.model.Institution;
 
@@ -52,10 +53,12 @@ public class AccessSyncServiceTest {
 
   @Mock UserService userService;
 
+  @Mock
+  InitialCreditsExpirationService initialCreditsExpirationService;
+
   @Mock UserServiceAuditor userServiceAuditor;
 
   Instant now = Instant.parse("2000-01-01T00:00:00.00Z");
-
 
   @InjectMocks private AccessSyncServiceImpl accessSyncService;
 
@@ -111,7 +114,7 @@ public class AccessSyncServiceTest {
 
     accessSyncService.updateUserAccessTiers(dbUser, agent);
 
-    verify(userService, times(enableInitialCreditsExpiration ? 1 : 0))
+    verify(initialCreditsExpirationService, times(enableInitialCreditsExpiration ? 1 : 0))
         .createInitialCreditsExpiration(dbUser);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -124,7 +124,7 @@ public class UserServiceAccessTest {
     FireCloudService.class,
     MailService.class,
     UserServiceAuditor.class,
-      InitialCreditsExpirationService.class
+    InitialCreditsExpirationService.class
   })
   @TestConfiguration
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/UserServiceAccessTest.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.access;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,7 +19,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -46,6 +44,7 @@ import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbVerifiedInstitutionalAffiliation;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.institution.InstitutionServiceImpl;
 import org.pmiops.workbench.mail.MailService;
@@ -125,6 +124,7 @@ public class UserServiceAccessTest {
     FireCloudService.class,
     MailService.class,
     UserServiceAuditor.class,
+      InitialCreditsExpirationService.class
   })
   @TestConfiguration
   static class Configuration {
@@ -1061,7 +1061,7 @@ public class UserServiceAccessTest {
     assertThat(userAccessTierDao.findAll()).isEmpty();
     dbUser = completeRTAndCTRequirements(dbUser);
 
-    ctTierConfig.setEmailDomains(Arrays.asList("fakeDomain.com"));
+    ctTierConfig.setEmailDomains(List.of("fakeDomain.com"));
     updateInstitutionTier(ctTierConfig);
 
     dbUser = updateUserAccessTiers();
@@ -1074,7 +1074,7 @@ public class UserServiceAccessTest {
   public void test_updateUserWithRetries_updateInvalidEmailForCT() {
     test_updateUserWithRetries_emailValidForRTButNotValidForCT();
 
-    ctTierConfig.setEmailDomains(Arrays.asList("domain.com"));
+    ctTierConfig.setEmailDomains(List.of("domain.com"));
     updateInstitutionTier(ctTierConfig);
 
     dbUser = updateUserAccessTiers();

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -286,6 +286,7 @@ public class ProfileControllerTest extends BaseControllerTest {
             .state(STATE)
             .country(COUNTRY)
             .zipCode(ZIP_CODE));
+    profile.setInitialCreditsExpirationBypassed(false);
 
     createAccountRequest = new CreateAccountRequest();
     createAccountRequest.setTermsOfServiceVersion(config.termsOfService.minimumAcceptedAouVersion);

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -192,7 +192,7 @@ public class RuntimeControllerTest {
     LeonardoApiClientFactory.class,
     MailService.class,
     UserServiceAuditor.class,
-      InitialCreditsExpirationService.class
+    InitialCreditsExpirationService.class
   })
   static class Configuration {
 

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -63,6 +63,7 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.PublicInstitutionDetailsMapperImpl;
 import org.pmiops.workbench.interactiveanalysis.InteractiveAnalysisService;
 import org.pmiops.workbench.legacy_leonardo_client.ApiException;
@@ -191,6 +192,7 @@ public class RuntimeControllerTest {
     LeonardoApiClientFactory.class,
     MailService.class,
     UserServiceAuditor.class,
+      InitialCreditsExpirationService.class
   })
   static class Configuration {
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -86,7 +86,7 @@ public class UserControllerTest {
     FreeTierBillingService.class,
     MailService.class,
     UserServiceAuditor.class,
-      InitialCreditsExpirationService.class
+    InitialCreditsExpirationService.class
   })
   static class Configuration {
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserControllerTest.java
@@ -36,6 +36,7 @@ import org.pmiops.workbench.db.model.DbUserAccessTier;
 import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.BillingAccount;
 import org.pmiops.workbench.model.TierAccessStatus;
@@ -85,6 +86,7 @@ public class UserControllerTest {
     FreeTierBillingService.class,
     MailService.class,
     UserServiceAuditor.class,
+      InitialCreditsExpirationService.class
   })
   static class Configuration {
 

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -35,6 +35,7 @@ import org.pmiops.workbench.db.model.DbComplianceTrainingVerification;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserAccessModule;
 import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.utils.PresetData;
@@ -86,7 +87,7 @@ public class ComplianceTrainingServiceTest {
     UserAccessModuleMapperImpl.class,
     ComplianceTrainingServiceImpl.class
   })
-  @MockBean({FireCloudService.class, InstitutionService.class, UserServiceAuditor.class})
+  @MockBean({FireCloudService.class, InstitutionService.class, UserServiceAuditor.class, InitialCreditsExpirationService.class})
   @TestConfiguration
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingServiceTest.java
@@ -87,7 +87,12 @@ public class ComplianceTrainingServiceTest {
     UserAccessModuleMapperImpl.class,
     ComplianceTrainingServiceImpl.class
   })
-  @MockBean({FireCloudService.class, InstitutionService.class, UserServiceAuditor.class, InitialCreditsExpirationService.class})
+  @MockBean({
+    FireCloudService.class,
+    InstitutionService.class,
+    UserServiceAuditor.class,
+    InitialCreditsExpirationService.class
+  })
   @TestConfiguration
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InitialCreditsExpirationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InitialCreditsExpirationServiceTest.java
@@ -1,0 +1,175 @@
+package org.pmiops.workbench.db.dao;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
+import org.pmiops.workbench.access.AccessModuleServiceImpl;
+import org.pmiops.workbench.access.AccessTierServiceImpl;
+import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.DbAccessModule;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
+import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration.NotificationStatus;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
+import org.pmiops.workbench.institution.InstitutionService;
+import org.pmiops.workbench.mail.MailService;
+import org.pmiops.workbench.model.Institution;
+import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class InitialCreditsExpirationServiceTest {
+
+  private static final String USERNAME = "abc@fake-research-aou.org";
+
+  // An arbitrary timestamp to use as the anchor time for access module test cases.
+  private static final Instant START_INSTANT = FakeClockConfiguration.NOW.toInstant();
+  private static DbUser providedDbUser;
+  private static WorkbenchConfig providedWorkbenchConfig;
+  private static List<DbAccessModule> accessModules;
+  @MockBean private InstitutionService mockInstitutionService;
+
+  @Autowired private AccessModuleDao accessModuleDao;
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private UserDao userDao;
+  @Autowired private InitialCreditsExpirationService initialCreditsExpirationService;
+
+  @Import({
+    FakeClockConfiguration.class,
+    FakeJpaDateTimeConfiguration.class,
+    UserServiceTestConfiguration.class,
+    AccessTierServiceImpl.class,
+    AccessModuleServiceImpl.class,
+    CommonMappers.class,
+    UserAccessModuleMapperImpl.class,
+  })
+  @MockBean({
+    MailService.class,
+  })
+  @TestConfiguration
+  static class Configuration {
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    WorkbenchConfig getWorkbenchConfig() {
+      return providedWorkbenchConfig;
+    }
+
+    @Bean
+    Random getRandom() {
+      return new Random();
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    DbUser getDbUser() {
+      return providedDbUser;
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public List<DbAccessModule> getDbAccessModules() {
+      return accessModules;
+    }
+  }
+
+  @BeforeEach
+  public void setUp() {
+    providedWorkbenchConfig = WorkbenchConfig.createEmptyConfig();
+    providedWorkbenchConfig.access.renewal.expiryDays = 365L;
+    providedWorkbenchConfig.termsOfService.minimumAcceptedAouVersion = 5; // arbitrary
+    providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays = 17L; // arbitrary
+
+    DbUserInitialCreditsExpiration initialCreditsExpiration =
+        new DbUserInitialCreditsExpiration()
+            .setBypassed(false)
+            .setCreditStartTime(Timestamp.from(START_INSTANT))
+            .setExpirationTime(
+                Timestamp.from(
+                    START_INSTANT.plus(
+                        providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays,
+                        ChronoUnit.DAYS)))
+            .setExtensionCount(0)
+            .setNotificationStatus(NotificationStatus.NO_NOTIFICATION_SENT);
+
+    DbUser user = new DbUser();
+    user.setUsername(USERNAME);
+    user.setUserInitialCreditsExpiration(initialCreditsExpiration);
+    user = userDao.save(user);
+    providedDbUser = user;
+
+    // key UserService logic depends on the existence of the Registered Tier
+    accessTierDao.save(createRegisteredTier());
+
+    accessModules = TestMockFactory.createAccessModules(accessModuleDao);
+    Institution institution = new Institution();
+    when(mockInstitutionService.getByUser(user)).thenReturn(Optional.of(institution));
+    when(mockInstitutionService.validateInstitutionalEmail(
+            institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME))
+        .thenReturn(true);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+  public void testSetInitialCreditsExpirationBypassed(
+      boolean initialBypassed, boolean expectedBypassed) {
+    providedDbUser.getUserInitialCreditsExpiration().setBypassed(initialBypassed);
+    initialCreditsExpirationService.setInitialCreditsExpirationBypassed(
+        providedDbUser, expectedBypassed);
+    assertThat(providedDbUser.getUserInitialCreditsExpiration().isBypassed())
+        .isEqualTo(expectedBypassed);
+  }
+
+  @Test
+  public void testCreateInitialCreditsExpiration() {
+    DbUser user = new DbUser();
+    user.setUsername("Test User");
+    user = userDao.save(user);
+    assertThat(user.getUserInitialCreditsExpiration()).isNull();
+
+    initialCreditsExpirationService.createInitialCreditsExpiration(user);
+
+    DbUserInitialCreditsExpiration initialCreditsExpiration =
+        user.getUserInitialCreditsExpiration();
+    assertThat(initialCreditsExpiration).isNotNull();
+    assertThat(initialCreditsExpiration.getCreditStartTime()).isEqualTo(FakeClockConfiguration.NOW);
+
+    Timestamp expectedExpirationTime =
+        Timestamp.from(
+            FakeClockConfiguration.NOW
+                .toInstant()
+                .atZone(FakeClockConfiguration.CLOCK.getZone())
+                .plusDays(providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays)
+                .toInstant());
+    assertThat(initialCreditsExpiration.getExpirationTime()).isEqualTo(expectedExpirationTime);
+    assertThat(initialCreditsExpiration.getExtensionCount()).isEqualTo(0);
+    assertThat(initialCreditsExpiration.getNotificationStatus())
+        .isEqualTo(NotificationStatus.NO_NOTIFICATION_SENT);
+    assertThat(initialCreditsExpiration.isBypassed()).isFalse();
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/db/dao/InitialCreditsExpirationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/InitialCreditsExpirationServiceTest.java
@@ -20,6 +20,7 @@ import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
+import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbUser;
@@ -68,6 +69,8 @@ public class InitialCreditsExpirationServiceTest {
     AccessModuleServiceImpl.class,
     CommonMappers.class,
     UserAccessModuleMapperImpl.class,
+    UserServiceAuditor.class,
+    UserService.class
   })
   @MockBean({
     MailService.class,

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -46,6 +46,7 @@ import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.Authority;
@@ -108,6 +109,7 @@ public class UserServiceTest {
   })
   @MockBean({
     MailService.class,
+      InitialCreditsExpirationService.class
   })
   @TestConfiguration
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -107,10 +107,7 @@ public class UserServiceTest {
     CommonMappers.class,
     UserAccessModuleMapperImpl.class,
   })
-  @MockBean({
-    MailService.class,
-      InitialCreditsExpirationService.class
-  })
+  @MockBean({MailService.class, InitialCreditsExpirationService.class})
   @TestConfiguration
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.db.dao;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,8 +25,6 @@ import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
@@ -610,44 +607,6 @@ public class UserServiceTest {
 
     assertThat(userService.isServiceAccount(serviceAccountUser)).isTrue();
     assertThat(userService.isServiceAccount(nonServiceAccountUser)).isFalse();
-  }
-
-  @ParameterizedTest
-  @CsvSource({"false,false", "false,true", "true,false", "true,true"})
-  public void testSetInitialCreditsExpirationBypassed(
-      boolean initialBypassed, boolean expectedBypassed) {
-    providedDbUser.getUserInitialCreditsExpiration().setBypassed(initialBypassed);
-    userService.setInitialCreditsExpirationBypassed(providedDbUser, expectedBypassed);
-    assertThat(providedDbUser.getUserInitialCreditsExpiration().isBypassed())
-        .isEqualTo(expectedBypassed);
-  }
-
-  @Test
-  public void testCreateInitialCreditsExpiration() {
-    DbUser user = new DbUser();
-    user.setUsername("Test User");
-    user = userDao.save(user);
-    assertThat(user.getUserInitialCreditsExpiration()).isNull();
-
-    userService.createInitialCreditsExpiration(user);
-
-    DbUserInitialCreditsExpiration initialCreditsExpiration =
-        user.getUserInitialCreditsExpiration();
-    assertThat(initialCreditsExpiration).isNotNull();
-    assertThat(initialCreditsExpiration.getCreditStartTime()).isEqualTo(FakeClockConfiguration.NOW);
-
-    Timestamp expectedExpirationTime =
-        Timestamp.from(
-            FakeClockConfiguration.NOW
-                .toInstant()
-                .atZone(FakeClockConfiguration.CLOCK.getZone())
-                .plusDays(providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays)
-                .toInstant());
-    assertThat(initialCreditsExpiration.getExpirationTime()).isEqualTo(expectedExpirationTime);
-    assertThat(initialCreditsExpiration.getExtensionCount()).isEqualTo(0);
-    assertThat(initialCreditsExpiration.getNotificationStatus())
-        .isEqualTo(NotificationStatus.NO_NOTIFICATION_SENT);
-    assertThat(initialCreditsExpiration.isBypassed()).isFalse();
   }
 
   private void tick() {

--- a/api/src/test/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/institution/PublicInstitutionDetailsMapperTest.java
@@ -33,6 +33,7 @@ public class PublicInstitutionDetailsMapperTest {
                 .displayName(dbInst.getDisplayName())
                 .shortName(dbInst.getShortName())
                 .organizationTypeEnum(dbInst.getOrganizationTypeEnum())
-                .registeredTierMembershipRequirement(InstitutionMembershipRequirement.DOMAINS));
+                .registeredTierMembershipRequirement(InstitutionMembershipRequirement.DOMAINS)
+                .institutionalInitialCreditsExpirationBypassed(false));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -112,6 +112,7 @@ public class ProfileServiceTest {
   @MockBean private InstitutionDao mockInstitutionDao;
   @MockBean private InstitutionService mockInstitutionService;
   @MockBean private UserService mockUserService;
+  @MockBean private InitialCreditsExpirationService mockInitialCreditsExpirationService;
   @MockBean private UserTermsOfServiceDao mockUserTermsOfServiceDao;
 
   @MockBean
@@ -575,7 +576,7 @@ public class ProfileServiceTest {
     profileService.updateProfile(
         targetUser, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);
 
-    verify(mockUserService, times(enableInitialCreditsExpiration ? 1 : 0))
+    verify(mockInitialCreditsExpirationService, times(enableInitialCreditsExpiration ? 1 : 0))
         .setInitialCreditsExpirationBypassed(targetUser, true);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/profile/ProfileServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +19,8 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
@@ -100,7 +103,8 @@ public class ProfileServiceTest {
         .familyName("Doe")
         .professionalUrl("https://scholar.google.com/citations?user=asdf")
         .areaOfResearch("asdfasdfasdf")
-        .verifiedInstitutionalAffiliation(BROAD_AFFILIATION);
+        .verifiedInstitutionalAffiliation(BROAD_AFFILIATION)
+        .initialCreditsExpirationBypassed(false);
   }
 
   private static final Profile VALID_PROFILE = createValidProfile();
@@ -548,6 +552,33 @@ public class ProfileServiceTest {
     assertThat(profileService.getProfile(targetUser).isDisabled()).isFalse();
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void updateProfile_bypassInitialCredits_user_asAdmin(
+      boolean enableInitialCreditsExpiration) {
+    providedWorkbenchConfig.featureFlags.enableInitialCreditsExpiration =
+        enableInitialCreditsExpiration;
+    // grant admin authority to loggedInUser
+    when(mockUserService.hasAuthority(loggedInUser.getUserId(), Authority.ACCESS_CONTROL_ADMIN))
+        .thenReturn(true);
+
+    Profile previousProfile = createValidProfile().initialCreditsExpirationBypassed(false);
+    Profile updatedProfile = createValidProfile().initialCreditsExpirationBypassed(true);
+
+    DbUser targetUser = new DbUser();
+    targetUser.setUserId(10);
+    targetUser.setGivenName("John");
+    targetUser.setFamilyName("Doe");
+
+    when(mockUserService.updateUserWithRetries(any(), any(), any())).thenReturn(targetUser);
+
+    profileService.updateProfile(
+        targetUser, Agent.asAdmin(loggedInUser), updatedProfile, previousProfile);
+
+    verify(mockUserService, times(enableInitialCreditsExpiration ? 1 : 0))
+        .setInitialCreditsExpirationBypassed(targetUser, true);
+  }
+
   @Test
   public void updateProfile_demo_survey_add_v2() {
     DemographicSurveyV2 v2Survey =
@@ -883,13 +914,13 @@ public class ProfileServiceTest {
     user1.setInstitutionName("University 1");
 
     final UserDao.DbAdminTableUser user2 = factory.createProjection(UserDao.DbAdminTableUser.class);
-    user2.setUserId(102l);
+    user2.setUserId(102L);
     user2.setContactEmail("fred@aou.biz");
     user2.setDisabled(true);
     user2.setInstitutionName("University 2");
 
     final UserDao.DbAdminTableUser user3 = factory.createProjection(UserDao.DbAdminTableUser.class);
-    user3.setUserId(103l);
+    user3.setUserId(103L);
     user3.setContactEmail("betty@aou.biz");
     user3.setDisabled(true);
     user3.setInstitutionName("University 3");

--- a/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/ras/RasLinkServiceTest.java
@@ -53,6 +53,7 @@ import org.pmiops.workbench.exceptions.ForbiddenException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.DirectoryService;
 import org.pmiops.workbench.identityverification.IdentityVerificationService;
+import org.pmiops.workbench.initialcredits.InitialCreditsExpirationService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.Institution;
@@ -168,6 +169,7 @@ public class RasLinkServiceTest {
     HttpTransport.class,
     MailService.class,
     UserServiceAuditor.class,
+    InitialCreditsExpirationService.class
   })
   static class Configuration {
     @Bean

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -139,6 +139,8 @@ export class InstitutionApiStub extends InstitutionApi {
               x,
               AccessTierShortNames.Registered
             ).membershipRequirement,
+            institutionalInitialCreditsExpirationBypassed:
+              x.bypassInitialCreditsExpiration,
           };
         }),
       });

--- a/ui/src/testing/stubs/profile-api-stub.ts
+++ b/ui/src/testing/stubs/profile-api-stub.ts
@@ -71,6 +71,7 @@ export class ProfileStubVariables {
         accessTierShortName: AccessTierShortNames.Controlled,
       },
     ],
+    initialCreditsExpirationBypass: false,
   };
   static ADMIN_TABLE_USER_STUB = <AdminTableUser>{
     ...ProfileStubVariables.PROFILE_STUB,


### PR DESCRIPTION
Split out the api work from https://github.com/all-of-us/workbench/pull/8850

Added `initialCreditsExpirationBypassed` to `Profile` and `institutionalInitialCreditsExpirationBypassed` to `PublicInstitutionDetails`

Added   these functions to InitialCreditsExpirationService.java:
```
DbUserInitialCreditsExpiration createInitialCreditsExpiration(DbUser user);
void setInitialCreditsExpirationBypassed(DbUser user, boolean isBypassed);
```
Changed AccessSyncServiceImpl.java to use function from InitialCreditsExpirationService
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
