### PR TITLE
[RW-13736][risk=no] Add extension date

### DIFF
--- a/api/db/changelog/db.changelog-243-replace-extension-count.xml
+++ b/api/db/changelog/db.changelog-243-replace-extension-count.xml
@@ -7,7 +7,7 @@
   <changeSet author="evrii" id="db.changelog-243-replace-extension-count">
     <dropColumn tableName="user_initial_credits_expiration" columnName="extension_count"/>
     <addColumn tableName="user_initial_credits_expiration">
-      <column name="extension_date" type="datetime"/>
+      <column name="extension_time" type="datetime"/>
     </addColumn>
   </changeSet>
 </databaseChangeLog>

--- a/api/db/changelog/db.changelog-243-replace-extension-count.xml
+++ b/api/db/changelog/db.changelog-243-replace-extension-count.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="evrii" id="db.changelog-243-replace-extension-count">
+    <dropColumn tableName="user_initial_credits_expiration" columnName="extension_count"/>
+    <addColumn tableName="user_initial_credits_expiration">
+      <column name="extension_date" type="datetime"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -250,6 +250,7 @@
   <include file="changelog/db.changelog-240-cdr-version-hasFitbitDevice-field.xml"/>
   <include file="changelog/db.changelog-241-replace-user-initial-credits-expiration-status.xml"/>
   <include file="changelog/db.changelog-242-remove-old-workspace-columns.xml"/>
