### PR TITLE
[risk=low][RW-13907] Fix Prod Zendesk by showing launcher button

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -312,17 +312,6 @@ form .form-block > label,
   font-weight: 300;
 }
 
-/*
- * Force the Zendesk web widget "launcher" button to be hidden at all times.
- * This is a style-based workaround to ensure the Zendesk launcher button isn't
- * shown. Ideally, hiding the launcher would be possible via the Zendesk web widget
- * API, but certain API limitations don't make that possible. See the AoU Zendesk
- * integration doc for more details.
- */
-iframe#launcher {
-  display: none;
-}
-
 /**:focus {outline:none !important}*/
 
 @keyframes rotation {


### PR DESCRIPTION
When I remove this setting using DevTools on Prod, it behaves in the way we expect.

I'm not sure why we were hiding the launcher button, but it seems that this is now the only way to close the menu, so we need it now.

![Zendesk](https://github.com/user-attachments/assets/82bb97cc-910c-4122-8557-8695629a180c)


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [x] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
