### PR TITLE
[risk=low][RW-13941] Re-enable transitions from DataProc to GCE

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -633,7 +633,7 @@ describe(getErrorsAndWarnings.name, () => {
   });
 });
 
-describe(RuntimeConfigurationPanel.name, () => {
+describe('RuntimeConfigurationPanel', () => {
   let runtimeApiStub: RuntimeApiStub;
   let disksApiStub: DisksApiStub;
   let workspacesApiStub: WorkspacesApiStub;

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -213,25 +213,26 @@ export const CustomizePanel = ({
                 style={{ width: '15rem' }}
                 options={[ComputeType.Standard, ComputeType.Dataproc]}
                 value={analysisConfig.computeType || ComputeType.Standard}
-                onChange={({ value: computeType }) => {
+                onChange={({ value: computeType }) =>
                   // When the compute type changes, we need to normalize the config and potentially restore defaults.
-
-                  // when switching from DataProc to Standard, associate any existing disk
-                  const diskConfig = {
-                    ...analysisConfig.diskConfig,
-                    size:
-                      computeType === ComputeType.Standard && gcePersistentDisk
-                        ? gcePersistentDisk.size
-                        : analysisConfig.diskConfig.size,
-                  };
-
                   setAnalysisConfig(
                     withAnalysisConfigDefaults(
-                      { ...analysisConfig, computeType, diskConfig },
+                      {
+                        ...analysisConfig,
+                        computeType,
+                        diskConfig: {
+                          ...analysisConfig.diskConfig,
+                          // when switching from DataProc to Standard, set to the size of any existing disk
+                          size:
+                            (computeType === ComputeType.Standard &&
+                              gcePersistentDisk?.size) ??
+                            analysisConfig.diskConfig.size,
+                        },
+                      },
                       gcePersistentDisk
                     )
-                  );
-                }}
+                  )
+                }
               />
               {analysisConfig.computeType === ComputeType.Dataproc && (
                 <TooltipTrigger

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -213,15 +213,27 @@ export const CustomizePanel = ({
                 style={{ width: '15rem' }}
                 options={[ComputeType.Standard, ComputeType.Dataproc]}
                 value={analysisConfig.computeType || ComputeType.Standard}
-                onChange={({ value: computeType }) =>
+                onChange={({ value: computeType }) => {
+                  console.log('computeType', computeType);
+
                   // When the compute type changes, we need to normalize the config and potentially restore defaults.
+
+                  // when switching from DataProc to Standard, associate any existing disk
+                  const diskConfig = {
+                    ...analysisConfig.diskConfig,
+                    size:
+                      computeType === ComputeType.Standard && gcePersistentDisk
+                        ? gcePersistentDisk.size
+                        : analysisConfig.diskConfig.size,
+                  };
+
                   setAnalysisConfig(
                     withAnalysisConfigDefaults(
-                      { ...analysisConfig, computeType },
+                      { ...analysisConfig, computeType, diskConfig },
                       gcePersistentDisk
                     )
-                  )
-                }
+                  );
+                }}
               />
               {analysisConfig.computeType === ComputeType.Dataproc && (
                 <TooltipTrigger

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -214,8 +214,6 @@ export const CustomizePanel = ({
                 options={[ComputeType.Standard, ComputeType.Dataproc]}
                 value={analysisConfig.computeType || ComputeType.Standard}
                 onChange={({ value: computeType }) => {
-                  console.log('computeType', computeType);
-
                   // When the compute type changes, we need to normalize the config and potentially restore defaults.
 
                   // when switching from DataProc to Standard, associate any existing disk

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -225,7 +225,7 @@ export const CustomizePanel = ({
                           // when switching from DataProc to Standard, set to the size of any existing disk
                           size:
                             (computeType === ComputeType.Standard &&
-                              gcePersistentDisk?.size) ??
+                              gcePersistentDisk?.size) ||
                             analysisConfig.diskConfig.size,
                         },
                       },

--- a/ui/src/app/utils/analysis-config.spec.tsx
+++ b/ui/src/app/utils/analysis-config.spec.tsx
@@ -1015,8 +1015,12 @@ describe(canUseExistingDisk.name, () => {
   });
 
   it('returns false when existingDisk is undefined', () => {
+    const existingDisk = undefined;
     expect(
-      canUseExistingDisk({ detachableType: DiskType.SSD, size: 5 }, undefined)
+      canUseExistingDisk(
+        { detachableType: DiskType.SSD, size: 5 },
+        existingDisk
+      )
     ).toBeFalsy();
   });
 });

--- a/ui/src/app/utils/analysis-config.tsx
+++ b/ui/src/app/utils/analysis-config.tsx
@@ -157,9 +157,6 @@ export const withAnalysisConfigDefaults = (
     dataprocConfig,
     zone,
   } = r;
-  console.log('withAnalysisConfigDefaults disk', existingPersistentDisk);
-  console.log('withAnalysisConfigDefaults type', r.computeType);
-  console.log('withAnalysisConfigDefaults diskConfig', r.diskConfig);
   let existingDiskName = null;
   const computeType = r.computeType ?? ComputeType.Standard;
   // For computeType Standard: We are moving away from storage disk as Standard
@@ -174,7 +171,6 @@ export const withAnalysisConfigDefaults = (
       detachable = true;
       size = size ?? existingPersistentDisk?.size ?? DEFAULT_DISK_SIZE;
       if (canUseExistingDisk(r.diskConfig, existingPersistentDisk)) {
-        console.log('canUseExistingDisk yes', existingPersistentDisk.name);
         existingDiskName = existingPersistentDisk.name;
       }
     }

--- a/ui/src/app/utils/analysis-config.tsx
+++ b/ui/src/app/utils/analysis-config.tsx
@@ -164,12 +164,11 @@ export const withAnalysisConfigDefaults = (
   // Eventually we will be removing this option altogether
   if (computeType === ComputeType.Standard) {
     zone ??= serverConfigStore.get().config.defaultGceVmZone;
-    detachableType ??= existingPersistentDisk?.diskType ?? DiskType.STANDARD;
     detachable = true;
+    detachableType ??= existingPersistentDisk?.diskType ?? DiskType.STANDARD;
     if (existingPersistentDisk) {
       zone = existingPersistentDisk.zone;
-      detachable = true;
-      size = size ?? existingPersistentDisk?.size ?? DEFAULT_DISK_SIZE;
+      size ??= existingPersistentDisk?.size ?? DEFAULT_DISK_SIZE;
       if (canUseExistingDisk(r.diskConfig, existingPersistentDisk)) {
         existingDiskName = existingPersistentDisk.name;
       }

--- a/ui/src/app/utils/runtime-hooks.spec.tsx
+++ b/ui/src/app/utils/runtime-hooks.spec.tsx
@@ -151,7 +151,7 @@ describe(useCustomRuntime.name, () => {
     });
   });
 
-  it('should allow Dataproc -> PD transition', async () => {
+  it('should allow Dataproc -> GCE transition', async () => {
     currentRuntime = defaultDataProcRuntime();
     runtimeStore.set({
       workspaceNamespace: workspaceDataStub.namespace,

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -336,6 +336,8 @@ export const useCustomRuntime = (
         );
 
         if (mostSevereDiskDiff === AnalysisDiffState.CAN_UPDATE_IN_PLACE) {
+          console.log('Updating disk in place');
+          console.log('mostSevereDiff', mostSevereDiff);
           await updateRuntimeAndInitializeLeoRuntime();
         }
         if (mostSevereDiff === AnalysisDiffState.NEEDS_DELETE) {
@@ -358,6 +360,7 @@ export const useCustomRuntime = (
             runtime.status === RuntimeStatus.RUNNING ||
             runtime.status === RuntimeStatus.STOPPED
           ) {
+            console.log('Updating runtime');
             await updateRuntimeAndInitializeLeoRuntime();
           }
         }

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -340,8 +340,6 @@ export const useCustomRuntime = (
           mostSevereDiff <= AnalysisDiffState.CAN_UPDATE_IN_PLACE &&
           mostSevereDiskDiff === AnalysisDiffState.CAN_UPDATE_IN_PLACE
         ) {
-          console.log('Updating disk in place');
-          console.log('mostSevereDiff', mostSevereDiff);
           await updateRuntimeAndInitializeLeoRuntime();
         }
 
@@ -374,7 +372,6 @@ export const useCustomRuntime = (
             runtime.status === RuntimeStatus.RUNNING ||
             runtime.status === RuntimeStatus.STOPPED
           ) {
-            console.log('Updating runtime');
             await updateRuntimeAndInitializeLeoRuntime();
           }
         }

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -335,21 +335,35 @@ export const useCustomRuntime = (
           )
         );
 
-        if (mostSevereDiskDiff === AnalysisDiffState.CAN_UPDATE_IN_PLACE) {
+        // update the disk in place, if the runtime can also be updated in place (or needs no change)
+        if (
+          mostSevereDiff <= AnalysisDiffState.CAN_UPDATE_IN_PLACE &&
+          mostSevereDiskDiff === AnalysisDiffState.CAN_UPDATE_IN_PLACE
+        ) {
           console.log('Updating disk in place');
           console.log('mostSevereDiff', mostSevereDiff);
           await updateRuntimeAndInitializeLeoRuntime();
         }
+
         if (mostSevereDiff === AnalysisDiffState.NEEDS_DELETE) {
           const deleteAttachedDisk =
             mostSevereDiskDiff === AnalysisDiffState.NEEDS_DELETE;
           await runtimeApi().deleteRuntime(
             currentWorkspaceNamespace,
             deleteAttachedDisk,
-            {
-              signal: aborter.signal,
-            }
+            { signal: aborter.signal }
           );
+
+          if (
+            !deleteAttachedDisk &&
+            diskNeedsSizeIncrease(requestedDisk, existingDisk)
+          ) {
+            await disksApi().updateDisk(
+              currentWorkspaceNamespace,
+              existingDisk.name,
+              requestedDisk.size
+            );
+          }
         } else if (
           [
             AnalysisDiffState.CAN_UPDATE_WITH_REBOOT,


### PR DESCRIPTION
If a Jupyter PD existed (from a previous Standard/GCE VM) and there is a running DataProc cluster, it appears to be impossible to transition back to Standard (!!) or ever use that PD again (!!) - and this seems to have been true since July (!!)

At least in my local testing, this resolves that situation.

Longer term, I am thinking about how to address the complexity in the Jupyter runtime configuration and associated UI code.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
