### PR TITLE
[risk=low][no ticket] rm outdated reference to 270 days in credit expiration email

### DIFF
--- a/api/src/main/resources/emails/initial_credits_expiring/content.html
+++ b/api/src/main/resources/emails/initial_credits_expiring/content.html
@@ -31,7 +31,7 @@
 <div>Hello ${FIRST_NAME},</div>
 <div>This is a notification that the initial credits offered to your ${ALL_OF_US} Researcher Workbench account ${USERNAME} by the ${ALL_OF_US} Research Program are expiring soon.</div>
 <div style="font-weight:bold; margin-bottom: 0">Your initial credits will expire on ${INITIAL_CREDITS_EXPIRATION}.</div>
-<div style="font-weight:bold; margin-top: 0">You are eligible to request a 270-day extension under your profile in the Researcher Workbench.</div>
+<div style="font-weight:bold; margin-top: 0">You are eligible to request an extension under your profile in the Researcher Workbench.</div>
 
 <div>For more information about using initial credits and requesting an extension, read the “<a href="https://support.researchallofus.org/hc/en-us/articles/28920849686036-Using-All-of-Us-Initial-Credits">Using ${ALL_OF_US} Initial Credits</a>” article on the User Support Hub.</div>
 <div><div style="font-weight:bold;display: inline">Questions?</div> Contact our support team by using the Help Desk widget in the Workbench or by emailing <a href="mailto:support@researchallofus.org">support@researchallofus.org</a></div>


### PR DESCRIPTION
90 + 270 = 360 but 120 + 270 is not.

We could add a more accurate number, but what do you think about just leaving it out?

---

<img width="1187" alt="Screenshot 2024-11-20 at 11 48 47 AM" src="https://github.com/user-attachments/assets/dbe2b3f9-a637-4f04-b609-68c92c1f36e8">

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
