### PR TITLE
[DT-914][risk=no] Switch to CDR version prop for Data Apps dropdown

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -19,7 +19,6 @@ import {
   WorkspaceOperationStatus,
 } from 'generated/fetch';
 
-import { environment } from 'environments/environment';
 import { parseQueryParams } from 'app/components/app-router';
 import { Button, LinkButton, StyledExternalLink } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
@@ -228,7 +227,10 @@ export const styles = reactStyles({
     width: '11em',
   },
   cdrVersionSpacing: {
-    width: environment.showDataAppsVersionSelect ? '23em' : '30em',
+    width: '30em',
+  },
+  dataAppsVersionSpacing: {
+    width: '23em',
   },
 });
 
@@ -1432,6 +1434,14 @@ export const WorkspaceEdit = fp.flow(
       );
     }
 
+    showDataAppsVersionSelect() {
+      const { tiers } = this.props.cdrVersionTiersResponse;
+      // Show the version dropdown if at least one CDR version has tanagraEnabled set to true
+      return fp
+        .flatMap((tier) => tier?.versions, tiers)
+        .some(({ tanagraEnabled }) => tanagraEnabled);
+    }
+
     dataAppsVersionOptions() {
       return getCdrVersion(
         this.state.workspace,
@@ -1616,12 +1626,17 @@ export const WorkspaceEdit = fp.flow(
                   >
                     <div
                       data-test-id='select-cdr-version'
-                      style={{ ...styles.select, ...styles.cdrVersionSpacing }}
+                      style={{
+                        ...styles.select,
+                        ...styles.dataAppsVersionSpacing,
+                      }}
                     >
                       <select
                         style={{
                           ...styles.selectInput,
-                          ...styles.cdrVersionSpacing,
+                          ...(this.showDataAppsVersionSelect()
+                            ? styles.dataAppsVersionSpacing
+                            : styles.cdrVersionSpacing),
                         }}
                         aria-label='cdr version dropdown'
                         value={cdrVersionId}
@@ -1656,7 +1671,7 @@ export const WorkspaceEdit = fp.flow(
                     </div>
                   </TooltipTrigger>
                 </FlexColumn>
-                {environment.showDataAppsVersionSelect && (
+                {this.showDataAppsVersionSelect() && (
                   <FlexColumn>
                     <div style={styles.fieldHeader}>
                       Data Apps version

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -65,8 +65,6 @@ export interface EnvironmentBase {
   // Pass auth token in iframe url
   // WARNING: This is insecure and should only be enabled for local environments
   tanagraLocalAuth: boolean;
-  // Show dropdown on workspace create to select Data Apps V1 (current/legacy) or Data Apps V2 (Tanagra)
-  showDataAppsVersionSelect: boolean;
 }
 
 export interface Environment extends EnvironmentBase {

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,5 +21,4 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 99999999999,
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: true,
-  showDataAppsVersionSelect: true,
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -19,5 +19,4 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
-  showDataAppsVersionSelect: true,
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -19,5 +19,4 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 12 * 60 * 60, // 12 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
-  showDataAppsVersionSelect: false,
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -19,5 +19,4 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
-  showDataAppsVersionSelect: true,
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -19,5 +19,4 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: false,
-  showDataAppsVersionSelect: true,
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,5 +23,4 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: false,
-  showDataAppsVersionSelect: true,
 };


### PR DESCRIPTION
- Remove the `showDataAppsVersionSelect` UI env var
- Only show the Data Apps version dropdown if one or more CDR version has `tanagraEnabled` set to `true

Tested locally by filtering out CDR versions with `tanagraEnabled: true` before set them in the store and verifying the data apps dropdown doesn't show:
<img width="1252" alt="Screenshot 2024-11-01 at 3 46 33 PM" src="https://github.com/user-attachments/assets/72b55f9d-5c25-4cba-a0de-adde60a6d16e">

If at least on CDR version is `tanagraEnabled`, the dropdown should show:
<img width="1283" alt="Screenshot 2024-11-01 at 3 48 40 PM" src="https://github.com/user-attachments/assets/0dfa0365-5d27-4c7e-9a7e-4eda2177838a">
