### PR TITLE
[risk=no][RW-11727] Add a v8 CDR and method config to local

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -157,7 +157,7 @@
       "wgsFilterSetName": "echo-controls",
       "creationTime": "2024-11-04 19:58:48Z",
       "numParticipants": 234525,
-      "cdrDbName": "sc_2022q4_19",
+      "cdrDbName": "cdr",
       "hasFitbitData": true,
       "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,

--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -150,24 +150,25 @@
     {
       "cdrVersionId": 10,
       "isDefault": true,
-      "name": "Synthetic Dataset in the Controlled Tier - Joeltest",
+      "name": "Synthetic Dataset in the Controlled Tier v8 (Echo)",
       "bigqueryProject": "fc-aou-cdr-synth-test-2",
-      "bigqueryDataset": "SC2023Q3R2",
-      "wgsBigqueryDataset": "1kg_wgs_2022q1",
-      "wgsFilterSetName": "example",
-      "creationTime": "2020-08-26 00:09:51Z",
+      "bigqueryDataset": "SC2023Q3R3",
+      "wgsBigqueryDataset": "echo_controls",
+      "wgsFilterSetName": "echo-controls",
+      "creationTime": "2024-11-04 19:58:48Z",
       "numParticipants": 234525,
-      "cdrDbName": "cdr",
+      "cdrDbName": "sc_2022q4_19",
       "hasFitbitData": true,
       "hasFitbitSleepData": true,
       "hasCopeSurveyData": true,
       "hasSurveyConductData": true,
-      "storageBasePath": "v7",
+      "storageBasePath": "5",
       "wgsVcfMergedStoragePath": "wgs/vcf/merged",
       "wgsCramManifestPath": "wgs/cram/manifest.csv",
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled",
-      "tanagraEnabled": true
+      "tanagraEnabled": true,
+      "needsV8GenomicExtractionWorkflow": true
     }
   ]
 }

--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -111,7 +111,6 @@
     },
     {
       "cdrVersionId": 8,
-      "isDefault": true,
       "name": "Synthetic Dataset in the Controlled Tier v4",
       "bigqueryProject": "fc-aou-cdr-synth-test-2",
       "bigqueryDataset": "SC2023Q3R2",
@@ -146,6 +145,28 @@
       "hasCopeSurveyData": true,
       "hasSurveyConductData": true,
       "accessTier": "registered",
+      "tanagraEnabled": true
+    },
+    {
+      "cdrVersionId": 10,
+      "isDefault": true,
+      "name": "Synthetic Dataset in the Controlled Tier - Joeltest",
+      "bigqueryProject": "fc-aou-cdr-synth-test-2",
+      "bigqueryDataset": "SC2023Q3R2",
+      "wgsBigqueryDataset": "1kg_wgs_2022q1",
+      "wgsFilterSetName": "example",
+      "creationTime": "2020-08-26 00:09:51Z",
+      "numParticipants": 234525,
+      "cdrDbName": "cdr",
+      "hasFitbitData": true,
+      "hasFitbitSleepData": true,
+      "hasCopeSurveyData": true,
+      "hasSurveyConductData": true,
+      "storageBasePath": "v7",
+      "wgsVcfMergedStoragePath": "wgs/vcf/merged",
+      "wgsCramManifestPath": "wgs/cram/manifest.csv",
+      "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
+      "accessTier": "controlled",
       "tanagraEnabled": true
     }
   ]

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -60,7 +60,7 @@
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "echo-prototyping",
-      "methodRepoVersion": 1,
+      "methodRepoVersion": 2,
       "methodLogicalVersion": 1
     }
   },

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -56,6 +56,12 @@
       "methodLogicalVersion": 3,
       "minExtractionScatterTasks": 20,
       "extractionScatterTasksPerSample": 4
+    },
+    "cdrv8plus": {
+      "methodNamespace": "aouwgscohortextraction-test",
+      "methodName": "echo-prototyping",
+      "methodRepoVersion": 1,
+      "methodLogicalVersion": 1
     }
   },
   "cdr": {


### PR DESCRIPTION
To run a genomic extraction on Local:
* run the CDR migration with this branch checked out `./project.rb run-local-all-migrations`
* dev-up API and UI
* create a Workspace using this Controlled Tier CDR
* create a Dataset with genomics (the cohort does not need the "Genomics" Program Data, which may not appear on Local - many cohorts will have genomics data regardless)
* analyze/extract that dataset

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
