### PR TITLE
[no ticket][risk=no] Account for User Provided Billing Account When Getting Billing Status.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -24,7 +24,6 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.ExpiredInitialCreditsEventRequest;
 import org.pmiops.workbench.utils.CostComparisonUtils;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -230,8 +229,7 @@ public class CloudTaskInitialCreditsExpiryController
   }
 
   private Set<DbUser> getFreeTierActiveWorkspaceCreatorsIn(Set<DbUser> users) {
-    return workspaceDao.findCreatorsByBillingStatusAndBillingAccountNameIn(
-        BillingStatus.ACTIVE,
+    return workspaceDao.findCreatorsByActiveInitialCredits(
         List.of(workbenchConfig.get().billing.initialCreditsBillingAccountName()),
         users);
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryController.java
@@ -230,8 +230,7 @@ public class CloudTaskInitialCreditsExpiryController
 
   private Set<DbUser> getFreeTierActiveWorkspaceCreatorsIn(Set<DbUser> users) {
     return workspaceDao.findCreatorsByActiveInitialCredits(
-        List.of(workbenchConfig.get().billing.initialCreditsBillingAccountName()),
-        users);
+        List.of(workbenchConfig.get().billing.initialCreditsBillingAccountName()), users);
   }
 
   private void deleteAppsAndRuntimesInFreeTierWorkspaces(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -11,7 +11,6 @@ import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -114,10 +113,9 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
 
   @Query(
       "SELECT w.creator FROM DbWorkspace w "
-          + "WHERE w.billingStatus = (:status) AND w.billingAccountName in (:billingAccountNames) AND w.creator in (:creators)")
-  Set<DbUser> findCreatorsByBillingStatusAndBillingAccountNameIn(
-      @Param("status") BillingStatus status,
-      @Param("billingAccountNames") List<String> billingAccountNames,
+          + "WHERE w.billingAccountName in (:initialCreditAccountNames) AND w.creator in (:creators) AND w.initialCreditsExhausted = false AND w.initialCreditsExpired = false")
+  Set<DbUser> findCreatorsByActiveInitialCredits(
+      @Param("initialCreditAccountNames") List<String> initialCreditAccountNames,
       @Param("creators") Set<DbUser> creators);
 
   interface WorkspaceCostView {

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -541,8 +541,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
             + "  LEFT OUTER JOIN featured_workspace fw ON w.workspace_id = fw.workspace_id\n"
             + "WHERE active_status = ? \n"
             + "ORDER BY w.workspace_id\n"
-            + "LIMIT %d\n"
-            + "OFFSET %d";
+            + "LIMIT ? \n"
+            + "OFFSET ?";
     return jdbcTemplate.query(
         sql,
         new Object[] {

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -28,9 +28,11 @@ import java.util.stream.Collectors;
 import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.model.DbStorageEnums;
 import org.pmiops.workbench.db.model.DbUser.DbGeneralDiscoverySource;
 import org.pmiops.workbench.db.model.DbUser.DbPartnerDiscoverySource;
 import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.InstitutionMembershipRequirement;
 import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
 import org.pmiops.workbench.model.ReportingCohort;
@@ -494,55 +496,63 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
 
   @Override
   public List<ReportingWorkspace> getWorkspaceBatch(long limit, long offset) {
+    String sql =
+        "SELECT \n"
+            + "  a.short_name AS access_tier_short_name,\n"
+            + "  billing_account_name,\n"
+            + "  CASE \n"
+            + "    WHEN (w.billing_account_name = ? AND (w.initial_credits_exhausted = 1 OR w.initial_credits_expired = 1)) THEN ? \n"
+            + "    ELSE ? \n"
+            + "  END AS billing_status,\n"
+            + "  w.cdr_version_id AS cdr_version_id,\n"
+            + "  w.creation_time AS creation_time,\n"
+            + "  creator_id,\n"
+            + "  disseminate_research_other,\n"
+            + "  fw.category AS featured_workspace_category,\n"
+            + "  last_modified_time,\n"
+            + "  w.name AS name,\n"
+            + "  rp_additional_notes,\n"
+            + "  rp_ancestry,\n"
+            + "  rp_anticipated_findings,\n"
+            + "  rp_approved,\n"
+            + "  rp_commercial_purpose,\n"
+            + "  rp_control_set,\n"
+            + "  rp_disease_focused_research,\n"
+            + "  rp_disease_of_focus,\n"
+            + "  rp_drug_development,\n"
+            + "  rp_educational,\n"
+            + "  rp_ethics,\n"
+            + "  rp_intended_study,\n"
+            + "  rp_methods_development,\n"
+            + "  rp_other_population_details,\n"
+            + "  rp_other_purpose,\n"
+            + "  rp_other_purpose_details,\n"
+            + "  rp_population_health,\n"
+            + "  rp_reason_for_all_of_us,\n"
+            + "  rp_review_requested,\n"
+            + "  rp_scientific_approach,\n"
+            + "  rp_social_behavioral,\n"
+            + "  rp_time_requested,\n"
+            + "  w.workspace_id,\n"
+            + "  workspace_namespace\n"
+            + "FROM workspace w\n"
+            + "  JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
+            + "  JOIN access_tier a ON c.access_tier = a.access_tier_id\n"
+            + "  LEFT OUTER JOIN featured_workspace fw ON w.workspace_id = fw.workspace_id\n"
+            + "WHERE active_status = ? \n"
+            + "ORDER BY w.workspace_id\n"
+            + "LIMIT %d\n"
+            + "OFFSET %d";
     return jdbcTemplate.query(
-        String.format(
-            "SELECT \n"
-                + "  a.short_name AS access_tier_short_name,\n"
-                + "  billing_account_name,\n"
-                + "  billing_status,\n"
-                + "  w.cdr_version_id AS cdr_version_id,\n"
-                + "  w.creation_time AS creation_time,\n"
-                + "  creator_id,\n"
-                + "  disseminate_research_other,\n"
-                + "  fw.category AS featured_workspace_category,\n"
-                + "  last_modified_time,\n"
-                + "  w.name AS name,\n"
-                + "  rp_additional_notes,\n"
-                + "  rp_ancestry,\n"
-                + "  rp_anticipated_findings,\n"
-                + "  rp_approved,\n"
-                + "  rp_commercial_purpose,\n"
-                + "  rp_control_set,\n"
-                + "  rp_disease_focused_research,\n"
-                + "  rp_disease_of_focus,\n"
-                + "  rp_drug_development,\n"
-                + "  rp_educational,\n"
-                + "  rp_ethics,\n"
-                + "  rp_intended_study,\n"
-                + "  rp_methods_development,\n"
-                + "  rp_other_population_details,\n"
-                + "  rp_other_purpose,\n"
-                + "  rp_other_purpose_details,\n"
-                + "  rp_population_health,\n"
-                + "  rp_reason_for_all_of_us,\n"
-                + "  rp_review_requested,\n"
-                + "  rp_scientific_approach,\n"
-                + "  rp_social_behavioral,\n"
-                + "  rp_time_requested,\n"
-                + "  w.workspace_id,\n"
-                + "  workspace_namespace\n"
-                + "FROM workspace w\n"
-                + "  JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
-                + "  JOIN access_tier a ON c.access_tier = a.access_tier_id\n"
-                + "  LEFT OUTER JOIN featured_workspace fw ON w.workspace_id = fw.workspace_id\n"
-                + "WHERE active_status = "
-                + workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE)
-                + "\n"
-                + "ORDER BY w.workspace_id\n"
-                + "LIMIT %d\n"
-                + "OFFSET %d",
-            limit,
-            offset),
+        sql,
+        new Object[] {
+          workbenchConfigProvider.get().billing.initialCreditsBillingAccountName(),
+          DbStorageEnums.billingStatusToStorage(BillingStatus.INACTIVE),
+          DbStorageEnums.billingStatusToStorage(BillingStatus.ACTIVE),
+          workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE),
+          limit,
+          offset
+        },
         (rs, unused) ->
             new ReportingWorkspace()
                 .accessTierShortName(rs.getString("access_tier_short_name"))

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -638,6 +638,14 @@ public class DbWorkspace {
     return WorkspaceActiveStatus.ACTIVE.equals(getWorkspaceActiveStatusEnum());
   }
 
+  @Deprecated(since = "September 2024", forRemoval = true)
+  @Column(name = "billing_status")
+  public BillingStatus getBillingStatus() {
+    return (initialCreditsExhausted || initialCreditsExpired
+        ? BillingStatus.INACTIVE
+        : BillingStatus.ACTIVE);
+  }
+
   public DbWorkspace setBillingStatus(BillingStatus billingStatus) {
     this.billingStatus = DbStorageEnums.billingStatusToStorage(billingStatus);
     return this;

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -638,14 +638,6 @@ public class DbWorkspace {
     return WorkspaceActiveStatus.ACTIVE.equals(getWorkspaceActiveStatusEnum());
   }
 
-  @Deprecated(since = "September 2024", forRemoval = true)
-  @Column(name = "billing_status")
-  public BillingStatus getBillingStatus() {
-    return (initialCreditsExhausted || initialCreditsExpired
-        ? BillingStatus.INACTIVE
-        : BillingStatus.ACTIVE);
-  }
-
   public DbWorkspace setBillingStatus(BillingStatus billingStatus) {
     this.billingStatus = DbStorageEnums.billingStatusToStorage(billingStatus);
     return this;
@@ -685,9 +677,7 @@ public class DbWorkspace {
   public boolean equals(Object o) {
     if (this == o) return true;
 
-    if (!(o instanceof DbWorkspace)) return false;
-
-    DbWorkspace workspace = (DbWorkspace) o;
+    if (!(o instanceof DbWorkspace workspace)) return false;
 
     return new EqualsBuilder()
         .append(billingMigrationStatus, workspace.billingMigrationStatus)

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -1,7 +1,10 @@
 package org.pmiops.workbench.utils.mappers;
 
+import static org.pmiops.workbench.utils.BillingUtils.isInitialCredits;
+
 import com.google.common.base.Strings;
 import jakarta.annotation.Nullable;
+import jakarta.inject.Provider;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -11,9 +14,12 @@ import java.util.Optional;
 import org.mapstruct.Context;
 import org.mapstruct.Named;
 import org.pmiops.workbench.api.Etags;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
+import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.Domain;
 import org.springframework.stereotype.Service;
 
@@ -21,9 +27,11 @@ import org.springframework.stereotype.Service;
 public class CommonMappers {
 
   private final Clock clock;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
-  public CommonMappers(Clock clock) {
+  public CommonMappers(Clock clock, Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.clock = clock;
+    this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
   public Long timestamp(Timestamp timestamp) {
@@ -125,5 +133,13 @@ public class CommonMappers {
   public Long getInitialCreditsExpiration(
       DbUser source, @Context InitialCreditsService initialCreditsService) {
     return initialCreditsService.getCreditsExpiration(source).map(this::timestamp).orElse(null);
+  }
+
+  @Named("getBillingStatus")
+  public BillingStatus getBillingStatus(DbWorkspace dbWorkspace) {
+    return (isInitialCredits(dbWorkspace.getBillingAccountName(), workbenchConfigProvider.get())
+            && (dbWorkspace.isInitialCreditsExhausted() || dbWorkspace.isInitialCreditsExpired()))
+        ? BillingStatus.INACTIVE
+        : BillingStatus.ACTIVE;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -59,6 +59,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "initialCredits.exhausted", source = "dbWorkspace.initialCreditsExhausted")
   @Mapping(target = "initialCredits.expired", source = "dbWorkspace.initialCreditsExpired")
   @Mapping(target = "usesTanagra", source = "dbWorkspace.usesTanagra")
+  @Mapping(target = "billingStatus", source = "dbWorkspace", qualifiedByName = "getBillingStatus")
   Workspace toApiWorkspace(
       DbWorkspace dbWorkspace,
       RawlsWorkspaceDetails fcWorkspace,

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -140,6 +140,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "namespace", source = "workspaceNamespace")
   @Mapping(target = "researchPurpose", source = "dbWorkspace")
   @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
+  @Mapping(target = "billingStatus", source = "dbWorkspace", qualifiedByName = "getBillingStatus")
   // provides an incomplete workspace!  Only for use by the RecentWorkspace mapper
   Workspace onlyForMappingRecentWorkspace(
       DbWorkspace dbWorkspace, @Context InitialCreditsService initialCreditsService);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -44,7 +44,10 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 public interface WorkspaceResourceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
-  @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace", qualifiedByName = "getBillingStatus")
+  @Mapping(
+      target = "workspaceBillingStatus",
+      source = "dbWorkspace",
+      qualifiedByName = "getBillingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   WorkspaceFields fromWorkspace(DbWorkspace dbWorkspace);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourceMapper.java
@@ -44,7 +44,7 @@ import org.pmiops.workbench.utils.mappers.MapStructConfig;
 public interface WorkspaceResourceMapper {
   @Mapping(target = "workspaceId", source = "dbWorkspace.workspaceId")
   @Mapping(target = "workspaceFirecloudName", source = "dbWorkspace.firecloudName")
-  @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace.billingStatus")
+  @Mapping(target = "workspaceBillingStatus", source = "dbWorkspace", qualifiedByName = "getBillingStatus")
   @Mapping(target = "cdrVersionId", source = "dbWorkspace.cdrVersion")
   @Mapping(target = "accessTierShortName", source = "dbWorkspace.cdrVersion.accessTier.shortName")
   WorkspaceFields fromWorkspace(DbWorkspace dbWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -1,10 +1,10 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
 import com.google.cloud.storage.BlobId;
@@ -26,6 +26,7 @@ import org.pmiops.workbench.cohorts.CohortMapperImpl;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.AccessTierDao;
@@ -59,13 +60,18 @@ import org.pmiops.workbench.workspaces.resources.UserRecentResourceService;
 import org.pmiops.workbench.workspaces.resources.WorkspaceResourceMapper;
 import org.pmiops.workbench.workspaces.resources.WorkspaceResourceMapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
 public class UserMetricsControllerTest {
+
+  private static WorkbenchConfig workbenchConfig;
 
   @Mock private CloudStorageClient mockCloudStorageClient;
   @Mock private UserRecentResourceService mockUserRecentResourceService;
@@ -113,10 +119,17 @@ public class UserMetricsControllerTest {
     CohortService.class,
     ConceptSetService.class,
   })
-  static class Configuration {}
+  static class Configuration {
+    @Bean
+    @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig workbenchConfig() {
+      return workbenchConfig;
+    }
+  }
 
   @BeforeEach
   public void setUp() {
+    workbenchConfig = createEmptyConfig();
     DbCdrVersion dbCdrVersion = createDefaultCdrVersion();
 
     accessTierDao.save(dbCdrVersion.getAccessTier());

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -2,6 +2,8 @@ package org.pmiops.workbench.utils.mappers;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
+import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -9,8 +11,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.api.Etags;
@@ -20,6 +26,7 @@ import org.pmiops.workbench.cohorts.CohortMapperImpl;
 import org.pmiops.workbench.cohorts.CohortService;
 import org.pmiops.workbench.conceptset.ConceptSetService;
 import org.pmiops.workbench.conceptset.mapper.ConceptSetMapperImpl;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.dataset.mapper.DataSetMapperImpl;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
@@ -48,9 +55,12 @@ import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceListResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig
@@ -63,6 +73,7 @@ public class WorkspaceMapperTest {
   private static final String WORKSPACE_AOU_NAME = "studyallthethings";
   private static final String WORKSPACE_FIRECLOUD_NAME = "aaaa-bbbb-cccc-dddd";
   private static final String BILLING_ACCOUNT_NAME = "billing-account";
+  private static final String INITIAL_CREDITS_BILLING_ACCOUNT_NAME = "initial-credits-billing-account";
   private static final String GOOGLE_PROJECT = "google_project";
 
   private static final Timestamp DB_CREATION_TIMESTAMP =
@@ -80,6 +91,8 @@ public class WorkspaceMapperTest {
 
   private DbWorkspace sourceDbWorkspace;
   private RawlsWorkspaceDetails sourceFirecloudWorkspace;
+
+  private static WorkbenchConfig workbenchConfig;
 
   @Autowired private InitialCreditsService initialCreditsService;
   @Autowired private WorkspaceMapper workspaceMapper;
@@ -109,7 +122,14 @@ public class WorkspaceMapperTest {
     WorkspaceFreeTierUsageDao.class,
     WorkspaceInitialCreditUsageService.class
   })
-  static class Configuration {}
+  static class Configuration {
+
+    @Bean
+    @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig workbenchConfig() {
+      return workbenchConfig;
+    }
+  }
 
   @BeforeEach
   public void setUp() {
@@ -171,13 +191,14 @@ public class WorkspaceMapperTest {
             .setReviewRequested(false)
             .setApproved(true)
             .setTimeRequested(DB_CREATION_TIMESTAMP)
-            .setBillingStatus(BillingStatus.ACTIVE)
             .setBillingAccountName(BILLING_ACCOUNT_NAME)
             .setSpecificPopulationsEnum(SPECIFIC_POPULATIONS)
             .setResearchOutcomeEnumSet(RESEARCH_OUTCOMES)
             .setDisseminateResearchEnumSet(Collections.emptySet())
             .setDisseminateResearchOther(DISSEMINATE_FINDINGS_OTHER)
             .setGoogleProject(GOOGLE_PROJECT);
+
+    workbenchConfig = createEmptyConfig();
   }
 
   @Test
@@ -308,6 +329,72 @@ public class WorkspaceMapperTest {
                     initialCreditsService));
 
     assertThat(result).isEmpty();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("dataForWorkspaceBilling")
+  public void testToApiWorkspaceBillingStatus(String testName, String billingAccount, boolean exhausted, boolean expired, BillingStatus expectedStatus) {
+    workbenchConfig.billing.accountId = INITIAL_CREDITS_BILLING_ACCOUNT_NAME;
+    sourceDbWorkspace.setInitialCreditsExhausted(exhausted);
+    sourceDbWorkspace.setInitialCreditsExpired(expired);
+    sourceDbWorkspace.setBillingAccountName(fullBillingAccountName(billingAccount));
+    Workspace x =
+        workspaceMapper.toApiWorkspace(
+            sourceDbWorkspace, sourceFirecloudWorkspace, initialCreditsService);
+    assertThat(x.getBillingStatus()).isEqualTo(expectedStatus);
+  }
+
+  static Stream<Arguments> dataForWorkspaceBilling() {
+    return Stream.of(
+        Arguments.of(
+            "If the workspace is using initial credits and the credits are neither exhausted or expired, the billing status is active.",
+            INITIAL_CREDITS_BILLING_ACCOUNT_NAME,
+            false,
+            false,
+            BillingStatus.ACTIVE),
+        Arguments.of(
+            "If the workspace is using initial credits and the credits are exhausted, the billing status is inactive.",
+            INITIAL_CREDITS_BILLING_ACCOUNT_NAME,
+            true,
+            false,
+            BillingStatus.INACTIVE),
+        Arguments.of(
+            "If the workspace is using initial credits and the credits are expired, the billing status is inactive.",
+            INITIAL_CREDITS_BILLING_ACCOUNT_NAME,
+            false,
+            true,
+            BillingStatus.INACTIVE),
+        Arguments.of(
+            "If the workspace is using initial credits and the credits are both exhausted and expired, the billing status is inactive.",
+            INITIAL_CREDITS_BILLING_ACCOUNT_NAME,
+            true,
+            true,
+            BillingStatus.INACTIVE),
+        Arguments.of(
+            "If the workspace is not using initial credits and the credits are neither exhausted or expired, the billing status is active.",
+            BILLING_ACCOUNT_NAME,
+            false,
+            false,
+            BillingStatus.ACTIVE),
+        Arguments.of(
+            "If the workspace is not using initial credits and the credits are exhausted, the billing status is active.",
+            BILLING_ACCOUNT_NAME,
+            true,
+            false,
+            BillingStatus.ACTIVE),
+        Arguments.of(
+            "If the workspace is not using initial credits and the credits are expired, the billing status is active.",
+            BILLING_ACCOUNT_NAME,
+            false,
+            true,
+            BillingStatus.ACTIVE),
+        Arguments.of(
+            "If the workspace is not using initial credits and the credits are both exhausted and expired, the billing status is active.",
+            BILLING_ACCOUNT_NAME,
+            true,
+            true,
+            BillingStatus.ACTIVE)
+        );
   }
 
   private void assertResearchPurposeMatches(ResearchPurpose rp) {

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -73,7 +73,8 @@ public class WorkspaceMapperTest {
   private static final String WORKSPACE_AOU_NAME = "studyallthethings";
   private static final String WORKSPACE_FIRECLOUD_NAME = "aaaa-bbbb-cccc-dddd";
   private static final String BILLING_ACCOUNT_NAME = "billing-account";
-  private static final String INITIAL_CREDITS_BILLING_ACCOUNT_NAME = "initial-credits-billing-account";
+  private static final String INITIAL_CREDITS_BILLING_ACCOUNT_NAME =
+      "initial-credits-billing-account";
   private static final String GOOGLE_PROJECT = "google_project";
 
   private static final Timestamp DB_CREATION_TIMESTAMP =
@@ -333,7 +334,12 @@ public class WorkspaceMapperTest {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("dataForWorkspaceBilling")
-  public void testToApiWorkspaceBillingStatus(String testName, String billingAccount, boolean exhausted, boolean expired, BillingStatus expectedStatus) {
+  public void testToApiWorkspaceBillingStatus(
+      String testName,
+      String billingAccount,
+      boolean exhausted,
+      boolean expired,
+      BillingStatus expectedStatus) {
     workbenchConfig.billing.accountId = INITIAL_CREDITS_BILLING_ACCOUNT_NAME;
     sourceDbWorkspace.setInitialCreditsExhausted(exhausted);
     sourceDbWorkspace.setInitialCreditsExpired(expired);
@@ -393,8 +399,7 @@ public class WorkspaceMapperTest {
             BILLING_ACCOUNT_NAME,
             true,
             true,
-            BillingStatus.ACTIVE)
-        );
+            BillingStatus.ACTIVE));
   }
 
   private void assertResearchPurposeMatches(ResearchPurpose rp) {

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceOperationMapperTest.java
@@ -3,11 +3,14 @@ package org.pmiops.workbench.workspaces;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.FakeClockConfiguration.NOW_TIME;
+import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
 
 import java.sql.Timestamp;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.db.model.DbWorkspaceOperation;
@@ -27,13 +30,18 @@ import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
 public class WorkspaceOperationMapperTest {
+  private static WorkbenchConfig workbenchConfig;
+
   @Autowired private WorkspaceOperationMapper workspaceOperationMapper;
 
   @Autowired private WorkspaceMapper workspaceMapper;
@@ -51,11 +59,19 @@ public class WorkspaceOperationMapperTest {
     WorkspaceMapperImpl.class,
     WorkspaceOperationMapperImpl.class,
   })
-  @MockBean({
-    FirecloudApiClientFactory.class,
-    FirecloudRetryHandler.class,
-  })
-  static class Configuration {}
+  @MockBean({FirecloudApiClientFactory.class, FirecloudRetryHandler.class})
+  static class Configuration {
+    @Bean
+    @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public WorkbenchConfig workbenchConfig() {
+      return workbenchConfig;
+    }
+  }
+
+  @BeforeEach
+  public void setUp() {
+    workbenchConfig = createEmptyConfig();
+  }
 
   @Test
   public void test_toModelWithoutWorkspace() {


### PR DESCRIPTION
DbWorkspace has a function, getBillingStatus, that has been deprecated, but billing status is still being used in various parts of the application. Until these usages can be removed throughout the application, we need to ensure that the UI is getting the correct billing status. This now being handled through mapping.

Future work:
- Drop billing_status column
- Drop getBillingStatus function

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
