### PR TITLE
[risk=no][RW-11727] Update test wgs extraction crdv8plus, rm local

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -56,12 +56,6 @@
       "methodLogicalVersion": 3,
       "minExtractionScatterTasks": 20,
       "extractionScatterTasksPerSample": 4
-    },
-    "cdrv8plus": {
-      "methodNamespace": "aouwgscohortextraction-test",
-      "methodName": "dest_project_id_yonghao_test",
-      "methodRepoVersion": 2,
-      "methodLogicalVersion": 4
     }
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -59,9 +59,9 @@
     },
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-test",
-      "methodName": "dest_project_id_yonghao_test",
-      "methodRepoVersion": 2,
-      "methodLogicalVersion": 4
+      "methodName": "echo-prototyping",
+      "methodRepoVersion": 1,
+      "methodLogicalVersion": 1
     }
   },
   "cdr": {


### PR DESCRIPTION
Use the newest workflow from https://github.com/broadinstitute/gatk/pull/9036 , uploaded to Agora Dev via
```
./project.rb create-terra-method-snapshot \
--source-git-repo broadinstitute/gatk \
--source-git-ref qi-attempt \
--source-git-path scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl \
--method-namespace aouwgscohortextraction-test \
--method-name echo-prototyping \
--project all-of-us-workbench-test
```

Also remove the config from Local, because we do not have an appropriate Echo/v8 CDR there.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
