### PR TITLE
RW-11727 add back query_project input for old workflow

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -359,7 +359,8 @@ public class GenomicExtractionService {
       // Added in https://github.com/broadinstitute/gatk/pull/7698
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".extraction_uuid", "\"" + extractionUuid + "\"");
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".cohort_table_prefix", "\"" + extractionUuid + "\"");
-      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".query_project", "\"" + workspace.getGoogleProject() + "\"");
+      maybeInputs.put(
+          EXTRACT_WORKFLOW_NAME + ".query_project", "\"" + workspace.getGoogleProject() + "\"");
     } else {
       // Added Nov 2024
       // replaces extraction_uuid and cohort_table_prefix which are now set to this value

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -384,7 +384,6 @@ public class GenomicExtractionService {
                 + "/"
                 + personIdsFile.getName()
                 + "\"")
-        .put(EXTRACT_WORKFLOW_NAME + ".query_project", "\"" + workspace.getGoogleProject() + "\"")
         .put(EXTRACT_WORKFLOW_NAME + ".destination_project_id", "\"" + destinationParts[0] + "\"")
         .put(EXTRACT_WORKFLOW_NAME + ".destination_dataset_name", "\"" + destinationParts[1] + "\"")
         .put(

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -359,6 +359,7 @@ public class GenomicExtractionService {
       // Added in https://github.com/broadinstitute/gatk/pull/7698
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".extraction_uuid", "\"" + extractionUuid + "\"");
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".cohort_table_prefix", "\"" + extractionUuid + "\"");
+      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".query_project", "\"" + workspace.getGoogleProject() + "\"");
     } else {
       // Added Nov 2024
       // replaces extraction_uuid and cohort_table_prefix which are now set to this value


### PR DESCRIPTION
For old workflow, the parameter is required, or we get the following error

```
[rawls-akka.actor.default-dispatcher-15] akka.actor.ActorSystemImpl - HttpMethod(POST) http://app:8080/api/workspaces/aou-wgs-cohort-extraction/aouwgscohortextraction/submissions: 400 Bad Request entity: {"causes":[],"message":"Validation errors: Missing inputs: GvsExtractCohortFromSampleNames.query_project","source":"rawls","stackTrace":[],"statusCode":400}
```

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