+  <include file="changelog/db.changelog-243-replace-extension-count.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
@@ -21,7 +21,7 @@ public class DbUserInitialCreditsExpiration {
   private Timestamp approachingExpirationNotificationTime;
   private Timestamp expirationCleanupTime;
   private boolean bypassed;
-  private int extensionCount;
+  private Timestamp extensionDate;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -76,13 +76,13 @@ public class DbUserInitialCreditsExpiration {
     return this;
   }
 
-  @Column(name = "extension_count")
-  public int getExtensionCount() {
-    return extensionCount;
+  @Column(name = "extension_date")
+  public Timestamp getExtensionDate() {
+    return extensionDate;
   }
 
-  public DbUserInitialCreditsExpiration setExtensionCount(int extensionCount) {
-    this.extensionCount = extensionCount;
+  public DbUserInitialCreditsExpiration setExtensionDate(Timestamp extensionDate) {
+    this.extensionDate = extensionDate;
     return this;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbUserInitialCreditsExpiration.java
@@ -21,7 +21,7 @@ public class DbUserInitialCreditsExpiration {
   private Timestamp approachingExpirationNotificationTime;
   private Timestamp expirationCleanupTime;
   private boolean bypassed;
-  private Timestamp extensionDate;
+  private Timestamp extensionTime;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -76,13 +76,13 @@ public class DbUserInitialCreditsExpiration {
     return this;
   }
 
-  @Column(name = "extension_date")
-  public Timestamp getExtensionDate() {
-    return extensionDate;
+  @Column(name = "extension_time")
+  public Timestamp getExtensionTime() {
+    return extensionTime;
   }
 
-  public DbUserInitialCreditsExpiration setExtensionDate(Timestamp extensionDate) {
-    this.extensionDate = extensionDate;
+  public DbUserInitialCreditsExpiration setExtensionTime(Timestamp extensionDate) {
+    this.extensionTime = extensionDate;
     return this;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -340,6 +340,7 @@ public class InitialCreditsService {
   public void extendInitialCreditsExpiration(DbUser user) {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
+    //This handles the case existing users that have not yet been migrated but also those who have not yet completed RT training.
     if (userInitialCreditsExpiration == null) {
       throw new WorkbenchException(
           "User does not have initial credits expiration set, so they cannot extend their expiration date.");

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -341,11 +341,24 @@ public class InitialCreditsService {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
     if (userInitialCreditsExpiration == null) {
-      throw new WorkbenchException("User does not have initial credits expiration set.");
+      throw new WorkbenchException("User does not have initial credits expiration set, so they cannot extend their expiration date.");
     }
+
+    if(institutionService.shouldBypassForCreditsExpiration(user)) {
+      throw new WorkbenchException("User has their initial credits expiration bypassed by their institution, and therefore cannot have their expiration extended.");
+    }
+
+    if(userInitialCreditsExpiration.isBypassed()) {
+      throw new WorkbenchException("User has their initial credits expiration bypassed, and therefore cannot have their expiration extended.");
+    }
+
     if (userInitialCreditsExpiration.getExtensionTime() != null) {
       throw new WorkbenchException(
           "User has already extended their initial credits expiration and cannot extend further.");
+    }
+    if (!areCreditsExpiringSoon(user)) {
+      throw new WorkbenchException(
+          "User's initial credits are not close enough to their expiration date to be extended.");
     }
     userInitialCreditsExpiration.setExpirationTime(
         new Timestamp(

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -341,15 +341,18 @@ public class InitialCreditsService {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
     if (userInitialCreditsExpiration == null) {
-      throw new WorkbenchException("User does not have initial credits expiration set, so they cannot extend their expiration date.");
+      throw new WorkbenchException(
+          "User does not have initial credits expiration set, so they cannot extend their expiration date.");
     }
 
-    if(institutionService.shouldBypassForCreditsExpiration(user)) {
-      throw new WorkbenchException("User has their initial credits expiration bypassed by their institution, and therefore cannot have their expiration extended.");
+    if (institutionService.shouldBypassForCreditsExpiration(user)) {
+      throw new WorkbenchException(
+          "User has their initial credits expiration bypassed by their institution, and therefore cannot have their expiration extended.");
     }
 
-    if(userInitialCreditsExpiration.isBypassed()) {
-      throw new WorkbenchException("User has their initial credits expiration bypassed, and therefore cannot have their expiration extended.");
+    if (userInitialCreditsExpiration.isBypassed()) {
+      throw new WorkbenchException(
+          "User has their initial credits expiration bypassed, and therefore cannot have their expiration extended.");
     }
 
     if (userInitialCreditsExpiration.getExtensionTime() != null) {

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -343,7 +343,7 @@ public class InitialCreditsService {
     if (userInitialCreditsExpiration == null) {
       throw new WorkbenchException("User does not have initial credits expiration set.");
     }
-    if (userInitialCreditsExpiration.getExtensionDate() != null) {
+    if (userInitialCreditsExpiration.getExtensionTime() != null) {
       throw new WorkbenchException(
           "User has already extended their initial credits expiration and cannot extend further.");
     }
@@ -352,7 +352,7 @@ public class InitialCreditsService {
             userInitialCreditsExpiration.getCreditStartTime().getTime()
                 + TimeUnit.DAYS.toMillis(
                     workbenchConfigProvider.get().billing.initialCreditsExtensionPeriodDays)));
-    userInitialCreditsExpiration.setExtensionDate(clockNow());
+    userInitialCreditsExpiration.setExtensionTime(clockNow());
     userDao.save(user);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -343,7 +343,7 @@ public class InitialCreditsService {
     if (userInitialCreditsExpiration == null) {
       throw new WorkbenchException("User does not have initial credits expiration set.");
     }
-    if (userInitialCreditsExpiration.getExtensionCount() != 0) {
+    if (userInitialCreditsExpiration.getExtensionDate() != null) {
       throw new WorkbenchException(
           "User has already extended their initial credits expiration and cannot extend further.");
     }
@@ -352,8 +352,7 @@ public class InitialCreditsService {
             userInitialCreditsExpiration.getCreditStartTime().getTime()
                 + TimeUnit.DAYS.toMillis(
                     workbenchConfigProvider.get().billing.initialCreditsExtensionPeriodDays)));
-    userInitialCreditsExpiration.setExtensionCount(
-        userInitialCreditsExpiration.getExtensionCount() + 1);
+    userInitialCreditsExpiration.setExtensionDate(clockNow());
     userDao.save(user);
   }
 

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -341,7 +341,8 @@ public class InitialCreditsService {
   public void extendInitialCreditsExpiration(DbUser user) {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
-    //This handles the case existing users that have not yet been migrated but also those who have not yet completed RT training.
+    // This handles the case existing users that have not yet been migrated but also those who have
+    // not yet completed RT training.
     if (userInitialCreditsExpiration == null) {
       throw new BadRequestException(
           "User does not have initial credits expiration set, so they cannot extend their expiration date.");

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -29,6 +29,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
@@ -342,26 +343,26 @@ public class InitialCreditsService {
         user.getUserInitialCreditsExpiration();
     //This handles the case existing users that have not yet been migrated but also those who have not yet completed RT training.
     if (userInitialCreditsExpiration == null) {
-      throw new WorkbenchException(
+      throw new BadRequestException(
           "User does not have initial credits expiration set, so they cannot extend their expiration date.");
     }
 
     if (institutionService.shouldBypassForCreditsExpiration(user)) {
-      throw new WorkbenchException(
+      throw new BadRequestException(
           "User has their initial credits expiration bypassed by their institution, and therefore cannot have their expiration extended.");
     }
 
     if (userInitialCreditsExpiration.isBypassed()) {
-      throw new WorkbenchException(
+      throw new BadRequestException(
           "User has their initial credits expiration bypassed, and therefore cannot have their expiration extended.");
     }
 
     if (userInitialCreditsExpiration.getExtensionTime() != null) {
-      throw new WorkbenchException(
+      throw new BadRequestException(
           "User has already extended their initial credits expiration and cannot extend further.");
     }
     if (!areCreditsExpiringSoon(user)) {
-      throw new WorkbenchException(
+      throw new BadRequestException(
           "User's initial credits are not close enough to their expiration date to be extended.");
     }
     userInitialCreditsExpiration.setExpirationTime(

--- a/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/profile/ProfileMapper.java
@@ -43,9 +43,12 @@ public interface ProfileMapper {
   @Mapping(source = "dbUser.duccAgreement.completionTime", target = "duccCompletionTimeEpochMillis")
   @Mapping(source = "dbUser.demographicSurveyV2", target = "demographicSurveyV2")
   @Mapping(
-      target = "initialCreditsExpirationEpochMillis",
       source = "dbUser",
+      target = "initialCreditsExpirationEpochMillis",
       qualifiedByName = "getInitialCreditsExpiration")
+  @Mapping(
+      source = "dbUser.userInitialCreditsExpiration.extensionTime",
+      target = "initialCreditsExtensionEpochMillis")
   @Mapping(
       source = "dbUser.userInitialCreditsExpiration.bypassed",
       target = "initialCreditsExpirationBypassed",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -383,6 +383,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/page-visits:
     post:
       tags:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -377,8 +377,8 @@ paths:
         204:
           description: The user's initial credit expiration period has been extended.
           content: {}
-        500:
-          description: Internal Error
+        400:
+          description: Bad request
           content:
             application/json:
               schema:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8514,6 +8514,10 @@ components:
           type: integer
           description: Timestamp indicating when the user's initial credits will expire, if applicable
           format: int64
+        initialCreditsExtensionEpochMillis:
+          type: integer
+          description: Timestamp indicating when the user requested their initial credits expiration to be extended, if applicable
+          format: int64
         initialCreditsExpirationBypassed:
           type: boolean
           default: false

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -152,7 +152,7 @@ public class AccessSyncServiceTest {
             .setCreditStartTime(new Timestamp(now.toEpochMilli()))
             .setExpirationTime(new Timestamp(now.toEpochMilli() + TimeUnit.DAYS.toMillis(57L)))
             .setBypassed(false)
-            .setExtensionDate(null);
+            .setExtensionTime(null);
     dbUser.setUserInitialCreditsExpiration(existingExpiration);
 
     DbUser updatedUser = accessSyncService.updateUserAccessTiers(dbUser, agent);

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -152,7 +152,7 @@ public class AccessSyncServiceTest {
             .setCreditStartTime(new Timestamp(now.toEpochMilli()))
             .setExpirationTime(new Timestamp(now.toEpochMilli() + TimeUnit.DAYS.toMillis(57L)))
             .setBypassed(false)
-            .setExtensionCount(0);
+            .setExtensionDate(null);
     dbUser.setUserInitialCreditsExpiration(existingExpiration);
 
     DbUser updatedUser = accessSyncService.updateUserAccessTiers(dbUser, agent);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -149,7 +149,7 @@ public class UserServiceTest {
                     START_INSTANT.plus(
                         providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays,
                         ChronoUnit.DAYS)))
-            .setExtensionDate(null);
+            .setExtensionTime(null);
 
     DbUser user = new DbUser();
     user.setUsername(USERNAME);

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -149,7 +149,7 @@ public class UserServiceTest {
                     START_INSTANT.plus(
                         providedWorkbenchConfig.billing.initialCreditsValidityPeriodDays,
                         ChronoUnit.DAYS)))
-            .setExtensionCount(0);
+            .setExtensionDate(null);
 
     DbUser user = new DbUser();
     user.setUsername(USERNAME);

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -1005,7 +1005,7 @@ public class InitialCreditsServiceTest {
     DbUser user = spyUserDao.save(new DbUser().setUserInitialCreditsExpiration(
         new DbUserInitialCreditsExpiration()
             .setExpirationTime(DURING_WARNING_PERIOD)
-            .setExtensionDate(DURING_WARNING_PERIOD)
+            .setExtensionTime(DURING_WARNING_PERIOD)
             .setBypassed(false)));
 
     WorkbenchException exception = assertThrows(WorkbenchException.class, ()-> initialCreditsService.extendInitialCreditsExpiration(user));
@@ -1018,14 +1018,14 @@ public class InitialCreditsServiceTest {
         new DbUserInitialCreditsExpiration()
             .setCreditStartTime(BEFORE_WARNING_PERIOD)
             .setExpirationTime(DURING_WARNING_PERIOD)
-            .setExtensionDate(null)
+            .setExtensionTime(null)
             .setBypassed(false)));
 
     initialCreditsService.extendInitialCreditsExpiration(user);
     DbUserInitialCreditsExpiration actualExpirationRecord = user.getUserInitialCreditsExpiration();
     Timestamp expectedExtensionDate = Timestamp.valueOf(BEFORE_WARNING_PERIOD.toLocalDateTime().plusDays(extensionPeriodDays));
     assertEquals(actualExpirationRecord.getExpirationTime(),expectedExtensionDate);
-    assertEquals(actualExpirationRecord.getExtensionDate(),NOW);
+    assertEquals(actualExpirationRecord.getExtensionTime(),NOW);
   }
 
   private TableResult mockBQTableResult(final Map<String, Double> costMap) {

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -61,7 +61,7 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceFreeTierUsage;
-import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.initialcredits.InitialCreditsExpiryTaskMatchers.UserListMatcher;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
@@ -996,9 +996,9 @@ public class InitialCreditsServiceTest {
   public void test_extendInitialCreditsExpiration_noExpirationRecord() {
     DbUser user = spyUserDao.save(new DbUser());
 
-    WorkbenchException exception =
+    BadRequestException exception =
         assertThrows(
-            WorkbenchException.class,
+            BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals(
         "User does not have initial credits expiration set, so they cannot extend their expiration date.",
@@ -1016,9 +1016,9 @@ public class InitialCreditsServiceTest {
                         .setExtensionTime(DURING_WARNING_PERIOD)
                         .setBypassed(false)));
 
-    WorkbenchException exception =
+    BadRequestException exception =
         assertThrows(
-            WorkbenchException.class,
+            BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals(
         "User has already extended their initial credits expiration and cannot extend further.",
@@ -1037,9 +1037,9 @@ public class InitialCreditsServiceTest {
                         .setBypassed(false)));
     when(institutionService.shouldBypassForCreditsExpiration(user)).thenReturn(true);
 
-    WorkbenchException exception =
+    BadRequestException exception =
         assertThrows(
-            WorkbenchException.class,
+            BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals(
         "User has their initial credits expiration bypassed by their institution, and therefore cannot have their expiration extended.",
@@ -1057,9 +1057,9 @@ public class InitialCreditsServiceTest {
                         .setExtensionTime(null)
                         .setBypassed(true)));
 
-    WorkbenchException exception =
+    BadRequestException exception =
         assertThrows(
-            WorkbenchException.class,
+            BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals(
         "User has their initial credits expiration bypassed, and therefore cannot have their expiration extended.",
@@ -1077,9 +1077,9 @@ public class InitialCreditsServiceTest {
                         .setExtensionTime(null)
                         .setBypassed(false)));
 
-    WorkbenchException exception =
+    BadRequestException exception =
         assertThrows(
-            WorkbenchException.class,
+            BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals(
         "User's initial credits are not close enough to their expiration date to be extended.",

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -1000,7 +1000,9 @@ public class InitialCreditsServiceTest {
         assertThrows(
             WorkbenchException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
-    assertEquals("User does not have initial credits expiration set, so they cannot extend their expiration date.", exception.getMessage());
+    assertEquals(
+        "User does not have initial credits expiration set, so they cannot extend their expiration date.",
+        exception.getMessage());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -996,36 +996,51 @@ public class InitialCreditsServiceTest {
   public void test_extendInitialCreditsExpiration_noExpirationRecord() {
     DbUser user = spyUserDao.save(new DbUser());
 
-    WorkbenchException exception = assertThrows(WorkbenchException.class, ()-> initialCreditsService.extendInitialCreditsExpiration(user));
+    WorkbenchException exception =
+        assertThrows(
+            WorkbenchException.class,
+            () -> initialCreditsService.extendInitialCreditsExpiration(user));
     assertEquals("User does not have initial credits expiration set.", exception.getMessage());
   }
 
   @Test
   public void test_extendInitialCreditsExpiration_alreadyExtended() {
-    DbUser user = spyUserDao.save(new DbUser().setUserInitialCreditsExpiration(
-        new DbUserInitialCreditsExpiration()
-            .setExpirationTime(DURING_WARNING_PERIOD)
-            .setExtensionTime(DURING_WARNING_PERIOD)
-            .setBypassed(false)));
+    DbUser user =
+        spyUserDao.save(
+            new DbUser()
+                .setUserInitialCreditsExpiration(
+                    new DbUserInitialCreditsExpiration()
+                        .setExpirationTime(DURING_WARNING_PERIOD)
+                        .setExtensionTime(DURING_WARNING_PERIOD)
+                        .setBypassed(false)));
 
-    WorkbenchException exception = assertThrows(WorkbenchException.class, ()-> initialCreditsService.extendInitialCreditsExpiration(user));
-    assertEquals("User has already extended their initial credits expiration and cannot extend further.", exception.getMessage());
+    WorkbenchException exception =
+        assertThrows(
+            WorkbenchException.class,
+            () -> initialCreditsService.extendInitialCreditsExpiration(user));
+    assertEquals(
+        "User has already extended their initial credits expiration and cannot extend further.",
+        exception.getMessage());
   }
 
   @Test
   public void test_extendInitialCreditsExpiration_notYetExtended() {
-    DbUser user = spyUserDao.save(new DbUser().setUserInitialCreditsExpiration(
-        new DbUserInitialCreditsExpiration()
-            .setCreditStartTime(BEFORE_WARNING_PERIOD)
-            .setExpirationTime(DURING_WARNING_PERIOD)
-            .setExtensionTime(null)
-            .setBypassed(false)));
+    DbUser user =
+        spyUserDao.save(
+            new DbUser()
+                .setUserInitialCreditsExpiration(
+                    new DbUserInitialCreditsExpiration()
+                        .setCreditStartTime(BEFORE_WARNING_PERIOD)
+                        .setExpirationTime(DURING_WARNING_PERIOD)
+                        .setExtensionTime(null)
+                        .setBypassed(false)));
 
     initialCreditsService.extendInitialCreditsExpiration(user);
     DbUserInitialCreditsExpiration actualExpirationRecord = user.getUserInitialCreditsExpiration();
-    Timestamp expectedExtensionDate = Timestamp.valueOf(BEFORE_WARNING_PERIOD.toLocalDateTime().plusDays(extensionPeriodDays));
-    assertEquals(actualExpirationRecord.getExpirationTime(),expectedExtensionDate);
-    assertEquals(actualExpirationRecord.getExtensionTime(),NOW);
+    Timestamp expectedExtensionDate =
+        Timestamp.valueOf(BEFORE_WARNING_PERIOD.toLocalDateTime().plusDays(extensionPeriodDays));
+    assertEquals(actualExpirationRecord.getExpirationTime(), expectedExtensionDate);
+    assertEquals(actualExpirationRecord.getExtensionTime(), NOW);
   }
 
   private TableResult mockBQTableResult(final Map<String, Double> costMap) {

--- a/ui/src/app/pages/admin/institution/admin-institution-edit.spec.tsx
+++ b/ui/src/app/pages/admin/institution/admin-institution-edit.spec.tsx
@@ -578,10 +578,10 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
   });
 
   it('Should allow updating bypassInitialCreditsExpiration from false to true', async () => {
-    component();
+    component(BROAD.shortName);
     await waitForNoSpinner();
 
-    // VERILY inst starts with bypassInitialCreditsExpiration = false
+    // BROAD inst starts with bypassInitialCreditsExpiration = false
 
     const bypassToggle = screen.getByRole('switch', {
       name: 'Initial Credits Expiration Bypass',
@@ -597,10 +597,10 @@ describe('AdminInstitutionEditSpec - edit mode', () => {
   });
 
   it('Should allow updating bypassInitialCreditsExpiration from true to false', async () => {
-    component(BROAD.shortName);
+    component(VERILY.shortName);
     await waitForNoSpinner();
 
-    // BROAD inst starts with bypassInitialCreditsExpiration = true
+    // VERILY inst starts with bypassInitialCreditsExpiration = true
 
     const bypassToggle = screen.getByRole('switch', {
       name: 'Initial Credits Expiration Bypass',

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -239,7 +239,8 @@ const InitialCreditsCard = ({
               }
             />
           )}
-          {!institution?.institutionalInitialCreditsExpirationBypassed &&
+          {enableInitialCreditsExpiration &&
+            !institution?.institutionalInitialCreditsExpirationBypassed &&
             oldProfile.initialCreditsExtensionEpochMillis && (
               <p style={{ color: colors.primary, fontWeight: 500 }}>
                 User requested an extension on{' '}

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -232,31 +232,37 @@ const InitialCreditsCard = ({
       <FlexRow style={styles.initialCreditsPanel}>
         <FlexColumn>
           <div style={styles.subHeader}>Initial credits</div>
-          <InstitutionExpirationBypassExplanation
-            bypassed={
-              !!institution?.institutionalInitialCreditsExpirationBypassed
-            }
-          />
-          {oldProfile.initialCreditsExtensionEpochMillis && (
-            <p style={{ color: colors.primary, fontWeight: 500 }}>
-              User requested an extension on{' '}
-              {formatDate(oldProfile.initialCreditsExtensionEpochMillis, '-')}
-            </p>
+          {enableInitialCreditsExpiration && (
+            <InstitutionExpirationBypassExplanation
+              bypassed={
+                !!institution?.institutionalInitialCreditsExpirationBypassed
+              }
+            />
           )}
-          <FlexColumn>
-            {enableInitialCreditsExpiration && (
-              <InitialCreditBypassSwitch
-                currentlyBypassed={
-                  updatedProfile.initialCreditsExpirationBypassed
-                }
-                previouslyBypassed={oldProfile.initialCreditsExpirationBypassed}
-                expirationEpochMillis={
-                  oldProfile.initialCreditsExpirationEpochMillis
-                }
-                onChange={(bypass) => onChangeInitialCreditBypass(bypass)}
-                label='Individual Expiration Bypass'
-              />
+          {!institution?.institutionalInitialCreditsExpirationBypassed &&
+            oldProfile.initialCreditsExtensionEpochMillis && (
+              <p style={{ color: colors.primary, fontWeight: 500 }}>
+                User requested an extension on{' '}
+                {formatDate(oldProfile.initialCreditsExtensionEpochMillis, '-')}
+              </p>
             )}
+          <FlexColumn>
+            {enableInitialCreditsExpiration &&
+              !institution?.institutionalInitialCreditsExpirationBypassed && (
+                <InitialCreditBypassSwitch
+                  currentlyBypassed={
+                    updatedProfile.initialCreditsExpirationBypassed
+                  }
+                  previouslyBypassed={
+                    oldProfile.initialCreditsExpirationBypassed
+                  }
+                  expirationEpochMillis={
+                    oldProfile.initialCreditsExpirationEpochMillis
+                  }
+                  onChange={(bypass) => onChangeInitialCreditBypass(bypass)}
+                  label='Individual Expiration Bypass'
+                />
+              )}
             <FlexRow style={{ gap: '1rem', paddingTop: '1.5rem' }}>
               <div
                 data-test-id='initial-credits-used'

--- a/ui/src/app/pages/admin/user/admin-user-profile.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-profile.tsx
@@ -37,6 +37,7 @@ import {
   hasAuthorityForAction,
   renderIfAuthorized,
 } from 'app/utils/authorities';
+import { formatDate } from 'app/utils/dates';
 import {
   checkInstitutionalEmail,
   getEmailValidationErrorMessage,
@@ -236,7 +237,12 @@ const InitialCreditsCard = ({
               !!institution?.institutionalInitialCreditsExpirationBypassed
             }
           />
-
+          {oldProfile.initialCreditsExtensionEpochMillis && (
+            <p style={{ color: colors.primary, fontWeight: 500 }}>
+              User requested an extension on{' '}
+              {formatDate(oldProfile.initialCreditsExtensionEpochMillis, '-')}
+            </p>
+          )}
           <FlexColumn>
             {enableInitialCreditsExpiration && (
               <InitialCreditBypassSwitch

--- a/ui/src/testing/stubs/institution-api-stub.ts
+++ b/ui/src/testing/stubs/institution-api-stub.ts
@@ -39,7 +39,7 @@ export const BROAD: Institution = {
       emailAddresses: [BROAD_ADDR_1, BROAD_ADDR_2],
     },
   ],
-  bypassInitialCreditsExpiration: true,
+  bypassInitialCreditsExpiration: false,
 };
 
 export const VERILY: Institution = {
@@ -59,7 +59,7 @@ export const VERILY: Institution = {
     },
   ],
   userInstructions: 'Verily User Instruction',
-  bypassInitialCreditsExpiration: false,
+  bypassInitialCreditsExpiration: true,
 };
 
 export const VERILY_WITHOUT_CT: Institution = {


### PR DESCRIPTION
The primary change in this PR relates to adding the extension date to the profile object and displaying that value on the admin user page which is shown below. In order to test this change, you should ensure that your user have a user_initial_credits_expiration record in the database. You will need to manually update the database to have an extension_time that is not null.
![Screenshot 2024-11-14 at 11 54 25 AM](https://github.com/user-attachments/assets/5a651c2a-b40c-4f5b-ac79-695f503a5043)

A secondary change was to hide fields that are irrelevant when a user has been institutionally bypassed from initial credit expiration. The result can be seen below:

https://github.com/user-attachments/assets/2682e6f3-88ca-475f-9a03-e6e404637971




<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
