### PR TITLE
[risk=low][no ticket] Change footer links to absolute paths so they always work

### DIFF
--- a/ui/src/app/components/footer.tsx
+++ b/ui/src/app/components/footer.tsx
@@ -177,13 +177,13 @@ const WorkbenchFooter = withUserProfile()(
                     Home
                   </FooterAnchorTag>
                   <FooterAnchorTag
-                    href='library'
+                    href='/library'
                     analyticsFn={tracker.FeaturedWorkspaces}
                   >
                     Featured Workspaces
                   </FooterAnchorTag>
                   <FooterAnchorTag
-                    href='workspaces'
+                    href='/workspaces'
                     analyticsFn={tracker.YourWorkspaces}
                   >
                     Your Workspaces

--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -337,7 +337,7 @@ export const SideNav = (props: SideNavProps) => {
         icon='star'
         content='Featured Workspaces'
         onToggleSideNav={() => onToggleSideNav()}
-        href={'/library'}
+        href='/library'
         active={libraryActive()}
         disabled={!hasRegisteredTierAccess(profile)}
       />
@@ -407,7 +407,7 @@ export const SideNav = (props: SideNavProps) => {
           <SideNavItem
             content='Workspaces'
             onToggleSideNav={() => onToggleSideNav()}
-            href='admin/workspaces'
+            href='/admin/workspaces'
             active={workspaceAdminActive()}
           />
         )}


### PR DESCRIPTION
When you are in a workspace, the "Your Workspaces" and "Featured Workspaces" do not work, though they do work when you're at the homepage - probably how we missed this.

Changing these links from relative to absolute means they now work in all cases.

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
