### PR TITLE
[risk=no][RW-13631] Add cdr config for the VWB template that will be cloned to create a workspace

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -145,7 +145,8 @@
       "hasCopeSurveyData": true,
       "hasSurveyConductData": true,
       "accessTier": "registered",
-      "tanagraEnabled": true
+      "tanagraEnabled": true,
+      "vwbTemplateId": "03e0a1e6-ddbc-499f-bdaa-6c0c91dc295a"
     },
     {
       "cdrVersionId": 10,
@@ -168,7 +169,8 @@
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled",
       "tanagraEnabled": true,
-      "needsV8GenomicExtractionWorkflow": true
+      "needsV8GenomicExtractionWorkflow": true,
+      "vwbTemplateId": "03e0a1e6-ddbc-499f-bdaa-6c0c91dc295a"
     }
   ]
 }

--- a/api/db/changelog/db.changelog-245-add-vwb-template-id-cdr-version.xml
+++ b/api/db/changelog/db.changelog-245-add-vwb-template-id-cdr-version.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet author="tarekahmed" id="db.changelog-245-add-vwb-template-id-cdr-version">
+        <addColumn tableName="cdr_version">
+            <column name="vwb_template_id" type="varchar(100)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>
+
+

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -252,6 +252,7 @@
   <include file="changelog/db.changelog-242-remove-old-workspace-columns.xml"/>
   <include file="changelog/db.changelog-243-replace-extension-count.xml"/>
   <include file="changelog/db.changelog-244-add-is-vwb-workspace-column.xml"/>
+  <include file="changelog/db.changelog-245-add-vwb-template-id-cdr-version.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -63,6 +63,8 @@ public class DbCdrVersion {
 
   private Boolean needsV8GenomicExtractionWorkflow;
 
+  private String vwbTemplateID;
+
   @Id
   @Column(name = "cdr_version_id")
   public long getCdrVersionId() {
@@ -506,6 +508,16 @@ public class DbCdrVersion {
     return this;
   }
 
+  @Column(name = "vwb_template_id")
+  public String getVwbTemplateID() {
+    return vwbTemplateID;
+  }
+
+  public DbCdrVersion setVwbTemplateID(String vwbTemplateID) {
+    this.vwbTemplateID = vwbTemplateID;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -550,7 +562,8 @@ public class DbCdrVersion {
         wgsLongReadsHailT2T,
         wgsLongReadsJointVcfGRCh38,
         wgsLongReadsJointVcfT2T,
-        needsV8GenomicExtractionWorkflow);
+        needsV8GenomicExtractionWorkflow,
+        vwbTemplateID);
   }
 
   @Override
@@ -604,6 +617,7 @@ public class DbCdrVersion {
         && Objects.equals(wgsLongReadsHailT2T, that.wgsLongReadsHailT2T)
         && Objects.equals(wgsLongReadsJointVcfGRCh38, that.wgsLongReadsJointVcfGRCh38)
         && Objects.equals(wgsLongReadsJointVcfT2T, that.wgsLongReadsJointVcfT2T)
-        && Objects.equals(needsV8GenomicExtractionWorkflow, that.needsV8GenomicExtractionWorkflow);
+        && Objects.equals(needsV8GenomicExtractionWorkflow, that.needsV8GenomicExtractionWorkflow)
+        && Objects.equals(vwbTemplateID, that.vwbTemplateID);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
+++ b/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
@@ -55,4 +55,6 @@ public class CdrVersionVO {
   public String wgsLongReadsJointVcfT2T;
 
   public Boolean needsV8GenomicExtractionWorkflow;
+
+  public String vwbTemplateID;
 }


### PR DESCRIPTION

In this PR, I add a CDR config to indicate the ID of the VWB workspace that will be used to create workspaces in AoU.

Each CDR version will have its own template to copy, that's why this is a CDR config rather than a global config

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
