### PR TITLE
[risk=low][RW-13725] remove getUploadResult in verifyAndLog

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -167,11 +167,7 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
                     getUploadResult(
                         snapshot,
                         DatasetConceptSetColumnValueExtractor.TABLE_NAME,
-                        ReportingSnapshot::getDatasetConceptSets),
-                    getUploadResult(
-                        snapshot,
-                        LeonardoAppUsageColumnValueExtractor.TABLE_NAME,
-                        ReportingSnapshot::getLeonardoAppUsage)));
+                        ReportingSnapshot::getDatasetConceptSets)));
     verifyStopwatch.stop();
     logger.info(LogFormatters.duration("Verification queries", verifyStopwatch.elapsed()));
     return result;


### PR DESCRIPTION
getUploadResult for leonardoAppUsage table isn't needed because verifyAndLog isn't used for validating batch results. `verifyBatchesAndLog` is validating leonardoAppUsage already

When I was testing locally, I commented out taking the non batch uploads, which is why I didn't catch this locally

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
