### PR TITLE
[RW-13733][risk=no] Add expiration info to DAR completion message.

### DIFF
--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -540,10 +540,10 @@ const CompletionBanner = ({
         </div>
         <div style={styles.completedText}>
           (You have {initialCreditsValidityPeriodDays} days to use credit after
-          gaining data access. You may request extension when it gets closer to
-          credit expiration date, which will extend your credit expiration date
-          to a total of {initialCreditsExtensionPeriodDays} days from the day
-          you gained data access.)
+          gaining data access. You may request an extension when it gets closer
+          to your credit expiration date, which will extend your credit
+          expiration date to a total of {initialCreditsExtensionPeriodDays} days
+          from the day you gained data access.)
         </div>
         <div style={styles.completedText}>
           Learn more{' '}

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -5,7 +5,7 @@ import * as fp from 'lodash/fp';
 import { AccessModule, Profile } from 'generated/fetch';
 
 import { switchCase } from '@terra-ui-packages/core-utils';
-import { Button, HashLinkButton } from 'app/components/buttons';
+import { Button, HashLinkButton, LinkButton } from 'app/components/buttons';
 import { FadeBox } from 'app/components/containers';
 import { FlexColumn, FlexRow } from 'app/components/flex';
 import { Header } from 'app/components/headers';
@@ -33,6 +33,7 @@ import {
 import { displayDateWithoutHours } from 'app/utils/dates';
 import { fetchWithErrorModal } from 'app/utils/errors';
 import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
+import { supportUrls } from 'app/utils/zendesk';
 import { ReactComponent as additional } from 'assets/icons/DAR/additional.svg';
 import { ReactComponent as electronic } from 'assets/icons/DAR/electronic.svg';
 import { ReactComponent as genomic } from 'assets/icons/DAR/genomic.svg';
@@ -528,7 +529,14 @@ const CompletionBanner = ({ profile }: CompletionBannerProps) => (
       <div style={styles.completedText}>
         Your credits expire on{' '}
         {displayDateWithoutHours(profile.initialCreditsExpirationEpochMillis)}{' '}
-        now that you have data access. Learn more here USH link
+        now that you have data access. Learn more{' '}
+        <LinkButton
+          style={{ display: 'inline' }}
+          onClick={() => window.open(supportUrls.initialCredits, '_blank')}
+        >
+          here
+        </LinkButton>
+        .
       </div>
     </FlexColumn>
     <GetStartedButton style={{ marginLeft: 'auto' }} />

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -516,32 +516,52 @@ const ControlledTierRenewalBanner = () => (
 );
 interface CompletionBannerProps {
   profile: Profile;
+  initialCreditsValidityPeriodDays: number;
+  initialCreditsExtensionPeriodDays: number;
 }
-const CompletionBanner = ({ profile }: CompletionBannerProps) => (
-  <FlexRow data-test-id='dar-completed' style={styles.completed}>
-    <FlexColumn>
-      <div style={styles.completedHeader}>
-        Thank you for completing all the necessary steps
-      </div>
-      <div style={styles.completedText}>
-        Researcher Workbench data access is complete.
-      </div>
-      <div style={styles.completedText}>
-        Your credits expire on{' '}
-        {displayDateWithoutHours(profile.initialCreditsExpirationEpochMillis)}{' '}
-        now that you have data access. Learn more{' '}
-        <LinkButton
-          style={{ display: 'inline' }}
-          onClick={() => window.open(supportUrls.initialCredits, '_blank')}
-        >
-          here
-        </LinkButton>
-        .
-      </div>
-    </FlexColumn>
-    <GetStartedButton style={{ marginLeft: 'auto' }} />
-  </FlexRow>
-);
+const CompletionBanner = ({
+  profile,
+  initialCreditsValidityPeriodDays,
+  initialCreditsExtensionPeriodDays,
+}: CompletionBannerProps) => {
+  let creditExpirationExplanation: string;
+
+  if (profile.initialCreditsExtensionEpochMillis) {
+    creditExpirationExplanation = `Initially users are given ${initialCreditsValidityPeriodDays} days from when they first gain data access, but since you requested an extension you will have ${initialCreditsExtensionPeriodDays} days.`;
+  } else {
+    creditExpirationExplanation = `This is ${initialCreditsValidityPeriodDays} days from when you first gained data access.`;
+  }
+
+  return (
+    <FlexRow data-test-id='dar-completed' style={styles.completed}>
+      <FlexColumn>
+        <div style={styles.completedHeader}>
+          Thank you for completing all the necessary steps
+        </div>
+        <div style={styles.completedText}>
+          Researcher Workbench data access is complete.
+        </div>
+        <div style={styles.completedText}>
+          Your credits expire on{' '}
+          {displayDateWithoutHours(profile.initialCreditsExpirationEpochMillis)}
+          .
+        </div>
+        <div style={styles.completedText}>{creditExpirationExplanation}</div>
+        <div style={styles.completedText}>
+          Learn more{' '}
+          <LinkButton
+            style={{ display: 'inline' }}
+            onClick={() => window.open(supportUrls.initialCredits, '_blank')}
+          >
+            here
+          </LinkButton>
+          .
+        </div>
+      </FlexColumn>
+      <GetStartedButton style={{ marginLeft: 'auto' }} />
+    </FlexRow>
+  );
+};
 
 // TODO is there a better way?
 const Additional = additional;
@@ -589,7 +609,11 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
     // Local Variables
     const { profile, reload } = useStore(profileStore);
     const {
-      config: { unsafeAllowSelfBypass },
+      config: {
+        unsafeAllowSelfBypass,
+        initialCreditsValidityPeriodDays,
+        initialCreditsExtensionPeriodDays,
+      },
     } = useStore(serverConfigStore);
 
     const urlParams = new URLSearchParams(window.location.search);
@@ -719,7 +743,15 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       <FlexColumn style={styles.pageWrapper}>
         <OuterHeader {...{ pageMode }} />
         {ctNeedsRenewal && <ControlledTierRenewalBanner />}
-        {showCompletionBanner && <CompletionBanner {...{ profile }} />}
+        {showCompletionBanner && (
+          <CompletionBanner
+            {...{
+              profile,
+              initialCreditsValidityPeriodDays,
+              initialCreditsExtensionPeriodDays,
+            }}
+          />
+        )}
         {unsafeAllowSelfBypass && activeModules.length > 0 && (
           <SelfBypass onClick={async () => selfBypass(spinnerProps, reload)} />
         )}

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -524,17 +524,9 @@ const CompletionBanner = ({
   initialCreditsValidityPeriodDays,
   initialCreditsExtensionPeriodDays,
 }: CompletionBannerProps) => {
-  let creditExpirationExplanation: string;
-
-  if (profile.initialCreditsExtensionEpochMillis) {
-    creditExpirationExplanation = `Initially users are given ${initialCreditsValidityPeriodDays} days from when they first gain data access, but since you requested an extension you will have ${initialCreditsExtensionPeriodDays} days.`;
-  } else {
-    creditExpirationExplanation = `This is ${initialCreditsValidityPeriodDays} days from when you first gained data access.`;
-  }
-
   return (
     <FlexRow data-test-id='dar-completed' style={styles.completed}>
-      <FlexColumn>
+      <FlexColumn style={{ flex: 0.5 }}>
         <div style={styles.completedHeader}>
           Thank you for completing all the necessary steps
         </div>
@@ -546,7 +538,13 @@ const CompletionBanner = ({
           {displayDateWithoutHours(profile.initialCreditsExpirationEpochMillis)}
           .
         </div>
-        <div style={styles.completedText}>{creditExpirationExplanation}</div>
+        <div style={styles.completedText}>
+          (You have {initialCreditsValidityPeriodDays} days to use credit after
+          gaining data access. You may request extension when it gets closer to
+          credit expiration date, which will extend your credit expiration date
+          to a total of {initialCreditsExtensionPeriodDays} days from the day
+          you gained data access.)
+        </div>
         <div style={styles.completedText}>
           Learn more{' '}
           <LinkButton

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -30,6 +30,7 @@ import {
   maybeDaysRemaining,
   syncModulesExternal,
 } from 'app/utils/access-utils';
+import { displayDateWithoutHours } from 'app/utils/dates';
 import { fetchWithErrorModal } from 'app/utils/errors';
 import { profileStore, serverConfigStore, useStore } from 'app/utils/stores';
 import { ReactComponent as additional } from 'assets/icons/DAR/additional.svg';
@@ -82,7 +83,6 @@ export const styles = reactStyles({
     gridArea: 'explanation',
   },
   completed: {
-    height: '87px',
     padding: '1em',
     marginLeft: '3%',
     marginRight: '3%',
@@ -98,7 +98,6 @@ export const styles = reactStyles({
     fontSize: '14px',
   },
   controlledRenewal: {
-    height: '87px',
     padding: '1em',
     marginLeft: '3%',
     marginRight: '3%',
@@ -114,7 +113,6 @@ export const styles = reactStyles({
     fontSize: '14px',
   },
   selfBypass: {
-    height: '87px',
     padding: '1em',
     marginLeft: '3%',
     marginRight: '3%',
@@ -515,8 +513,10 @@ const ControlledTierRenewalBanner = () => (
     </HashLinkButton>
   </FlexRow>
 );
-
-const CompletionBanner = () => (
+interface CompletionBannerProps {
+  profile: Profile;
+}
+const CompletionBanner = ({ profile }: CompletionBannerProps) => (
   <FlexRow data-test-id='dar-completed' style={styles.completed}>
     <FlexColumn>
       <div style={styles.completedHeader}>
@@ -524,6 +524,11 @@ const CompletionBanner = () => (
       </div>
       <div style={styles.completedText}>
         Researcher Workbench data access is complete.
+      </div>
+      <div style={styles.completedText}>
+        Your credits expire on{' '}
+        {displayDateWithoutHours(profile.initialCreditsExpirationEpochMillis)}{' '}
+        now that you have data access. Learn more here USH link
       </div>
     </FlexColumn>
     <GetStartedButton style={{ marginLeft: 'auto' }} />
@@ -706,7 +711,7 @@ export const DataAccessRequirements = fp.flow(withProfileErrorModal)(
       <FlexColumn style={styles.pageWrapper}>
         <OuterHeader {...{ pageMode }} />
         {ctNeedsRenewal && <ControlledTierRenewalBanner />}
-        {showCompletionBanner && <CompletionBanner />}
+        {showCompletionBanner && <CompletionBanner {...{ profile }} />}
         {unsafeAllowSelfBypass && activeModules.length > 0 && (
           <SelfBypass onClick={async () => selfBypass(spinnerProps, reload)} />
         )}


### PR DESCRIPTION
Add credit expiration warning to data access requirements page.

In order to test this, you will need to make sure that you have a record in the user_initial_credits_expiration table.

![image](https://github.com/user-attachments/assets/241fa086-d577-49e0-bfb2-8bcabce91b1d)

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
