### PR TITLE
[risk=low][no ticket] Can't get app usage row count when we don't populate the table

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -590,6 +590,10 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
 
   @Override
   public int getAppUsageRowCount(String tableName) {
+    if (!workbenchConfigProvider.get().reporting.exportTerraDataWarehouse) {
+      return 0;
+    }
+
     var queryString =
         "SELECT count(*) "
             + "FROM `"

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -19,13 +19,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import jakarta.persistence.EntityManager;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Handler;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
@@ -106,13 +104,12 @@ public class ReportingVerificationServiceTest {
         .executeQuery(any(QueryJobConfiguration.class));
 
     logCapturingStream = new ByteArrayOutputStream();
-    Handler[] handlers = LOGGER.getParent().getHandlers();
     customLogHandler = new StreamHandler(logCapturingStream, new SimpleFormatter());
     LOGGER.addHandler(customLogHandler);
   }
 
   @Test
-  public void testVerifyBatch_verified() throws Exception {
+  public void testVerifyBatch_verified() {
     createTableEntries(ACTUAL_COUNT);
     assertThat(
             reportingVerificationService.verifyBatchesAndLog(
@@ -137,7 +134,7 @@ public class ReportingVerificationServiceTest {
   }
 
   @Test
-  public void testVerifyBatch_fail() throws Exception {
+  public void testVerifyBatch_fail() {
     createTableEntries(ACTUAL_COUNT * 2);
     assertThat(
             reportingVerificationService.verifyBatchesAndLog(
@@ -177,7 +174,7 @@ public class ReportingVerificationServiceTest {
   }
 
   /** Gets the captured log. */
-  private static String getTestCapturedLog() throws IOException {
+  private static String getTestCapturedLog() {
     customLogHandler.flush();
     return logCapturingStream.toString();
   }

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestConfig.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestConfig.java
@@ -24,6 +24,7 @@ public class ReportingTestConfig {
     final WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.reporting.dataset = "wb_reporting";
     workbenchConfig.reporting.maxRowsPerInsert = 2;
+    workbenchConfig.reporting.exportTerraDataWarehouse = true;
     workbenchConfig.server.projectId = "rw-wb-unit-test";
     workbenchConfig.billing.accountId = WORKSPACE__BILLING_ACCOUNT_ID;
     return workbenchConfig;


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
