### PR TITLE
[risk=low][no ticket] AdminRuntimeFields with v2 versions of admin runtime endpoints

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -7,12 +7,12 @@ import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.AccessReason;
 import org.pmiops.workbench.model.AdminLockingRequest;
+import org.pmiops.workbench.model.AdminRuntimeFields;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
-import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.PublishWorkspaceRequest;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
 import org.pmiops.workbench.model.UserAppEnvironment;
@@ -45,9 +45,18 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
     return ResponseEntity.ok(workspaceAdminService.getWorkspaceAdminView(workspaceNamespace));
   }
 
+  // use adminListRuntimesInWorkspaceV2
+  @Deprecated(since = "October 2024", forRemoval = true)
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
-  public ResponseEntity<List<ListRuntimeResponse>> adminListRuntimesInWorkspace(
+  public ResponseEntity<List<org.pmiops.workbench.model.ListRuntimeResponse>>
+      adminListRuntimesInWorkspace(String workspaceNamespace) {
+    return ResponseEntity.ok(workspaceAdminService.deprecatedListRuntimes(workspaceNamespace));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  public ResponseEntity<List<AdminRuntimeFields>> adminListRuntimesInWorkspaceV2(
       String workspaceNamespace) {
     return ResponseEntity.ok(workspaceAdminService.listRuntimes(workspaceNamespace));
   }
@@ -98,9 +107,20 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
         workspaceAdminService.listFiles(workspaceNamespace, Boolean.TRUE.equals(onlyAppFiles)));
   }
 
+  // use adminDeleteRuntimesInWorkspace
+  @Deprecated(since = "October 2024", forRemoval = true)
   @Override
   @AuthorityRequired(Authority.SECURITY_ADMIN)
