### PR TITLE
[risk=low][no ticket] Update Leo swagger for GetRuntimeResponse and ListruntimeResponse

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.api;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -328,7 +329,8 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
     return true;
   }
 
-  private boolean isDiskAttached(ListPersistentDiskResponse diskResponse, String googleProject)
+  @VisibleForTesting
+  public boolean isDiskAttached(ListPersistentDiskResponse diskResponse, String googleProject)
       throws ApiException {
     final String diskName = diskResponse.getName();
 
@@ -346,10 +348,10 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
                 return CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService());
               })
           .map(
-              runtimeConfig ->
+              resp ->
                   new Gson()
                       .fromJson(
-                          new Gson().toJson(runtimeConfig),
+                          new Gson().toJson(resp.getRuntimeConfig()),
                           LeonardoGceWithPdConfigInResponse.class))
           .anyMatch(
               gceWithPdConfig ->

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.api;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
 import jakarta.inject.Provider;
 import jakarta.mail.MessagingException;
 import java.time.Clock;
@@ -16,7 +17,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.billing.FreeTierBillingService;
@@ -29,8 +29,11 @@ import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.legacy_leonardo_client.ApiException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
@@ -330,9 +333,25 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
     final String diskName = diskResponse.getName();
 
     if (leonardoMapper.toApiListDisksResponse(diskResponse).isGceRuntime()) {
+
       return leonardoApiClient.listRuntimesByProjectAsService(googleProject).stream()
-          .flatMap(runtime -> Stream.ofNullable(runtime.getDiskConfig()))
-          .anyMatch(diskConfig -> diskName.equals(diskConfig.getName()));
+          .map(
+              resp ->
+                  new Gson()
+                      .fromJson(
+                          new Gson().toJson(resp.getRuntimeConfig()), LeonardoRuntimeConfig.class))
+          // this filter/map follows the discriminator logic in the source Leonardo Swagger
+          // for OneOfRuntimeConfigInResponse
+          .filter(runtimeConfig -> CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService()))
+          .map(
+              runtimeConfig ->
+                  new Gson()
+                      .fromJson(
+                          new Gson().toJson(runtimeConfig),
+                          LeonardoGceWithPdConfigInResponse.class))
+          .anyMatch(
+              gceWithPdConfig ->
+                  diskResponse.getId().equals(gceWithPdConfig.getPersistentDiskId()));
     } else {
       return leonardoApiClient.listAppsInProjectAsService(googleProject).stream()
           .anyMatch(userAppEnvironment -> diskName.equals(userAppEnvironment.getDiskName()));

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -32,7 +32,6 @@ import org.pmiops.workbench.legacy_leonardo_client.ApiException;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
@@ -335,11 +334,7 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
     if (leonardoMapper.toApiListDisksResponse(diskResponse).isGceRuntime()) {
 
       return leonardoApiClient.listRuntimesByProjectAsService(googleProject).stream()
-          .map(
-              resp ->
-                  new Gson()
-                      .fromJson(
-                          new Gson().toJson(resp.getRuntimeConfig()), LeonardoRuntimeConfig.class))
+          .map(LeonardoListRuntimeResponse::getRuntimeConfig)
           // this filter/map follows the discriminator logic in the source Leonardo Swagger
           // for OneOfRuntimeConfigInResponse
           .filter(runtimeConfig -> CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService()))

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -147,7 +147,7 @@ public class RuntimeController implements RuntimeApiDelegate {
             .values()
             .contains(runtimeLabels.get(LEONARDO_LABEL_AOU_CONFIG))) {
       try {
-        Runtime runtime = leonardoMapper.toApiRuntime(mostRecentRuntime);
+        Runtime runtime = leonardoMapper.toApiRuntimeWithoutDisk(mostRecentRuntime);
         if (!RuntimeStatus.DELETED.equals(runtime.getStatus())) {
           log.warning(
               "Runtimes returned from ListRuntimes should be DELETED but found "

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -280,6 +280,7 @@ public interface LeonardoMapper {
     String runtimeConfigJson = gson.toJson(runtimeConfigObj);
     LeonardoRuntimeConfig runtimeConfig =
         gson.fromJson(runtimeConfigJson, LeonardoRuntimeConfig.class);
+
     if (CloudServiceEnum.DATAPROC.equals(runtimeConfig.getCloudService())) {
       runtime.dataprocConfig(
           toDataprocConfig(gson.fromJson(runtimeConfigJson, LeonardoMachineConfig.class)));

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -122,6 +122,8 @@ public interface LeonardoMapper {
   }
 
   @Mapping(target = "patchInProgress", ignore = true)
+  @Mapping(target = "workspaceId", ignore = true)
+  @Mapping(target = "googleProject", ignore = true)
   LeonardoListRuntimeResponse toListRuntimeResponse(LeonardoGetRuntimeResponse runtime);
 
   @Nullable
@@ -187,7 +189,7 @@ public interface LeonardoMapper {
   @Mapping(target = "gceConfig", ignore = true)
   @Mapping(target = "gceWithPdConfig", ignore = true)
   @Mapping(target = "dataprocConfig", ignore = true)
-  Runtime toApiRuntime(LeonardoListRuntimeResponse runtime);
+  Runtime toApiRuntimeWithoutDisk(LeonardoListRuntimeResponse runtime);
 
   RuntimeError toApiRuntimeError(LeonardoClusterError err);
 
@@ -206,7 +208,9 @@ public interface LeonardoMapper {
     mapRuntimeConfig(
         runtime,
         leonardoListRuntimeResponse.getRuntimeConfig(),
-        leonardoListRuntimeResponse.getDiskConfig());
+        // listRuntime does not actually have a diskConfig field.  This is OK because we only
+        // call this from a context where we're not expecting one.
+        null);
   }
 
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -271,15 +271,15 @@ public interface LeonardoMapper {
   }
 
   default void mapRuntimeConfig(
-      Runtime runtime,
-      LeonardoRuntimeConfig runtimeConfig,
-      @Nullable LeonardoDiskConfig diskConfig) {
-    if (runtimeConfig == null) {
+      Runtime runtime, Object runtimeConfigObj, @Nullable LeonardoDiskConfig diskConfig) {
+    if (runtimeConfigObj == null) {
       return;
     }
 
     Gson gson = new Gson();
-    String runtimeConfigJson = gson.toJson(runtimeConfig);
+    String runtimeConfigJson = gson.toJson(runtimeConfigObj);
+    LeonardoRuntimeConfig runtimeConfig =
+        gson.fromJson(runtimeConfigJson, LeonardoRuntimeConfig.class);
     if (CloudServiceEnum.DATAPROC.equals(runtimeConfig.getCloudService())) {
       runtime.dataprocConfig(
           toDataprocConfig(gson.fromJson(runtimeConfigJson, LeonardoMachineConfig.class)));

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -271,16 +271,15 @@ public interface LeonardoMapper {
   }
 
   default void mapRuntimeConfig(
-      Runtime runtime, Object runtimeConfigObj, @Nullable LeonardoDiskConfig diskConfig) {
-    if (runtimeConfigObj == null) {
+      Runtime runtime,
+      LeonardoRuntimeConfig runtimeConfig,
+      @Nullable LeonardoDiskConfig diskConfig) {
+    if (runtimeConfig == null) {
       return;
     }
 
     Gson gson = new Gson();
-    String runtimeConfigJson = gson.toJson(runtimeConfigObj);
-    LeonardoRuntimeConfig runtimeConfig =
-        gson.fromJson(runtimeConfigJson, LeonardoRuntimeConfig.class);
-
+    String runtimeConfigJson = gson.toJson(runtimeConfig);
     if (CloudServiceEnum.DATAPROC.equals(runtimeConfig.getCloudService())) {
       runtime.dataprocConfig(
           toDataprocConfig(gson.fromJson(runtimeConfigJson, LeonardoMachineConfig.class)));

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1654,15 +1654,20 @@ components:
       required:
         - id
         - runtimeName
+        - googleProject
         - cloudContext
         - serviceAccount
         - auditInfo
         - runtimeConfig
+        - proxyUrl
         - status
         - labels
+        - errors
         - autopauseThreshold
-        - defaultClientId
+        - runtimeImages
         - scopes
+        - customEnvironmentVariables
+        - patchInProgress
       properties:
         id:
           type: integer
@@ -1670,6 +1675,9 @@ components:
         runtimeName:
           type: string
           description: The user-supplied name for the runtime
+        googleProject:
+          type: string
+          description: Deprecated. The Google Project used to create the runtime
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         serviceAccount:
@@ -1681,7 +1689,8 @@ components:
           $ref: "#/components/schemas/AuditInfo"
         runtimeConfig:
           type: object
-          description: oneOf GceConfig, GceWithPdConfig, MachineConfig
+          description: oneOf GceWithPdConfigInResponse, MachineConfig
+          # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         proxyUrl:
           type: string
           description: The URL to access a tool on the runtime
@@ -1692,34 +1701,31 @@ components:
           description: The labels to be placed on the runtime. Of type Map[String,String]
         jupyterUserScriptUri:
           type: string
+          description: DEPRECATED on 05/2021. Please use userScriptUri instead. This field may be removed after 6 months of deprecation.
+          deprecated: true
+        userScriptUri:
+          type: string
           description: >
-            Optional GCS object URI to a bash script the user wishes to run
-            inside their jupyter
-
-            docker. This script runs exactly once when the cluster is first initialized. Logs from
-
-            this script can be found in the Leo staging bucket for the cluster. Script is run as root
-
+            Optional GCS or HTTP URI to a bash script the user wishes to run
+            inside their Docker container. This script runs exactly once when the runtime is first initialized. Logs from
+            this script can be found in the Leo staging bucket for the runtime. The script is run as root
             and docker --privileged.
         jupyterStartUserScriptUri:
           type: string
+          description: DEPRECATED on 05/2021. Please use startUserScriptUri instead. This field may be removed after 6 months of deprecation.
+          deprecated: true
+        startUserScriptUri:
+          type: string
           description: >
-            Optional GCS object URI to a bash script the user wishes to run on
-            cluster start inside
+            Optional GCS or HTTP URI to a bash script the user wishes to run on runtime start inside
+            the Docker container. In contrast to userScriptUri, this always runs before starting
+            the Docker container, both on initial runtime creation and on runtime resume (sserScriptUri runs
+            once on runtime creation). This script may be used to launch background processes which
+            would not otherwise survive a runtime stop/start.
 
-            the jupyter docker. In contrast to jupyterUserScriptUri, this always runs before starting
-
-            Jupyter, both on initial cluster creation and on cluster resume (jupyterUserScriptUri runs
-
-            once on cluster creation). This script may be used to launch background processes which
-
-            would not otherwise survive a cluster stop/start.
-
-            The script is pulled once at cluster creation time; subsequent client changes to the user
-
-            script at this URI do not affect the cluster. Timestamped logs for this script can be
-
-            found in the Leo staging bucket for the cluster. Script is run as root and docker --privileged.
+            The script is pulled once at runtime creation time; subsequent client changes to the user
+            script at this URI do not affect the runtime. Timestamped logs for this script can be
+            found in the Leo staging bucket for the cluster. The script is run as root and docker --privileged.
         errors:
           type: array
           description: The list of errors that were encountered on runtime create. Each
@@ -1751,6 +1757,9 @@ components:
           description: Optional environment variables to be set on the runtime.
         diskConfig:
           $ref: "#/components/schemas/DiskConfig"
+        patchInProgress:
+          type: boolean
+          description: Whether there is a patch in progress on the runtime. Is used to indicate updates that require status transitions.
     ListRuntimeResponse:
       description: ""
       required:

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1688,7 +1688,8 @@ components:
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         runtimeConfig:
-          $ref: '#/components/schemas/RuntimeConfig'
+          type: object
+          description: oneOf GceWithPdConfigInResponse, MachineConfig
           # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         proxyUrl:
           type: string
@@ -1786,7 +1787,8 @@ components:
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         runtimeConfig:
-          $ref: '#/components/schemas/RuntimeConfig'
+          type: object
+          description: oneOf GceWithPdConfigInResponse, MachineConfig
           # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1688,8 +1688,7 @@ components:
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         runtimeConfig:
-          type: object
-          description: oneOf GceWithPdConfigInResponse, MachineConfig
+          $ref: '#/components/schemas/RuntimeConfig'
           # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         proxyUrl:
           type: string
@@ -1787,8 +1786,7 @@ components:
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         runtimeConfig:
-          type: object
-          description: oneOf GceWithPdConfigInResponse, MachineConfig
+          $ref: '#/components/schemas/RuntimeConfig'
           # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"

--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -1765,7 +1765,7 @@ components:
       required:
         - id
         - runtimeName
-        - cloudContext
+        - googleProject
         - serviceAccount
         - runtimeConfig
         - status
@@ -1774,14 +1774,22 @@ components:
         id:
           type: integer
           description: Internal Leonardo ID of the runtime
+        workspaceId:
+          type: string
+          description: Id of the workspace associated with this runtime
         runtimeName:
           type: string
           description: The user-supplied name for the runtime
+        googleProject:
+          type: string
+          description:
+            Deprecated. The Google Project used to create the runtime
         cloudContext:
           $ref: '#/components/schemas/CloudContext'
         runtimeConfig:
           type: object
-          description: oneOf GceConfig, GceWithPdConfig, MachineConfig
+          description: oneOf GceWithPdConfigInResponse, MachineConfig
+          # Leo's version -> $ref: "#/components/schemas/OneOfRuntimeConfigInResponse"
         auditInfo:
           $ref: "#/components/schemas/AuditInfo"
         proxyUrl:
@@ -1795,8 +1803,6 @@ components:
         patchInProgress:
           type: boolean
           description: Whether there is a patch in progress on the runtime. Is used to indicate updates that require status transitions.
-        diskConfig:
-          $ref: "#/components/schemas/DiskConfig"
     ListPersistentDiskResponse:
       description: ""
       required:
@@ -2361,6 +2367,35 @@ components:
             Defaults to us-central1-a.
         gpuConfig:
           $ref: "#/components/schemas/GpuConfig"
+    GceWithPdConfigInResponse:
+      description: Configuration for Google Compute Engine instances.
+      allOf:
+        - $ref: '#/components/schemas/RuntimeConfig'
+        - type: object
+          required:
+            - machineType
+            - bootDiskSize
+            - zone
+          properties:
+            persistentDiskId:
+              type: integer
+            bootDiskSize:
+              type: integer
+              description: size for boot disk
+            machineType:
+              type: string
+              description: >
+                Optional, the machine type determines the number of CPUs and memory
+                for the master node. For example "n1-standard-16"
+                or "n1-highmem-64". If unspecified, defaults to creating a "n1-standard-4" machine. To decide which is right for you,
+                see https://cloud.google.com/compute/docs/machine-types
+            zone:
+              type: string
+              description: >
+                Optional, the deployment area of the GCE VM. For example, us-east1-a or europe-west2-c.
+                Defaults to us-central1-a.
+            gpuConfig:
+              $ref: "#/components/schemas/GpuConfig"
     MachineConfig:
       description: Configuration for a single Dataproc cluster.
       required:

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineRuntimeControllerTest.java
@@ -1,10 +1,13 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -12,6 +15,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import jakarta.mail.MessagingException;
@@ -19,6 +24,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
@@ -44,11 +50,15 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
+import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
@@ -405,5 +415,136 @@ public class OfflineRuntimeControllerTest {
     verify(mockMailService)
         .alertUsersUnusedDiskWarningThreshold(
             eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(14), eq(123.0));
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_attached() throws Exception {
+    int diskId = 1;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse)));
+
+    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_multiple() throws Exception {
+    int diskId = 1;
+    int otherDiskId = 2;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse1 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse1.cloudService(CloudServiceEnum.GCE);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(
+                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse1),
+                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
+
+    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_mismatch() throws Exception {
+    int diskId = 1;
+    int otherDiskId = 2;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
+
+    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_no_runtimes() throws Exception {
+    int diskId = 1;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(Collections.emptyList());
+
+    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_attached() throws Exception {
+    String diskName = "my-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(List.of(new UserAppEnvironment().diskName(diskName)));
+
+    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_multiple() throws Exception {
+    String diskName = "my-disk-name";
+    String otherDiskName = "other-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(
+            List.of(
+                new UserAppEnvironment().diskName(diskName),
+                new UserAppEnvironment().diskName(otherDiskName)));
+
+    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_mismatch() throws Exception {
+    String diskName = "my-disk-name";
+    String otherDiskName = "other-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(List.of(new UserAppEnvironment().diskName(otherDiskName)));
+
+    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_no_apps() throws Exception {
+    String diskName = "my-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(Collections.emptyList());
+
+    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -319,7 +319,8 @@ public class RuntimeControllerTest {
             .toolDockerImage(TOOL_DOCKER_IMAGE)
             .autopauseThreshold(AUTOPAUSE_THRESHOLD)
             .dataprocConfig(dataprocConfig)
-            .createdDate(createdDate);
+            .createdDate(createdDate)
+            .errors(Collections.emptyList());
 
     testWorkspace =
         new DbWorkspace()
@@ -437,12 +438,22 @@ public class RuntimeControllerTest {
   }
 
   @Test
-  public void testGetRuntime_errorNoMessages() throws ApiException {
+  public void testGetRuntime_error_nullMessages() throws ApiException {
     when(mockUserRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
         .thenReturn(testLeoRuntime.status(LeonardoRuntimeStatus.ERROR).errors(null));
 
     assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody())
-        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR));
+        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR).errors(null));
+  }
+
+  @Test
+  public void testGetRuntime_error_emptyMessageList() throws ApiException {
+    when(mockUserRuntimesApi.getRuntime(GOOGLE_PROJECT_ID, getRuntimeName()))
+        .thenReturn(
+            testLeoRuntime.status(LeonardoRuntimeStatus.ERROR).errors(Collections.emptyList()));
+
+    assertThat(runtimeController.getRuntime(WORKSPACE_NS).getBody())
+        .isEqualTo(testRuntime.status(RuntimeStatus.ERROR).errors(Collections.emptyList()));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/RuntimeControllerTest.java
@@ -598,7 +598,8 @@ public class RuntimeControllerTest {
   public void testGetRuntime_fromListRuntimes_dataprocConfig() throws ApiException {
     String timestamp = "2020-09-13T19:19:57.347Z";
 
-    LeonardoMachineConfig dataprocRuntimeConfig = new LeonardoMachineConfig()
+    LeonardoMachineConfig dataprocRuntimeConfig =
+        new LeonardoMachineConfig()
             .cloudService(LeonardoMachineConfig.CloudServiceEnum.DATAPROC)
             .masterDiskSize(50)
             .masterMachineType("n1-standard-4")


### PR DESCRIPTION
This now approximates current state, to help ease the transition to using the Leo client.  No expected changes.

Tested locally by creating a runtime.  This process calls getRuntime() repeatedly to poll for success.
After deleting a runtime, opening the runtime configuration panel calls listRuntimes() to get information about previously deleted runtimes.  Tested by observing that this continued to work in cases where a disk exists and does not.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
