### PR TITLE
[risk=low][no ticket] Fix UI unit test which may fail on a time-change week

### DIFF
--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -20,6 +20,7 @@ import {
   defaultAppRequest,
 } from 'app/components/apps-panel/utils';
 import { appsApi, registerApiClient } from 'app/services/swagger-fetch-clients';
+import { MILLIS_PER_DAY } from 'app/utils/dates';
 import { autodeleteOptions, findMachineByName } from 'app/utils/machines';
 import { serverConfigStore } from 'app/utils/stores';
 import { appTypeToString } from 'app/utils/user-apps-utils';
@@ -295,9 +296,14 @@ describe(CreateGkeApp.name, () => {
 
       it('should correctly calculate autodeleteRemainingDays', async () => {
         const now = new Date();
-        now.setDate(now.getDate() - 2); // Subtract 2 days
-        const dateAccessed = now;
-        const autodeleteThreshold = 7 * 24 * 60 + 1; // 7 days in minutes plus a small buffer
+        const twoDaysInMillis = 2 * MILLIS_PER_DAY;
+        const oneMinuteBufferInMillis = 70; // just over 60 seconds
+        // 2 days ago, minus a minute buffer
+        const elapsedTime = twoDaysInMillis - oneMinuteBufferInMillis;
+        const dateAccessed = new Date(now.valueOf() - elapsedTime);
+
+        const sevenDaysInMinutes = 7 * 24 * 60;
+        const autodeleteThreshold = sevenDaysInMinutes;
 
         await component(appType, {
           userApps: [
@@ -316,9 +322,14 @@ describe(CreateGkeApp.name, () => {
 
       it('should show correct message when autodeleteRemainingDays is 0', async () => {
         const now = new Date();
-        now.setDate(now.getDate() - 2); // Subtract 2 days
-        const dateAccessed = now;
-        const autodeleteThreshold = 2 * 24 * 60 + 1; // 2 days in minutes plus small buffer.
+        const twoDaysInMillis = 2 * MILLIS_PER_DAY;
+        const oneMinuteBufferInMillis = 70; // just over 60 seconds
+        // 2 days ago, minus a minute buffer
+        const elapsedTime = twoDaysInMillis - oneMinuteBufferInMillis;
+        const dateAccessed = new Date(now.valueOf() - elapsedTime);
+
+        const twoDaysInMinutes = 2 * 24 * 60;
+        const autodeleteThreshold = twoDaysInMinutes;
 
         await component(appType, {
           userApps: [


### PR DESCRIPTION
Instead of using MILLIS_PER_DAY to determine a day length, this test subtracted calendar days.  When daylight savings is starting or ending, these values can be off by an hour.  I got unlucky this morning!

Now the test uses MILLIS_PER_DAY so it always lines up with the check.

UX impact: when we tell the user that "3 days remain" that's a whole-number estimate.  IMO it's fine to be off by an hour here.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
