### PR TITLE
[risk=low][no ticket] mysql docker start can take a minute or longer

### DIFF
--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -6,6 +6,7 @@ require_relative "./mysql_docker"
 class CloudSqlProxyContext < ServiceAccountContext
 
   DOCKER_PROXY_NAME = 'rw_cloud_sql_proxy'
+  DEADLINE_SEC = 75
 
   def run()
     common = Common.new
@@ -38,13 +39,11 @@ class CloudSqlProxyContext < ServiceAccountContext
           }).chomp
       end
       begin
-        deadline_sec = 75
-
-        common.status "waiting up to #{deadline_sec}s for cloudsql proxy to start..."
+        common.status "waiting up to #{DEADLINE_SEC}s for cloudsql proxy to start..."
         start = Time.now
         until common.run(maybe_dockerize_mysql_cmd("mysqladmin ping --host 0.0.0.0 --port 3307 --silent")).success?
-          if Time.now - start >= deadline_sec
-            raise("mysql docker service did not become available after #{deadline_sec}s")
+          if Time.now - start >= DEADLINE_SEC
+            raise("mysql docker service did not become available after #{DEADLINE_SEC}s")
           end
           sleep 1
         end

--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -38,13 +38,13 @@ class CloudSqlProxyContext < ServiceAccountContext
           }).chomp
       end
       begin
-        deadlineSec = 40
+        deadline_sec = 75
 
-        common.status "waiting up to #{deadlineSec}s for cloudsql proxy to start..."
+        common.status "waiting up to #{deadline_sec}s for cloudsql proxy to start..."
         start = Time.now
         until common.run(maybe_dockerize_mysql_cmd("mysqladmin ping --host 0.0.0.0 --port 3307 --silent")).success?
-          if Time.now - start >= deadlineSec
-            raise("mysql docker service did not become available after #{deadlineSec}s")
+          if Time.now - start >= deadline_sec
+            raise("mysql docker service did not become available after #{deadline_sec}s")
           end
           sleep 1
         end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -75,20 +75,20 @@ def format_benchmark(bm)
   "%ds" % [bm.real]
 end
 
+DEADLINE_SEC = 75
 def start_local_db_service()
   common = Common.new
-  deadline_sec = 75
 
   bm = Benchmark.measure {
     common.run_inline %W{docker compose up -d db}
 
     root_pass = "root-notasecret"
 
-    common.status "waiting up to #{deadline_sec}s for mysql service to start..."
+    common.status "waiting up to #{DEADLINE_SEC}s for mysql service to start..."
     start = Time.now
     until (common.run "docker compose exec -T db mysql -p#{root_pass} --silent -e 'SELECT 1;'").success?
-      if Time.now - start >= deadline_sec
-        raise("mysql docker service did not become available after #{deadline_sec}s")
+      if Time.now - start >= DEADLINE_SEC
+        raise("mysql docker service did not become available after #{DEADLINE_SEC}s")
       end
       sleep 1
     end

--- a/api/libproject/devstart.rb
+++ b/api/libproject/devstart.rb
@@ -77,18 +77,18 @@ end
 
 def start_local_db_service()
   common = Common.new
-  deadlineSec = 40
+  deadline_sec = 75
 
   bm = Benchmark.measure {
     common.run_inline %W{docker compose up -d db}
 
     root_pass = "root-notasecret"
 
-    common.status "waiting up to #{deadlineSec}s for mysql service to start..."
+    common.status "waiting up to #{deadline_sec}s for mysql service to start..."
     start = Time.now
     until (common.run "docker compose exec -T db mysql -p#{root_pass} --silent -e 'SELECT 1;'").success?
-      if Time.now - start >= deadlineSec
-        raise("mysql docker service did not become available after #{deadlineSec}s")
+      if Time.now - start >= deadline_sec
+        raise("mysql docker service did not become available after #{deadline_sec}s")
       end
       sleep 1
     end


### PR DESCRIPTION
Bump the wait time which is causing many spurious CircleCI failures.  Tested locally by running a few project.rb commands.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
