### PR TITLE
[risk=low][RW-13930] Make gatkJarUri version-dependent

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -47,9 +47,9 @@
     "operationalTerraWorkspaceName": "aouwgscohortextraction",
     "operationalTerraWorkspaceBucket": "fc-56d2f6f5-3efa-46f7-8c01-0911fd77f888",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-177-gbd0a99c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": false,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 15,
@@ -58,6 +58,7 @@
       "extractionScatterTasksPerSample": 4
     },
     "cdrv8plus": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-177-gbd0a99c-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "echo-prototyping",
       "methodRepoVersion": 2,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -47,9 +47,9 @@
     "operationalTerraWorkspaceName": "aouwgscohortextractionpreprod",
     "operationalTerraWorkspaceBucket": "fc-5d8e6afe-9429-44ae-a22a-67b09705d1b4",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-preprod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -47,9 +47,9 @@
     "operationalTerraWorkspaceName": "aouwgscohortextractionprod",
     "operationalTerraWorkspaceBucket": "fc-43443354-728d-4523-a31d-acdff4a271b8",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-prod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 4,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -46,10 +46,10 @@
     "operationalTerraWorkspaceNamespace": "aouwgscohortextraction-stable",
     "operationalTerraWorkspaceName": "aouwgscohortextractionstable",
     "operationalTerraWorkspaceBucket": "fc-b7045821-7a05-497e-844d-8889625ed10e",
-     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+    "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "enableJiraTicketingOnFailure": true,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-stable",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -48,9 +48,9 @@
     "operationalTerraWorkspaceName": "aouwgscohortextractionstaging",
     "operationalTerraWorkspaceBucket": "fc-c143d305-0ffd-4ca5-b585-9b222691da6c",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-staging",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -47,9 +47,9 @@
     "operationalTerraWorkspaceName": "aouwgscohortextraction",
     "operationalTerraWorkspaceBucket": "fc-56d2f6f5-3efa-46f7-8c01-0911fd77f888",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
-    "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-177-gbd0a99c-SNAPSHOT-local.jar",
     "enableJiraTicketingOnFailure": true,
     "legacyVersions": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 15,
@@ -58,6 +58,7 @@
       "extractionScatterTasksPerSample": 4
     },
     "cdrv8plus": {
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-177-gbd0a99c-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "echo-prototyping",
       "methodRepoVersion": 2,

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -175,10 +175,10 @@ public class WorkbenchConfig {
     public String operationalTerraWorkspaceName;
     public String operationalTerraWorkspaceBucket;
     public String extractionDestinationDataset;
-    public String gatkJarUri;
     public boolean enableJiraTicketingOnFailure;
 
     public abstract static class VersionedConfig {
+      public String gatkJarUri;
       // 'method' values refer to both the stored Method and the generated Method Configuration
       public String methodNamespace;
       public String methodName;

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -320,7 +320,8 @@ public class GenomicExtractionService {
       List<String> personIds,
       String extractionFolder,
       String outputDir,
-      boolean useLegacyWorkflow) {
+      boolean useLegacyWorkflow,
+      String gatkJarUri) {
 
     String[] destinationParts = cohortExtractionConfig.extractionDestinationDataset.split("\\.");
     if (destinationParts.length != 2) {
@@ -397,9 +398,7 @@ public class GenomicExtractionService {
         // etc
         .put(EXTRACT_WORKFLOW_NAME + ".output_file_base_name", "\"interval\"")
         .put(EXTRACT_WORKFLOW_NAME + ".output_gcs_dir", "\"" + outputDir + "\"")
-        .put(
-            EXTRACT_WORKFLOW_NAME + ".gatk_override",
-            "\"" + cohortExtractionConfig.gatkJarUri + "\"")
+        .put(EXTRACT_WORKFLOW_NAME + ".gatk_override", "\"" + gatkJarUri + "\"")
         .putAll(maybeInputs)
         .build();
   }
@@ -463,7 +462,8 @@ public class GenomicExtractionService {
                             personIds,
                             extractionFolder,
                             outputDir,
-                            useLegacyWorkflow))
+                            useLegacyWorkflow,
+                            versionedConfig.gatkJarUri))
                     .methodConfigVersion(versionedConfig.methodRepoVersion)
                     .methodRepoMethod(createRepoMethodParameter(versionedConfig))
                     .name(extractionUuid)


### PR DESCRIPTION
Tested by running v7 and v8 extractions on Local

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