-  public ResponseEntity<List<ListRuntimeResponse>> deleteRuntimesInWorkspace(
+  public ResponseEntity<List<org.pmiops.workbench.model.ListRuntimeResponse>>
+      deleteRuntimesInWorkspace(
+          String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
+    return ResponseEntity.ok(
+        workspaceAdminService.deprecatedDeleteRuntimes(workspaceNamespace, runtimesToDelete));
+  }
+
+  @Override
+  @AuthorityRequired(Authority.SECURITY_ADMIN)
+  public ResponseEntity<List<AdminRuntimeFields>> adminDeleteRuntimesInWorkspace(
       String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
     return ResponseEntity.ok(
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -45,7 +45,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
     return ResponseEntity.ok(workspaceAdminService.getWorkspaceAdminView(workspaceNamespace));
   }
 
-  // use adminListRuntimesInWorkspaceV2
+  // use adminListRuntimes
   @Deprecated(since = "October 2024", forRemoval = true)
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
@@ -56,8 +56,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
-  public ResponseEntity<List<AdminRuntimeFields>> adminListRuntimesInWorkspaceV2(
-      String workspaceNamespace) {
+  public ResponseEntity<List<AdminRuntimeFields>> adminListRuntimes(String workspaceNamespace) {
     return ResponseEntity.ok(workspaceAdminService.listRuntimes(workspaceNamespace));
   }
 
@@ -107,7 +106,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
         workspaceAdminService.listFiles(workspaceNamespace, Boolean.TRUE.equals(onlyAppFiles)));
   }
 
-  // use adminDeleteRuntimesInWorkspace
+  // use adminDeleteRuntimes
   @Deprecated(since = "October 2024", forRemoval = true)
   @Override
   @AuthorityRequired(Authority.SECURITY_ADMIN)
@@ -120,7 +119,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
 
   @Override
   @AuthorityRequired(Authority.SECURITY_ADMIN)
-  public ResponseEntity<List<AdminRuntimeFields>> adminDeleteRuntimesInWorkspace(
+  public ResponseEntity<List<AdminRuntimeFields>> adminDeleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
     return ResponseEntity.ok(
         workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -122,7 +122,7 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
   public ResponseEntity<List<AdminRuntimeFields>> adminDeleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
     return ResponseEntity.ok(
-        workspaceAdminService.deleteRuntimesInWorkspace(workspaceNamespace, runtimesToDelete));
+        workspaceAdminService.deleteRuntimes(workspaceNamespace, runtimesToDelete));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -36,6 +36,7 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoUpdateDataprocConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoUpdateGceConfig;
 import org.pmiops.workbench.leonardo.LeonardoLabelHelper;
+import org.pmiops.workbench.model.AdminRuntimeFields;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.DataprocConfig;
 import org.pmiops.workbench.model.Disk;
@@ -44,7 +45,6 @@ import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.GceConfig;
 import org.pmiops.workbench.model.GceWithPdConfig;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
-import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.PersistentDiskRequest;
 import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
@@ -146,12 +146,14 @@ public interface LeonardoMapper {
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
-  @Mapping(
-      target = "googleProject",
-      source = "cloudContext",
-      qualifiedByName = "legacy_cloudContextToGoogleProject")
-  ListRuntimeResponse toApiListRuntimeResponse(
-      LeonardoListRuntimeResponse leonardoListRuntimeResponse);
+  AdminRuntimeFields toAdminRuntimeFields(LeonardoListRuntimeResponse leonardoListRuntimeResponse);
+
+  // these were unused, so they have been removed in the newer AdminRuntimeFields
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "googleProject", ignore = true)
+  @Mapping(target = "patchInProgress", ignore = true)
+  org.pmiops.workbench.model.ListRuntimeResponse toDeprecatedListRuntimeResponse(
+      AdminRuntimeFields source);
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "toolDockerImage", source = "runtimeImages")

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -49,10 +49,9 @@ public interface WorkspaceAdminService {
 
   List<FileDetail> listFiles(String workspaceNamespace, boolean onlyAppFiles);
 
-  List<AdminRuntimeFields> deleteRuntimesInWorkspace(
-      String workspaceNamespace, ListRuntimeDeleteRequest req);
+  List<AdminRuntimeFields> deleteRuntimes(String workspaceNamespace, ListRuntimeDeleteRequest req);
 
-  // use deleteRuntimesInWorkspace
+  // use deleteRuntimes
   @Deprecated(since = "October 2024", forRemoval = true)
   List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedDeleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest req);

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -6,12 +6,12 @@ import java.util.Optional;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.model.AccessReason;
 import org.pmiops.workbench.model.AdminLockingRequest;
+import org.pmiops.workbench.model.AdminRuntimeFields;
 import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FileDetail;
 import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
-import org.pmiops.workbench.model.ListRuntimeResponse;
 import org.pmiops.workbench.model.PublishWorkspaceRequest;
 import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAdminView;
@@ -29,7 +29,12 @@ public interface WorkspaceAdminService {
 
   WorkspaceAdminView getWorkspaceAdminView(String workspaceNamespace);
 
-  List<ListRuntimeResponse> listRuntimes(String workspaceNamespace);
+  List<AdminRuntimeFields> listRuntimes(String workspaceNamespace);
+
+  // use listRuntimes
+  @Deprecated(since = "October 2024", forRemoval = true)
+  List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedListRuntimes(
+      String workspaceNamespace);
 
   List<UserAppEnvironment> listUserApps(String workspaceNamespace);
 
@@ -44,7 +49,12 @@ public interface WorkspaceAdminService {
 
   List<FileDetail> listFiles(String workspaceNamespace, boolean onlyAppFiles);
 
-  List<ListRuntimeResponse> deleteRuntimesInWorkspace(
+  List<AdminRuntimeFields> deleteRuntimesInWorkspace(
+      String workspaceNamespace, ListRuntimeDeleteRequest req);
+
+  // use deleteRuntimesInWorkspace
+  @Deprecated(since = "October 2024", forRemoval = true)
+  List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedDeleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest req);
 
   void setAdminLockedState(String workspaceNamespace, AdminLockingRequest adminLockingRequest);

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -298,13 +298,13 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   @Override
   public List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedDeleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest req) {
-    return deleteRuntimesInWorkspace(workspaceNamespace, req).stream()
+    return deleteRuntimes(workspaceNamespace, req).stream()
         .map(leonardoMapper::toDeprecatedListRuntimeResponse)
         .collect(Collectors.toList());
   }
 
   @Override
-  public List<AdminRuntimeFields> deleteRuntimesInWorkspace(
+  public List<AdminRuntimeFields> deleteRuntimes(
       String workspaceNamespace, ListRuntimeDeleteRequest req) {
     final String googleProject =
         getWorkspaceByNamespaceOrThrow(workspaceNamespace).getGoogleProject();

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -282,7 +282,6 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   @Override
   public List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedListRuntimes(
       String workspaceNamespace) {
-    final DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
     return listRuntimes(workspaceNamespace).stream()
         .map(leonardoMapper::toDeprecatedListRuntimeResponse)
         .toList();

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -659,7 +659,7 @@ paths:
       requestBody:
         description: A list of names of runtimes to delete. To delete all runtimes,
           use an empty object, without providing a list property at all (e.g., {})
-          An empty list will delete no runtimes.
+          An empty list will delete no runtimes.  SECURITY_ADMIN required.
         content:
           '*/*':
             schema:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -605,8 +605,8 @@ paths:
       - workspaceAdmin
       summary: Delete specified (or all if no specified list) runtimes in given workspace
         namespace.
-      description: An admin gated endpoint that deletes given runtimes in a given
-        workspaace.
+      description: DEPRECATED.  Use adminDeleteRuntimesInWorkspace. 
+        WAS - An admin gated endpoint that deletes given runtimes in a given workspace.
       operationId: deleteRuntimesInWorkspace
       parameters:
       - name: workspaceNamespace
@@ -633,6 +633,47 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ListRuntimeResponse'
+        500:
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      x-codegen-request-body-name: runtimesToDelete
+  /v1/admin/security/workspaces/{workspaceNamespace}/deleteRuntimes:
+    post:
+      tags:
+        - workspaceAdmin
+      summary: Delete specified (or all if no specified list) runtimes in given workspace
+        namespace.
+      description: An admin gated endpoint that deletes given runtimes in a given
+        workspace.
+      operationId: adminDeleteRuntimesInWorkspace
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: The workspace's namespace.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: A list of names of runtimes to delete. To delete all runtimes,
+          use an empty object, without providing a list property at all (e.g., {})
+          An empty list will delete no runtimes.
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ListRuntimeDeleteRequest'
+        required: true
+      responses:
+        200:
+          description: Runtimes deleted
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminRuntimeFields'
         500:
           description: Internal Error
           content:
@@ -2182,7 +2223,8 @@ paths:
     get:
       tags:
         - workspaceAdmin
-      description: Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
+      description: DEPRECATED.  Use adminListRuntimesInWorkspaceV2.
+        WAS - Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
       operationId: adminListRuntimesInWorkspace
       parameters:
         - name: workspaceNamespace
@@ -2200,6 +2242,28 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ListRuntimeResponse'
+  /v1/admin/workspaces/{workspaceNamespace}/listRuntimes:
+    get:
+      tags:
+        - workspaceAdmin
+      description: Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
+      operationId: adminListRuntimesInWorkspaceV2
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: The Workspace namespace
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of runtimes in this Workspace
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminRuntimeFields'
   /v1/admin/workspaces/{workspaceNamespace}/userApps:
     get:
       tags:
@@ -9016,7 +9080,35 @@ components:
           type: boolean
           description: Whether there is a patch in progress on the runtime. Is used
             to indicate updates that require status transitions.
-      description: This is a subset of options in a full runtimes response, copied
+      description: DEPRECATED in favor of AdminRuntimeResponse, to prevent name clashes.  
+        WAS - This is a subset of options in a full runtimes response, copied from leonardo.yaml.
+    AdminRuntimeFields:
+      required:
+        - runtimeName
+        - status
+        - createdDate
+        - labels
+        - dateAccessed
+      type: object
+      properties:
+        runtimeName:
+          type: string
+          description: The user-supplied name for the runtime
+        status:
+          $ref: '#/components/schemas/RuntimeStatus'
+        createdDate:
+          type: string
+          description: The date and time the runtime was created, in ISO-8601 format
+        labels:
+          type: object
+          properties: {}
+          description: The labels to be placed on the runtime. Of type Map[String,String]
+        dateAccessed:
+          type: string
+          description: |
+            The date and time the runtime was last accessed, in ISO-8601 format.
+            Date accessed is defined as the last time the runtime was created, modified, or accessed via the proxy.
+      description: This is a subset of options in a full list runtimes response, copied
         from leonardo.yaml.
     ListRuntimeDeleteRequest:
       type: object

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -605,7 +605,7 @@ paths:
       - workspaceAdmin
       summary: Delete specified (or all if no specified list) runtimes in given workspace
         namespace.
-      description: DEPRECATED.  Use adminDeleteRuntimesInWorkspace. 
+      description: DEPRECATED.  Use adminDeleteRuntimes.
         WAS - An admin gated endpoint that deletes given runtimes in a given workspace.
       operationId: deleteRuntimesInWorkspace
       parameters:
@@ -648,7 +648,7 @@ paths:
         namespace.
       description: An admin gated endpoint that deletes given runtimes in a given
         workspace.
-      operationId: adminDeleteRuntimesInWorkspace
+      operationId: adminDeleteRuntimes
       parameters:
         - name: workspaceNamespace
           in: path
@@ -2223,7 +2223,7 @@ paths:
     get:
       tags:
         - workspaceAdmin
-      description: DEPRECATED.  Use adminListRuntimesInWorkspaceV2.
+      description: DEPRECATED.  Use adminListRuntimes.
         WAS - Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
       operationId: adminListRuntimesInWorkspace
       parameters:
@@ -2247,7 +2247,7 @@ paths:
       tags:
         - workspaceAdmin
       description: Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
-      operationId: adminListRuntimesInWorkspaceV2
+      operationId: adminListRuntimes
       parameters:
         - name: workspaceNamespace
           in: path

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -431,7 +431,7 @@ public class WorkspaceAdminServiceTest {
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(GOOGLE_PROJECT_ID))
         .thenReturn(listRuntimeResponseList);
 
-    workspaceAdminService.deleteRuntimesInWorkspace(
+    workspaceAdminService.deleteRuntimes(
         WORKSPACE_NAMESPACE,
         new ListRuntimeDeleteRequest()
             .runtimesToDelete(ImmutableList.of(testLeoRuntime.getRuntimeName())));
@@ -453,7 +453,7 @@ public class WorkspaceAdminServiceTest {
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(GOOGLE_PROJECT_ID))
         .thenReturn(listRuntimeResponseList);
 
-    workspaceAdminService.deleteRuntimesInWorkspace(
+    workspaceAdminService.deleteRuntimes(
         WORKSPACE_NAMESPACE, new ListRuntimeDeleteRequest().runtimesToDelete(runtimesToDelete));
     verify(mockLeonardoNotebooksClient, times(runtimesToDelete.size()))
         .deleteRuntimeAsService(GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName());
@@ -470,7 +470,7 @@ public class WorkspaceAdminServiceTest {
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(GOOGLE_PROJECT_ID))
         .thenReturn(listRuntimeResponseList);
 
-    workspaceAdminService.deleteRuntimesInWorkspace(
+    workspaceAdminService.deleteRuntimes(
         WORKSPACE_NAMESPACE, new ListRuntimeDeleteRequest().runtimesToDelete(runtimesToDelete));
     verify(mockLeonardoNotebooksClient, times(0))
         .deleteRuntimeAsService(GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName());
@@ -485,7 +485,7 @@ public class WorkspaceAdminServiceTest {
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(GOOGLE_PROJECT_ID))
         .thenReturn(listRuntimeResponseList);
 
-    workspaceAdminService.deleteRuntimesInWorkspace(
+    workspaceAdminService.deleteRuntimes(
         WORKSPACE_NAMESPACE, new ListRuntimeDeleteRequest().runtimesToDelete(ImmutableList.of()));
     verify(mockLeonardoNotebooksClient, never())
         .deleteRuntimeAsService(GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName());
@@ -504,7 +504,7 @@ public class WorkspaceAdminServiceTest {
     when(mockLeonardoNotebooksClient.listRuntimesByProjectAsService(GOOGLE_PROJECT_ID))
         .thenReturn(listRuntimeResponseList);
 
-    workspaceAdminService.deleteRuntimesInWorkspace(
+    workspaceAdminService.deleteRuntimes(
         WORKSPACE_NAMESPACE, new ListRuntimeDeleteRequest().runtimesToDelete(null));
     verify(mockLeonardoNotebooksClient)
         .deleteRuntimeAsService(GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName());

--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -88,7 +88,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
     // to the main admin view call
 
     workspaceAdminApi()
-      .adminListRuntimesInWorkspaceV2(ns)
+      .adminListRuntimes(ns)
       .then((runtimes) => this.setState({ runtimes }))
       .catch(this.handleDataLoadError);
 

--- a/ui/src/app/pages/admin/workspace/admin-workspace.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import {
+  AdminRuntimeFields,
   CloudStorageTraffic,
-  ListRuntimeResponse,
   UserAppEnvironment,
   WorkspaceActiveStatus,
   WorkspaceAdminView,
@@ -40,7 +40,7 @@ interface State {
   cloudStorageTraffic?: CloudStorageTraffic;
   loadingWorkspace?: boolean;
   dataLoadError?: Response;
-  runtimes?: ListRuntimeResponse[];
+  runtimes?: AdminRuntimeFields[];
   userApps?: UserAppEnvironment[];
 }
 
@@ -88,7 +88,7 @@ export class AdminWorkspaceImpl extends React.Component<Props, State> {
     // to the main admin view call
 
     workspaceAdminApi()
-      .adminListRuntimesInWorkspace(ns)
+      .adminListRuntimesInWorkspaceV2(ns)
       .then((runtimes) => this.setState({ runtimes }))
       .catch(this.handleDataLoadError);
 

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Column } from 'primereact/column';
 import { DataTable } from 'primereact/datatable';
 
-import { ListRuntimeResponse, UserAppEnvironment } from 'generated/fetch';
+import { AdminRuntimeFields, UserAppEnvironment } from 'generated/fetch';
 
 import {
   fromRuntimeStatus,
@@ -32,12 +32,12 @@ interface CloudEnvironmentRow {
   status: string;
 }
 
-const runtimeToRow = (runtime: ListRuntimeResponse): CloudEnvironmentRow => {
-  const { runtimeName, createdDate, dateAccessed, status } = runtime;
+const runtimeToRow = (runtime: AdminRuntimeFields): CloudEnvironmentRow => {
+  const { runtimeName, createdDate, dateAccessed, status, labels } = runtime;
   return {
     appType: UIAppType.JUPYTER,
     name: runtimeName,
-    creator: getCreator(runtime),
+    creator: getCreator(labels),
     createdTime: new Date(createdDate).toDateString(),
     lastAccessedTime: new Date(dateAccessed).toDateString(),
     status: fromRuntimeStatus(status),
@@ -60,7 +60,7 @@ const userAppToRow = (userApp: UserAppEnvironment): CloudEnvironmentRow => {
 interface Props {
   workspaceNamespace: string;
   onDelete: () => void;
-  runtimes?: ListRuntimeResponse[];
+  runtimes?: AdminRuntimeFields[];
   userApps?: UserAppEnvironment[];
 }
 export const CloudEnvironmentsTable = ({
@@ -75,7 +75,7 @@ export const CloudEnvironmentsTable = ({
   const deleteRuntime = () => {
     setConfirmDeleteRuntime(false);
     workspaceAdminApi()
-      .deleteRuntimesInWorkspace(workspaceNamespace, {
+      .adminDeleteRuntimesInWorkspace(workspaceNamespace, {
         runtimesToDelete: [runtimeToDelete],
       })
       .then(() => {

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -75,7 +75,7 @@ export const CloudEnvironmentsTable = ({
   const deleteRuntime = () => {
     setConfirmDeleteRuntime(false);
     workspaceAdminApi()
-      .adminDeleteRuntimesInWorkspace(workspaceNamespace, {
+      .adminDeleteRuntimes(workspaceNamespace, {
         runtimesToDelete: [runtimeToDelete],
       })
       .then(() => {

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -15,7 +15,7 @@ import {
 } from 'app/utils/stores';
 
 import defaultServerConfig from 'testing/default-server-config';
-import { defaultRuntime, RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
+import { RuntimeApiStub } from 'testing/stubs/runtime-api-stub';
 
 import { useCustomRuntime } from './runtime-hooks';
 

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { ListRuntimeResponse, RuntimeApi } from 'generated/fetch';
+import { RuntimeApi } from 'generated/fetch';
 
 import { render, waitFor } from '@testing-library/react';
 import { registerApiClient } from 'app/services/swagger-fetch-clients';
@@ -109,21 +109,21 @@ describe('runtime-utils', () => {
 
 describe(getCreator.name, () => {
   test.each([
-    ['a runtime without a creator label', defaultRuntime(), undefined],
     [
-      'a runtime with a creator label',
-      { ...defaultRuntime(), labels: { creator: 'scientist@aou' } },
+      'a (labels) object with a creator label',
+      { creator: 'scientist@aou', other: 'n/a' },
       'scientist@aou',
     ],
-    ['a non-runtime object', {}, undefined],
+    [
+      'a (labels) object without a creator label',
+      { some: 123, other: 'n/a', fields: 'ok' },
+      undefined,
+    ],
     ['undefined', undefined, undefined],
     ['null', null, undefined],
   ])(
     'getCreator should have the expected result for %s',
-    (
-      desc: string,
-      runtimeResponse: ListRuntimeResponse,
-      expected: string | undefined
-    ) => expect(getCreator(runtimeResponse)).toEqual(expected)
+    (_desc: string, labels: object, expected: string | undefined) =>
+      expect(getCreator(labels)).toEqual(expected)
   );
 });

--- a/ui/src/app/utils/runtime-utils.tsx
+++ b/ui/src/app/utils/runtime-utils.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import {
   DiskType,
   ErrorCode,
-  ListRuntimeResponse,
   Runtime,
   RuntimeError,
   RuntimeStatus,
@@ -176,6 +175,6 @@ export const canUpdateRuntime = (status: RuntimeStatus) =>
     [RuntimeStatus.RUNNING, RuntimeStatus.STOPPED] as Array<RuntimeStatus>
   ).includes(status);
 
-export const getCreator = (runtime: ListRuntimeResponse): string | undefined =>
+export const getCreator = (labels?: object): string | undefined =>
   // eslint-disable-next-line @typescript-eslint/dot-notation
-  runtime?.labels?.['creator'];
+  labels?.['creator'];


### PR DESCRIPTION
This change is motivated by the ongoing Leo client upgrade process.  Soon "LeonardoListRuntimesResponse" will become "ListRuntimesResponse", which will clash with an existing ListRuntimesResponse RWB model entity.  I found that the existing ListRuntimesResponse RWB model entity is not used in many places, and also contains additional fields which we don't need, so I am replacing it with a new entity AdminRuntimeFields.

This is part 1: add new API endpoints which use the new entity, and update the UI to call the new endpoints.
Part 2 will remove the old endpoints.

Tested locally by creating a runtime and observing and deleting it in the Admin Workspace UI.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
