### PR TITLE
[risk=low][no ticket] Make DUCC v6 the only valid version

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -99,7 +99,7 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -99,7 +99,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": false,
     "enableRasLoginGovLinking": false,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -99,7 +99,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -99,7 +99,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -100,7 +100,7 @@
     "unsafeAllowUserCreationFromGSuiteData": false,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 365,
       "expiryDaysWarningThresholds": [1, 7, 15],

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -99,7 +99,7 @@
     "unsafeAllowUserCreationFromGSuiteData": true,
     "enableRasIdMeLinking": true,
     "enableRasLoginGovLinking": true,
-    "currentDuccVersions": [5, 6],
+    "currentDuccVersions": [6],
     "renewal": {
       "expiryDays": 3650,
       "expiryDaysWarningThresholds": [1, 7, 15],


### PR DESCRIPTION
DUCC v6 has been out for a year now.  We expect all users with current access have completed annual renewal, so they have all signed v6 of the DUCC.  We don't need to support any older versions now.

Tested locally with no issues.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
