### PR TITLE
[risk=low][no ticket] Remove deprecated admin runtimes endpoints

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -45,15 +45,6 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
     return ResponseEntity.ok(workspaceAdminService.getWorkspaceAdminView(workspaceNamespace));
   }
 
-  // use adminListRuntimes
-  @Deprecated(since = "October 2024", forRemoval = true)
-  @Override
-  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
-  public ResponseEntity<List<org.pmiops.workbench.model.ListRuntimeResponse>>
-      adminListRuntimesInWorkspace(String workspaceNamespace) {
-    return ResponseEntity.ok(workspaceAdminService.deprecatedListRuntimes(workspaceNamespace));
-  }
-
   @Override
   @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
   public ResponseEntity<List<AdminRuntimeFields>> adminListRuntimes(String workspaceNamespace) {
@@ -104,17 +95,6 @@ public class WorkspaceAdminController implements WorkspaceAdminApiDelegate {
       String workspaceNamespace, Boolean onlyAppFiles) {
     return ResponseEntity.ok(
         workspaceAdminService.listFiles(workspaceNamespace, Boolean.TRUE.equals(onlyAppFiles)));
-  }
-
-  // use adminDeleteRuntime
-  @Deprecated(since = "October 2024", forRemoval = true)
-  @Override
-  @AuthorityRequired(Authority.SECURITY_ADMIN)
-  public ResponseEntity<List<org.pmiops.workbench.model.ListRuntimeResponse>>
-      deleteRuntimesInWorkspace(
-          String workspaceNamespace, ListRuntimeDeleteRequest runtimesToDelete) {
-    return ResponseEntity.ok(
-        workspaceAdminService.deprecatedDeleteRuntimes(workspaceNamespace, runtimesToDelete));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspaceAdminController.java
@@ -12,7 +12,6 @@ import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.EmptyResponse;
 import org.pmiops.workbench.model.FileDetail;
-import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.PublishWorkspaceRequest;
 import org.pmiops.workbench.model.ReadOnlyNotebookResponse;
 import org.pmiops.workbench.model.UserAppEnvironment;

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -154,13 +154,6 @@ public interface LeonardoMapper {
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   AdminRuntimeFields toAdminRuntimeFields(LeonardoListRuntimeResponse leonardoListRuntimeResponse);
 
-  // these were unused, so they have been removed in the newer AdminRuntimeFields
-  @Mapping(target = "id", ignore = true)
-  @Mapping(target = "googleProject", ignore = true)
-  @Mapping(target = "patchInProgress", ignore = true)
-  org.pmiops.workbench.model.ListRuntimeResponse toDeprecatedListRuntimeResponse(
-      AdminRuntimeFields source);
-
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "toolDockerImage", source = "runtimeImages")
   @Mapping(

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.model.AdminWorkspaceCloudStorageCounts;
 import org.pmiops.workbench.model.AdminWorkspaceObjectsCounts;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FileDetail;
-import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.PublishWorkspaceRequest;
 import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAdminView;

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminService.java
@@ -31,11 +31,6 @@ public interface WorkspaceAdminService {
 
   List<AdminRuntimeFields> listRuntimes(String workspaceNamespace);
 
-  // use listRuntimes
-  @Deprecated(since = "October 2024", forRemoval = true)
-  List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedListRuntimes(
-      String workspaceNamespace);
-
   List<UserAppEnvironment> listUserApps(String workspaceNamespace);
 
   WorkspaceAuditLogQueryResponse getWorkspaceAuditLogEntries(
@@ -50,11 +45,6 @@ public interface WorkspaceAdminService {
   List<FileDetail> listFiles(String workspaceNamespace, boolean onlyAppFiles);
 
   AdminRuntimeFields deleteRuntime(String workspaceNamespace, String runtimeNameToDelete);
-
-  // use deleteRuntimes
-  @Deprecated(since = "October 2024", forRemoval = true)
-  List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedDeleteRuntimes(
-      String workspaceNamespace, ListRuntimeDeleteRequest req);
 
   void setAdminLockedState(String workspaceNamespace, AdminLockingRequest adminLockingRequest);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -266,32 +266,10 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
         .toList();
   }
 
-  // use listRuntimes
-  @Deprecated(since = "October 2024", forRemoval = true)
-  @Override
-  public List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedListRuntimes(
-      String workspaceNamespace) {
-    return listRuntimes(workspaceNamespace).stream()
-        .map(leonardoMapper::toDeprecatedListRuntimeResponse)
-        .toList();
-  }
-
   @Override
   public List<UserAppEnvironment> listUserApps(String workspaceNamespace) {
     final DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
     return leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
-  }
-
-  // use deleteRuntimesInWorkspace
-  @Deprecated(since = "October 2024", forRemoval = true)
-  @Override
-  public List<org.pmiops.workbench.model.ListRuntimeResponse> deprecatedDeleteRuntimes(
-      String workspaceNamespace, ListRuntimeDeleteRequest req) {
-    // the UI only calls this with a single argument, so this is safe
-    String runtimeNameToDelete = req.getRuntimesToDelete().get(0);
-    return List.of(
-        leonardoMapper.toDeprecatedListRuntimeResponse(
-            deleteRuntime(workspaceNamespace, runtimeNameToDelete)));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -48,7 +48,6 @@ import org.pmiops.workbench.model.AdminWorkspaceResources;
 import org.pmiops.workbench.model.CloudStorageTraffic;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.FileDetail;
-import org.pmiops.workbench.model.ListRuntimeDeleteRequest;
 import org.pmiops.workbench.model.PublishWorkspaceRequest;
 import org.pmiops.workbench.model.TimeSeriesPoint;
 import org.pmiops.workbench.model.UserAppEnvironment;

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8968,46 +8968,6 @@ components:
           type: integer
           description: File size in bytes.
           format: int64
-    ListRuntimeResponse:
-      required:
-      - createdDate
-      - dateAccessed
-      - googleProject
-      - id
-      - labels
-      - runtimeName
-      - status
-      type: object
-      properties:
-        id:
-          type: integer
-          description: Internal Leonardo ID of the runtime
-        runtimeName:
-          type: string
-          description: The user-supplied name for the runtime
-        googleProject:
-          type: string
-          description: The Google Project used to create the runtime
-        status:
-          $ref: '#/components/schemas/RuntimeStatus'
-        createdDate:
-          type: string
-          description: The date and time the runtime was created, in ISO-8601 format
-        labels:
-          type: object
-          properties: {}
-          description: The labels to be placed on the runtime. Of type Map[String,String]
-        dateAccessed:
-          type: string
-          description: |
-            The date and time the runtime was last accessed, in ISO-8601 format.
-            Date accessed is defined as the last time the runtime was created, modified, or accessed via the proxy.
-        patchInProgress:
-          type: boolean
-          description: Whether there is a patch in progress on the runtime. Is used
-            to indicate updates that require status transitions.
-      description: DEPRECATED in favor of AdminRuntimeResponse, to prevent name clashes.  
-        WAS - This is a subset of options in a full runtimes response, copied from leonardo.yaml.
     AdminRuntimeFields:
       required:
         - runtimeName

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -588,47 +588,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkbenchListBillingAccountsResponse'
-  /v1/admin/security/workspaces/{workspaceNamespace}/delete-runtimes:
-    post:
-      tags:
-      - workspaceAdmin
-      summary: Delete specified (or all if no specified list) runtimes in given workspace
-        namespace.
-      description: DEPRECATED.  Use adminDeleteRuntime.
-        WAS - An admin gated endpoint that deletes given runtimes in a given workspace.
-      operationId: deleteRuntimesInWorkspace
-      parameters:
-      - name: workspaceNamespace
-        in: path
-        description: The workspace's workspace namespace. the runtimes
-        required: true
-        schema:
-          type: string
-      requestBody:
-        description: A list of names of runtimes to delete. To delete all runtimes,
-          use an empty object, without providing a list property at all (e.g., {})
-          An empty list will delete no runtimes.
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/ListRuntimeDeleteRequest'
-        required: true
-      responses:
-        200:
-          description: Runtimes deleted
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ListRuntimeResponse'
-        500:
-          description: Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      x-codegen-request-body-name: runtimesToDelete
   /v1/runtimes/{workspaceNamespace}:
     get:
       tags:
@@ -2167,29 +2126,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FileDetail'
-  /v1/admin/workspaces/{workspaceNamespace}/runtimes:
-    get:
-      tags:
-        - workspaceAdmin
-      description: DEPRECATED.  Use adminListRuntimes.
-        WAS - Get a list of runtimes in this Workspace. RESEARCHER_DATA_VIEW authority required.
-      operationId: adminListRuntimesInWorkspace
-      parameters:
-        - name: workspaceNamespace
-          in: path
-          description: The Workspace namespace
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: List of runtimes in this Workspace
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ListRuntimeResponse'
   /v1/admin/security/workspaces/{workspaceNamespace}/runtimes/{runtimeName}:
     delete:
       tags:


### PR DESCRIPTION
These are no longer used by the UI.  Tested locally by going to the Admin Workspace page and listing and deleting runtimes.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
