### PR TITLE
[risk=low][RW-13725] Fix app usage reporting pipeline

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -146,6 +146,8 @@ public interface ReportingQueryService {
 
   int getTableRowCount(String tableName);
 
+  int getAppUsageRowCount(String tableName);
+
   int getWorkspaceCount();
 
   List<ReportingLeonardoAppUsage> getLeonardoAppUsage(long limit, long offset);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -148,5 +148,9 @@ public interface ReportingQueryService {
 
   int getWorkspaceCount();
 
-  List<ReportingLeonardoAppUsage> getLeonardoAppUsage();
+  List<ReportingLeonardoAppUsage> getLeonardoAppUsage(long limit, long offset);
+
+  default Stream<List<ReportingLeonardoAppUsage>> getBatchedLeonardoAppUsageStream() {
+    return getBatchedStream(this::getLeonardoAppUsage);
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -589,6 +589,23 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
   }
 
   @Override
+  public int getAppUsageRowCount(String tableName) {
+    var queryString = "SELECT count(*) "
+                    + "FROM `"
+                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
+                    + "` au "
+                    + "JOIN `"
+                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
+                    + "` a on a.id = au.appId where STARTS_WITH(appName, \""
+                    + USER_APP_NAME_PREFIX
+                    + "\")";
+
+    final QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(queryString).build();
+    var res = bigQueryService.executeQuery(queryConfig);
+    return res.getValues().iterator().next().get(0).getNumericValue().intValue();
+  }
+
+  @Override
   public int getWorkspaceCount() {
     return jdbcTemplate.queryForObject(
         "SELECT count(*) FROM workspace WHERE active_status = "

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -602,23 +602,24 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
       // Skip querying data if not enabled, and just return empty list instead.
       return new ArrayList<>();
     }
+    var queryString = String.format(
+            "SELECT appId, appName, status, createdDate, destroyedDate, "
+                    + "startTime, stopTime, creator, customEnvironmentVariables "
+                    + "FROM `"
+                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
+                    + "` au "
+                    + "JOIN `"
+                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
+                    + "` a on a.id = au.appId where STARTS_WITH(appName, \""
+                    + USER_APP_NAME_PREFIX
+                    + "\") "
+                    + "LIMIT %d\n"
+                    + "OFFSET %d",
+            limit,
+            offset);
+
     final QueryJobConfiguration queryConfig =
-        QueryJobConfiguration.newBuilder(
-                String.format(
-                    "SELECT appId, appName, status, createdDate, destroyedDate, "
-                        + "startTime, stopTime, creator, customEnvironmentVariables "
-                        + "FROM `"
-                        + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
-                        + "` au "
-                        + "JOIN `"
-                        + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
-                        + "` a on a.id = au.appId where STARTS_WITH(appName, \""
-                        + USER_APP_NAME_PREFIX
-                        + "LIMIT %d\n"
-                        + "OFFSET %d"
-                        + "\")",
-                    limit,
-                    offset))
+        QueryJobConfiguration.newBuilder(queryString)
             .build();
 
     List<ReportingLeonardoAppUsage> queryResults = new ArrayList<>();

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -602,25 +602,24 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
       // Skip querying data if not enabled, and just return empty list instead.
       return new ArrayList<>();
     }
-    var queryString = String.format(
+    var queryString =
+        String.format(
             "SELECT appId, appName, status, createdDate, destroyedDate, "
-                    + "startTime, stopTime, creator, customEnvironmentVariables "
-                    + "FROM `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
-                    + "` au "
-                    + "JOIN `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
-                    + "` a on a.id = au.appId where STARTS_WITH(appName, \""
-                    + USER_APP_NAME_PREFIX
-                    + "\") "
-                    + "LIMIT %d\n"
-                    + "OFFSET %d",
+                + "startTime, stopTime, creator, customEnvironmentVariables "
+                + "FROM `"
+                + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
+                + "` au "
+                + "JOIN `"
+                + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
+                + "` a on a.id = au.appId where STARTS_WITH(appName, \""
+                + USER_APP_NAME_PREFIX
+                + "\") "
+                + "LIMIT %d\n"
+                + "OFFSET %d",
             limit,
             offset);
 
-    final QueryJobConfiguration queryConfig =
-        QueryJobConfiguration.newBuilder(queryString)
-            .build();
+    final QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(queryString).build();
 
     List<ReportingLeonardoAppUsage> queryResults = new ArrayList<>();
     for (FieldValueList row : bigQueryService.executeQuery(queryConfig).getValues()) {

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -590,15 +590,16 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
 
   @Override
   public int getAppUsageRowCount(String tableName) {
-    var queryString = "SELECT count(*) "
-                    + "FROM `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
-                    + "` au "
-                    + "JOIN `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
-                    + "` a on a.id = au.appId where STARTS_WITH(appName, \""
-                    + USER_APP_NAME_PREFIX
-                    + "\")";
+    var queryString =
+        "SELECT count(*) "
+            + "FROM `"
+            + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
+            + "` au "
+            + "JOIN `"
+            + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
+            + "` a on a.id = au.appId where STARTS_WITH(appName, \""
+            + USER_APP_NAME_PREFIX
+            + "\")";
 
     final QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(queryString).build();
     var res = bigQueryService.executeQuery(queryConfig);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -597,23 +597,28 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
   }
 
   @Override
-  public List<ReportingLeonardoAppUsage> getLeonardoAppUsage() {
+  public List<ReportingLeonardoAppUsage> getLeonardoAppUsage(long limit, long offset) {
     if (!workbenchConfigProvider.get().reporting.exportTerraDataWarehouse) {
       // Skip querying data if not enabled, and just return empty list instead.
       return new ArrayList<>();
     }
     final QueryJobConfiguration queryConfig =
         QueryJobConfiguration.newBuilder(
-                "SELECT appId, appName, status, createdDate, destroyedDate, "
-                    + "startTime, stopTime, creator, customEnvironmentVariables "
-                    + "FROM `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
-                    + "` au "
-                    + "JOIN `"
-                    + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
-                    + "` a on a.id = au.appId where STARTS_WITH(appName, \""
-                    + USER_APP_NAME_PREFIX
-                    + "\")")
+                String.format(
+                    "SELECT appId, appName, status, createdDate, destroyedDate, "
+                        + "startTime, stopTime, creator, customEnvironmentVariables "
+                        + "FROM `"
+                        + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId
+                        + "` au "
+                        + "JOIN `"
+                        + workbenchConfigProvider.get().reporting.terraWarehouseLeoAppTableId
+                        + "` a on a.id = au.appId where STARTS_WITH(appName, \""
+                        + USER_APP_NAME_PREFIX
+                        + "LIMIT %d\n"
+                        + "OFFSET %d"
+                        + "\")",
+                    limit,
+                    offset))
             .build();
 
     List<ReportingLeonardoAppUsage> queryResults = new ArrayList<>();

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -73,6 +73,9 @@ public class ReportingServiceImpl implements ReportingService {
         .getBatchedCohortStream()
         .forEach(b -> reportingUploadService.uploadCohortBatch(b, captureTimestamp));
     reportingQueryService
+        .getBatchedLeonardoAppUsageStream()
+        .forEach(b -> reportingUploadService.uploadLeonardoAppUsagetBatch(b, captureTimestamp));
+    reportingQueryService
         .getBatchedNewUserSatisfactionSurveyStream()
         .forEach(
             b -> reportingUploadService.uploadNewUserSatisfactionSurveyBatch(b, captureTimestamp));

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -74,7 +74,7 @@ public class ReportingServiceImpl implements ReportingService {
         .forEach(b -> reportingUploadService.uploadCohortBatch(b, captureTimestamp));
     reportingQueryService
         .getBatchedLeonardoAppUsageStream()
-        .forEach(b -> reportingUploadService.uploadLeonardoAppUsagetBatch(b, captureTimestamp));
+        .forEach(b -> reportingUploadService.uploadLeonardoAppUsageBatch(b, captureTimestamp));
     reportingQueryService
         .getBatchedNewUserSatisfactionSurveyStream()
         .forEach(

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
@@ -42,7 +42,6 @@ public class ReportingSnapshotServiceImpl implements ReportingSnapshotService {
             .datasetDomainIdValues(reportingQueryService.getDatasetDomainIdValues())
             .institutions(reportingQueryService.getInstitutions())
             .workspaceFreeTierUsage(reportingQueryService.getWorkspaceFreeTierUsage())
-            .leonardoAppUsage(reportingQueryService.getLeonardoAppUsage());
     stopwatch.stop();
     log.info(LogFormatters.duration("Application DB Queries", stopwatch.elapsed()));
     return result;

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingSnapshotServiceImpl.java
@@ -41,7 +41,8 @@ public class ReportingSnapshotServiceImpl implements ReportingSnapshotService {
             .datasetConceptSets(reportingQueryService.getDatasetConceptSets())
             .datasetDomainIdValues(reportingQueryService.getDatasetDomainIdValues())
             .institutions(reportingQueryService.getInstitutions())
-            .workspaceFreeTierUsage(reportingQueryService.getWorkspaceFreeTierUsage())
+            .workspaceFreeTierUsage(reportingQueryService.getWorkspaceFreeTierUsage());
+
     stopwatch.stop();
     log.info(LogFormatters.duration("Application DB Queries", stopwatch.elapsed()));
     return result;

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.reporting;
 
 import java.util.List;
 import org.pmiops.workbench.model.ReportingCohort;
+import org.pmiops.workbench.model.ReportingLeonardoAppUsage;
 import org.pmiops.workbench.model.ReportingNewUserSatisfactionSurvey;
 import org.pmiops.workbench.model.ReportingSnapshot;
 import org.pmiops.workbench.model.ReportingUser;
@@ -22,6 +23,8 @@ public interface ReportingUploadService {
   void uploadUserBatch(List<ReportingUser> batch, long captureTimestamp);
 
   void uploadCohortBatch(List<ReportingCohort> batch, long captureTimestamp);
+
+  void uploadLeonardoAppUsagetBatch(List<ReportingLeonardoAppUsage> batch, long captureTimestamp);
 
   void uploadNewUserSatisfactionSurveyBatch(
       List<ReportingNewUserSatisfactionSurvey> batch, long captureTimestamp);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadService.java
@@ -24,7 +24,7 @@ public interface ReportingUploadService {
 
   void uploadCohortBatch(List<ReportingCohort> batch, long captureTimestamp);
 
-  void uploadLeonardoAppUsagetBatch(List<ReportingLeonardoAppUsage> batch, long captureTimestamp);
+  void uploadLeonardoAppUsageBatch(List<ReportingLeonardoAppUsage> batch, long captureTimestamp);
 
   void uploadNewUserSatisfactionSurveyBatch(
       List<ReportingNewUserSatisfactionSurvey> batch, long captureTimestamp);

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -159,7 +159,8 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
 
   /** Batch uploads {@link ReportingLeonardoAppUsage}. */
   @Override
-  public void uploadLeonardoAppUsagetBatch(List<ReportingLeonardoAppUsage> batch, long captureTimestamp) {
+  public void uploadLeonardoAppUsagetBatch(
+      List<ReportingLeonardoAppUsage> batch, long captureTimestamp) {
     uploadBatchTable(
         leonardoAppUsageInsertAllRequestBuilder.build(
             getTableId(LeonardoAppUsageColumnValueExtractor.TABLE_NAME),

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -157,6 +157,16 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
             getFixedValues(captureTimestamp)));
   }
 
+  /** Batch uploads {@link ReportingLeonardoAppUsage}. */
+  @Override
+  public void uploadLeonardoAppUsagetBatch(List<ReportingLeonardoAppUsage> batch, long captureTimestamp) {
+    uploadBatchTable(
+        leonardoAppUsageInsertAllRequestBuilder.build(
+            getTableId(LeonardoAppUsageColumnValueExtractor.TABLE_NAME),
+            batch,
+            getFixedValues(captureTimestamp)));
+  }
+
   /** Batch uploads {@link ReportingNewUserSatisfactionSurvey}. */
   @Override
   public void uploadNewUserSatisfactionSurveyBatch(

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingUploadServiceImpl.java
@@ -159,7 +159,7 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
 
   /** Batch uploads {@link ReportingLeonardoAppUsage}. */
   @Override
-  public void uploadLeonardoAppUsagetBatch(
+  public void uploadLeonardoAppUsageBatch(
       List<ReportingLeonardoAppUsage> batch, long captureTimestamp) {
     uploadBatchTable(
         leonardoAppUsageInsertAllRequestBuilder.build(
@@ -302,12 +302,6 @@ public class ReportingUploadServiceImpl implements ReportingUploadService {
         workspaceFreeTierUsageRequestBuilder.buildBatchedRequests(
             getTableId(WorkspaceFreeTierUsageColumnValueExtractor.TABLE_NAME),
             reportingSnapshot.getWorkspaceFreeTierUsage(),
-            fixedValues,
-            batchSize));
-    resultBuilder.addAll(
-        leonardoAppUsageInsertAllRequestBuilder.buildBatchedRequests(
-            getTableId(LeonardoAppUsageColumnValueExtractor.TABLE_NAME),
-            reportingSnapshot.getLeonardoAppUsage(),
             fixedValues,
             batchSize));
 

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -103,7 +103,9 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
             Map.entry(
                 LeonardoAppUsageColumnValueExtractor.TABLE_NAME,
                 reportingQueryService.getAppUsageRowCount(
-                  workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId)), //get source row count
+                    workbenchConfigProvider.get()
+                        .reporting
+                        .terraWarehouseLeoAppUsageTableId)), // get source row count
             Map.entry(
                 NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
                 reportingQueryService.getTableRowCount(

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -101,6 +101,10 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
                 CohortColumnValueExtractor.TABLE_NAME,
                 reportingQueryService.getTableRowCount(CohortColumnValueExtractor.TABLE_NAME)),
             Map.entry(
+                LeonardoAppUsageColumnValueExtractor.TABLE_NAME,
+                reportingQueryService.getAppUsageRowCount(
+                  workbenchConfigProvider.get().reporting.terraWarehouseLeoAppUsageTableId)), //get source row count
+            Map.entry(
                 NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME,
                 reportingQueryService.getTableRowCount(
                     NewUserSatisfactionSurveyColumnValueExtractor.TABLE_NAME)),

--- a/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceTest.java
@@ -761,7 +761,7 @@ public class ReportingQueryServiceTest {
     TableResult tableResult =
         new TableResult(s, tableRows.size(), new PageImpl<>(() -> null, null, tableRows));
     when(bigQueryService.executeQuery(any(QueryJobConfiguration.class))).thenReturn(tableResult);
-    assertThat(reportingQueryService.getLeonardoAppUsage())
+    assertThat(reportingQueryService.getLeonardoAppUsage(10, 0))
         .containsExactly(
             new ReportingLeonardoAppUsage()
                 .appId(123l)


### PR DESCRIPTION
Tested locally with smaller batch size 100

```
[Mon Nov 18 13:55:00 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into user table: 2 in 102ms (19.607843 rows/sec)

[Mon Nov 18 13:55:03 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into leonardo_app_usage table: 100 in 150ms (666.666667 rows/sec)

[Mon Nov 18 13:55:04 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into leonardo_app_usage table: 100 in 98ms (1020.408163 rows/sec)

[Mon Nov 18 13:55:05 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into leonardo_app_usage table: 100 in 97ms (1030.927835 rows/sec)

[Mon Nov 18 13:55:07 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into leonardo_app_usage table: 100 in 106ms (943.396226 rows/sec)

[Mon Nov 18 13:55:08 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingUploadServiceImpl uploadBatchTable - Streaming upload into leonardo_app_usage table: 24 in 103ms (233.009709 rows/sec)

[Mon Nov 18 13:55:16 EST 2024] INFO: org.pmiops.workbench.reporting.ReportingVerificationServiceImpl verifyBatchesAndLog - Verifying batches at 1731956099858:
Table   Source  Destination     Difference(%)
workspace       3       3       0 (0.000%)
user    2       2       0 (0.000%)
cohort  0       0       0
leonardo_app_usage      424     424     0 (0.000%)
new_user_satisfaction_survey    0       0       0
user_general_discovery_source   0       0       0
user_partner_discovery_source   0       0       0
```

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
