### PR TITLE
[risk=no][no-ticket] Add some logs to trace billing sync related issues

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -428,6 +428,7 @@ public class InitialCreditsService {
         .filter(ws -> !ws.isInitialCreditsExpired())
         .forEach(
             ws -> {
+              logger.info("Setting workspace {} to inactive", ws.getWorkspaceNamespace());
               ws.setInitialCreditsExpired(true);
               ws.setBillingStatus(BillingStatus.INACTIVE);
               workspaceDao.save(ws);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -643,6 +643,11 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         .filter(ws -> isInitialCredits(ws.getBillingAccountName(), workbenchConfigProvider.get()))
         .forEach(
             ws -> {
+              log.info(
+                  String.format(
+                      "Setting initial credits exhaustion status for workspace %s to %s",
+                      ws.getWorkspaceNamespace(),
+                      exhausted ? BillingStatus.INACTIVE : BillingStatus.ACTIVE));
               ws.setInitialCreditsExhausted(exhausted);
               ws.setBillingStatus(exhausted ? BillingStatus.INACTIVE : BillingStatus.ACTIVE);
               workspaceDao.save(ws);


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

We're seeing strange billing sync issues that we cannot understand, where a user updates their billing account however the billing active status stays as Inactive. 
Also I see another strange issue where the actual billing account name was not updated after being linked successfully in gcp (https://precisionmedicineinitiative.atlassian.net/browse/RW-13997)
I am adding some logs to trace the code and better understand the root cause of the issue.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
