### PR TITLE
[risk=low][RW-11727] Fix the Create Terra Method Snapshot tool

### DIFF
--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
@@ -149,7 +149,8 @@ public class CreateTerraMethodSnapshot extends Tool {
               .name(methodName)
               .entityType("Workflow")
               .snapshotComment(snapshotComment)
-              .payload(sourceFileContents);
+              .payload(sourceFileContents)
+              .documentation("Automatically created snapshot from Github").synopsis("Automatically created snapshot from Github");
 
       FirecloudMethodResponse methodResponse;
       if (existingMethods.isEmpty()) {

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
@@ -150,7 +150,8 @@ public class CreateTerraMethodSnapshot extends Tool {
               .entityType("Workflow")
               .snapshotComment(snapshotComment)
               .payload(sourceFileContents)
-              .documentation("Automatically created snapshot from Github").synopsis("Automatically created snapshot from Github");
+              .documentation("Automatically created snapshot from Github")
+              .synopsis("Automatically created snapshot from Github");
 
       FirecloudMethodResponse methodResponse;
       if (existingMethods.isEmpty()) {

--- a/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
+++ b/api/tools/src/main/java/org/pmiops/workbench/tools/CreateTerraMethodSnapshot.java
@@ -26,8 +26,6 @@ import org.pmiops.workbench.firecloud.model.FirecloudMethodQuery;
 import org.pmiops.workbench.firecloud.model.FirecloudMethodResponse;
 import org.pmiops.workbench.tools.factories.ToolsFirecloudApiClientFactory;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.WebApplicationType;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -250,9 +248,6 @@ public class CreateTerraMethodSnapshot extends Tool {
   }
 
   public static void main(String[] args) {
-    new SpringApplicationBuilder(CreateTerraMethodSnapshot.class)
-        .web(WebApplicationType.NONE)
-        .run(args)
-        .close();
+    CommandLineToolConfig.runCommandLine(CreateTerraMethodSnapshot.class, args);
   }
 }


### PR DESCRIPTION
This tool is used to update the Genomic Extraction Workflow.  We haven't used it for over 2 years, so it was no longer working.

I removed one of the operational modes (all-projects) and I was then able to run it with this command line (this is unlikely to produce a valid workflow / method; it's just for experimentation)
```
./project.rb create-terra-method-snapshot \
--source-git-repo all-of-us/workbench \
--source-git-path api/genomics/wdl/WgsCohortExtract.wdl \
--source-git-ref main \
--method-name joeltest \
--project all-of-us-workbench-test
```

I did not explore how to restore all-projects.  We don't strictly need it - a workaround is to run it once per project.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
