### PR TITLE
[risk=low][RW-13940] If a DataProc runtime and PD both exists, allow deletion of both

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel-footer.tsx
@@ -50,7 +50,7 @@ export const CustomizePanelFooter = ({
     (gcePersistentDisk.size > analysisConfig.diskConfig.size ||
       gcePersistentDisk.diskType !== analysisConfig.diskConfig.detachableType);
 
-  return unattachedPdExists ? (
+  return unattachedPdExists && !runtimeExists ? (
     <FlexRow
       style={{
         justifyContent: 'space-between',


### PR DESCRIPTION
Tested by deleting DataProc runtimes without deleting the workspace's PD.  After deleting the runtime, it became possible to delete the PD, as expected.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
