### PR TITLE
[RW-13720][risk=no] Cleaned up credit exhaustion cron language

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -22,8 +22,8 @@
     "accountId": "013713-75CFF6-1751E5",
     "projectNamePrefix": "aou-rw-local1-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -31,9 +31,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
-    "freeTierCronUserBatchSize": 100,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 2
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -168,6 +167,7 @@
     "unsafeCloudTasksForwardingHost": "http:\/\/localhost:8081",
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 100,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -22,8 +22,8 @@
     "accountId": "01DDC8-7ED304-6E46FE",
     "projectNamePrefix": "aou-rw-preprod-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -31,9 +31,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
-    "freeTierCronUserBatchSize": 100,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 2
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -159,6 +158,7 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 100,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -22,8 +22,8 @@
     "accountId": "01DDC8-7ED304-6E46FE",
     "projectNamePrefix": "aou-rw-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -31,9 +31,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
-    "freeTierCronUserBatchSize": 200,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 7
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 7
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -171,6 +170,7 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 200,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -22,8 +22,8 @@
     "accountId": "01DDC8-7ED304-6E46FE",
     "projectNamePrefix": "aou-rw-stable-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -31,9 +31,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
-    "freeTierCronUserBatchSize": 100,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 2
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -157,6 +156,7 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 100,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -23,8 +23,8 @@
     "accountId": "01DDC8-7ED304-6E46FE",
     "projectNamePrefix": "aou-rw-staging-",
     "exportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.rw_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -32,9 +32,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
-    "freeTierCronUserBatchSize": 100,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 2
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -154,6 +153,7 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 100,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -22,8 +22,8 @@
     "accountId": "013713-75CFF6-1751E5",
     "projectNamePrefix": "aou-rw-test-",
     "exportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_firecloud_view",
-    "defaultFreeCreditsDollarLimit": 300.0,
-    "freeTierCostAlertThresholds": [
+    "defaultInitialCreditsDollarLimit": 300.0,
+    "initialCreditsCostAlertThresholds": [
       0.5,
       0.75
     ],
@@ -31,9 +31,8 @@
     "initialCreditsExtensionPeriodDays": 365,
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
-    "freeTierCronUserBatchSize": 5,
-    "minutesBeforeLastFreeTierJob": 60,
-    "numberOfDaysToConsiderForFreeTierUsageUpdate": 2
+    "minutesBeforeLastInitialCreditsJob": 60,
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -168,6 +167,7 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
+    "usersPerCheckInitialCreditsUsageTask": 100,
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
@@ -120,7 +120,7 @@ public class CloudTaskInitialCreditsExhaustionController
       Map<Long, Double> liveCostByCreator,
       Set<DbUser> newlyExhaustedUsers) {
     final List<Double> costThresholdsInDescOrder =
-        workbenchConfig.get().billing.freeTierCostAlertThresholds;
+        workbenchConfig.get().billing.initialCreditsCostAlertThresholds;
     costThresholdsInDescOrder.sort(Comparator.reverseOrder());
 
     Map<Long, DbUser> usersCache =
@@ -183,7 +183,7 @@ public class CloudTaskInitialCreditsExhaustionController
                         e.getValue(),
                         Math.max(
                             dbCostByCreator.get(e.getKey()), liveCostByCreator.get(e.getKey())),
-                        workbenchConfig.get().billing.defaultFreeCreditsDollarLimit))
+                        workbenchConfig.get().billing.defaultInitialCreditsDollarLimit))
             .map(Map.Entry::getValue)
             .collect(Collectors.toSet());
 
@@ -272,7 +272,7 @@ public class CloudTaskInitialCreditsExhaustionController
 
     final double limit =
         getUserInitialCreditsLimit(
-            user, workbenchConfig.get().billing.defaultFreeCreditsDollarLimit);
+            user, workbenchConfig.get().billing.defaultInitialCreditsDollarLimit);
     final double remainingBalance = limit - currentCost;
 
     // this shouldn't happen, but it did (RW-4678)

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -69,7 +69,7 @@ public class OfflineUserController implements OfflineUserApiDelegate {
             userIds.size(), formatDurationPretty(elapsed)));
 
     stopwatch.reset().start();
-    List<String> taskIds = taskQueueService.groupAndPushCheckInitialCreditExpirationTasks(userIds);
+    List<String> taskIds = taskQueueService.groupAndPushCheckInitialCreditsExpirationTasks(userIds);
     elapsed = stopwatch.stop().elapsed();
     logger.info(
         String.format(

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 import org.pmiops.workbench.auth.UserAuthentication;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.OfflineBatchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.RdrExportConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.BadRequestException;
@@ -140,28 +141,23 @@ public class TaskQueueService {
   }
 
   public void groupAndPushAuditProjectsTasks(List<Long> userIds) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    createAndPushAll(userIds, workbenchConfig.offlineBatch.usersPerAuditTask, AUDIT_PROJECTS);
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    createAndPushAll(userIds, config.usersPerAuditTask, AUDIT_PROJECTS);
   }
 
   public void groupAndPushInitialCreditsUsage(List<Long> userIds) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    createAndPushAll(
-        userIds, workbenchConfig.billing.freeTierCronUserBatchSize, INITIAL_CREDITS_USAGE);
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    createAndPushAll(userIds, config.usersPerCheckInitialCreditsUsageTask, INITIAL_CREDITS_USAGE);
   }
 
   public List<String> groupAndPushSynchronizeAccessTasks(List<Long> userIds) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    return createAndPushAll(
-        userIds, workbenchConfig.offlineBatch.usersPerSynchronizeAccessTask, SYNCHRONIZE_ACCESS);
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    return createAndPushAll(userIds, config.usersPerSynchronizeAccessTask, SYNCHRONIZE_ACCESS);
   }
 
   public void groupAndPushAccessExpirationEmailTasks(List<Long> userIds) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    createAndPushAll(
-        userIds,
-        workbenchConfig.offlineBatch.usersPerAccessExpirationEmailTask,
-        ACCESS_EXPIRATION_EMAIL);
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    createAndPushAll(userIds, config.usersPerAccessExpirationEmailTask, ACCESS_EXPIRATION_EMAIL);
   }
 
   private int getDeleteWorkspacesBatchSize() throws BadRequestException {
@@ -185,10 +181,10 @@ public class TaskQueueService {
   }
 
   public void groupAndPushDeleteWorkspaceEnvironmentTasks(List<String> workspaceNamespaces) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
     createAndPushAll(
         workspaceNamespaces,
-        workbenchConfig.offlineBatch.workspacesPerDeleteWorkspaceEnvironmentsTask,
+        config.workspacesPerDeleteWorkspaceEnvironmentsTask,
         DELETE_UNSHARED_WORKSPACE_ENVIRONMENTS);
   }
 
@@ -230,18 +226,15 @@ public class TaskQueueService {
             .liveCostByCreator(liveCostByCreator));
   }
 
-  public List<String> groupAndPushCheckInitialCreditExpirationTasks(List<Long> userIds) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
+  public List<String> groupAndPushCheckInitialCreditsExpirationTasks(List<Long> userIds) {
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
     return createAndPushAll(
-        userIds,
-        workbenchConfig.offlineBatch.usersPerCheckInitialCreditsExpirationTask,
-        INITIAL_CREDITS_EXPIRATION);
+        userIds, config.usersPerCheckInitialCreditsExpirationTask, INITIAL_CREDITS_EXPIRATION);
   }
 
   public void groupAndPushCheckPersistentDiskTasks(List<Disk> disks) {
-    WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    createAndPushAll(
-        disks, workbenchConfig.offlineBatch.disksPerCheckPersistentDiskTask, PERSISTENT_DISKS);
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    createAndPushAll(disks, config.disksPerCheckPersistentDiskTask, PERSISTENT_DISKS);
   }
 
   public void pushVwbPodCreationTask(String email) {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -98,24 +98,21 @@ public class WorkbenchConfig {
     // checkInitialCreditsUsage cron endpoint.
     public String exportBigQueryTable;
     // The default dollar limit to apply to initial credits usage in this environment.
-    public Double defaultFreeCreditsDollarLimit;
+    public Double defaultInitialCreditsDollarLimit;
     // Thresholds for email alerting based on initial credits usage, by cost
-    public List<Double> freeTierCostAlertThresholds;
+    public List<Double> initialCreditsCostAlertThresholds;
     // The contact email from Carahsoft for billing account setup
     public String carahsoftEmail;
 
-    // The batch size used by the cron job to process users
-    public Integer freeTierCronUserBatchSize;
-
-    // The number of minutes elapsed after the last cron run to update the free tier billing
+    // The number of minutes elapsed after the last cron run to update the initial credits billing
     // information
-    public Integer minutesBeforeLastFreeTierJob;
+    public Integer minutesBeforeLastInitialCreditsJob;
 
     // A value that defines the number of days to consider between the last update of initial
     // credits usage in the database and the last workspace update when calculating the eligibility
     // of a workspace initial credits usage to be updated. To account for charges that may occur
     // after the workspace gets deleted and after the last cron had run
-    public Long numberOfDaysToConsiderForFreeTierUsageUpdate;
+    public Long numberOfDaysToConsiderForInitialCreditsUsageUpdate;
 
     // The number of days that initial credits are valid for.
     public Long initialCreditsValidityPeriodDays;
@@ -416,6 +413,8 @@ public class WorkbenchConfig {
     public Integer usersPerAuditTask;
     // Number of users to process within a single access synchronization task.
     public Integer usersPerSynchronizeAccessTask;
+    // Number of users to process within a single check initial credits usage task.
+    public Integer usersPerCheckInitialCreditsUsageTask;
     // Number of users to process within a single check initial credits expiration task.
     public Integer usersPerCheckInitialCreditsExpirationTask;
     // Number of users to process within a single access expiration email task.

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -45,6 +45,7 @@ public interface WorkbenchConfigMapper {
   @Mapping(target = "rasLogoutUrl", source = "config.ras.logoutUrl")
   @Mapping(target = "tanagraBaseUrl", source = "config.tanagra.baseUrl")
   @Mapping(target = "freeTierBillingAccountId", source = "config.billing.accountId")
+  @Mapping(target = "initialCreditsBillingAccountId", source = "config.billing.accountId")
   @Mapping(target = "currentDuccVersions", source = "config.access.currentDuccVersions")
   @Mapping(target = "enableCaptcha", source = "config.captcha.enableCaptcha")
   @Mapping(target = "enableDataExplorer", source = "config.featureFlags.enableDataExplorer")

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -24,7 +24,10 @@ public interface WorkbenchConfigMapper {
       source = "config.server.publicApiKeyForErrorReports")
   @Mapping(
       target = "defaultFreeCreditsDollarLimit",
-      source = "config.billing.defaultFreeCreditsDollarLimit")
+      source = "config.billing.defaultInitialCreditsDollarLimit")
+  @Mapping(
+      target = "defaultInitialCreditsDollarLimit",
+      source = "config.billing.defaultInitialCreditsDollarLimit")
   @Mapping(target = "enableComplianceTraining", source = "config.access.enableComplianceTraining")
   @Mapping(target = "absorbSamlIdentityProviderId", source = "config.absorb.samlIdentityProviderId")
   @Mapping(target = "absorbSamlServiceProviderId", source = "config.absorb.samlServiceProviderId")

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -158,7 +158,7 @@ public class InitialCreditsService {
    */
   private Set<DbUser> filterUsersHigherThanTheLowestThreshold(
       Set<DbUser> users, final Map<Long, Double> liveCostByCreator) {
-    return workbenchConfigProvider.get().billing.freeTierCostAlertThresholds.stream()
+    return workbenchConfigProvider.get().billing.initialCreditsCostAlertThresholds.stream()
         .min(Comparator.naturalOrder())
         .map(
             lowestThreshold ->
@@ -211,7 +211,7 @@ public class InitialCreditsService {
    */
   public double getUserInitialCreditsLimit(DbUser user) {
     return CostComparisonUtils.getUserInitialCreditsLimit(
-        user, workbenchConfigProvider.get().billing.defaultFreeCreditsDollarLimit);
+        user, workbenchConfigProvider.get().billing.defaultInitialCreditsDollarLimit);
   }
 
   /**
@@ -235,7 +235,7 @@ public class InitialCreditsService {
         && (previousLimitMaybe != null
             || CostComparisonUtils.costsDiffer(
                 newDollarLimit,
-                workbenchConfigProvider.get().billing.defaultFreeCreditsDollarLimit))) {
+                workbenchConfigProvider.get().billing.defaultInitialCreditsDollarLimit))) {
 
       // TODO: prevent setting this limit directly except in this method?
       user = userDao.save(user.setInitialCreditsLimitOverride(newDollarLimit));
@@ -573,7 +573,7 @@ public class InitialCreditsService {
                                         < Duration.ofDays(
                                                 workbenchConfigProvider.get()
                                                     .billing
-                                                    .numberOfDaysToConsiderForFreeTierUsageUpdate)
+                                                    .numberOfDaysToConsiderForInitialCreditsUsageUpdate)
                                             .toMillis()))))
             .toList();
 
@@ -639,11 +639,12 @@ public class InitialCreditsService {
 
   private boolean costAboveLimit(final DbUser user, final double currentCost) {
     return CostComparisonUtils.costAboveLimit(
-        user, currentCost, workbenchConfigProvider.get().billing.defaultFreeCreditsDollarLimit);
+        user, currentCost, workbenchConfigProvider.get().billing.defaultInitialCreditsDollarLimit);
   }
 
   private Integer getMinutesBeforeLastInitialCreditsJob() {
-    return Optional.ofNullable(workbenchConfigProvider.get().billing.minutesBeforeLastFreeTierJob)
+    return Optional.ofNullable(
+            workbenchConfigProvider.get().billing.minutesBeforeLastInitialCreditsJob)
         .orElse(120);
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7137,8 +7137,12 @@ components:
           default: false
         defaultFreeCreditsDollarLimit:
           type: number
-          description: The default dollar amount of free credits allotted to each
-            user
+          description: DEPRECATED in favor of defaultInitialCreditsDollarLimit.
+            The default dollar amount of initial credits allotted to each user
+          format: double
+        defaultInitialCreditsDollarLimit:
+          type: number
+          description: The default dollar amount of initial credits allotted to each user
           format: double
         enableEventDateModifier:
           type: boolean

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7177,7 +7177,11 @@ components:
           description: The URL that can sign out RAS login session.
         freeTierBillingAccountId:
           type: string
-          description: The free tier billing account id
+          description: DEPRECATED in favor of initialCreditsBillingAccountId.
+            The initial credits billing account id
+        initialCreditsBillingAccountId:
+          type: string
+          description: The initial credits billing account id
         accessModules:
           type: array
           items:

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
@@ -18,7 +18,6 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +78,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
   @Autowired UserDao userDao;
   @Autowired WorkspaceDao workspaceDao;
-  @Autowired WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
+  @Autowired WorkspaceFreeTierUsageDao workspaceInitialCreditsUsageDao;
   @Autowired VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   @Autowired InitialCreditsService initialCreditsService;
@@ -140,17 +139,17 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   public void setUp() {
     dbInstitution = institutionDao.save(createDbInstitution());
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.billing.freeTierCostAlertThresholds = new ArrayList<>(Doubles.asList(.5, .75));
+    workbenchConfig.billing.initialCreditsCostAlertThresholds = Doubles.asList(.5, .75);
     workbenchConfig.billing.accountId = "initial-credits";
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 1000.0;
-    workbenchConfig.billing.freeTierCronUserBatchSize = 10;
-    workbenchConfig.billing.minutesBeforeLastFreeTierJob = 0;
-    workbenchConfig.billing.numberOfDaysToConsiderForFreeTierUsageUpdate = 2L;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 1000.0;
+    workbenchConfig.billing.minutesBeforeLastInitialCreditsJob = 0;
+    workbenchConfig.billing.numberOfDaysToConsiderForInitialCreditsUsageUpdate = 2L;
+    workbenchConfig.offlineBatch.usersPerCheckInitialCreditsUsageTask = 10;
   }
 
   @AfterEach
   public void tearDown() {
-    workspaceFreeTierUsageDao.deleteAll();
+    workspaceInitialCreditsUsageDao.deleteAll();
     workspaceDao.deleteAll();
     userDao.deleteAll();
     institutionDao.deleteAll();
@@ -168,7 +167,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     double costOverThreshold = 50.5;
     double remaining = limit - costOverThreshold;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = limit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = limit;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -236,7 +235,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
           throws MessagingException {
 
     // set alert thresholds at 30% and 65% instead
-    workbenchConfig.billing.freeTierCostAlertThresholds = new ArrayList<>(Doubles.asList(.3, .65));
+    workbenchConfig.billing.initialCreditsCostAlertThresholds = Doubles.asList(.3, .65);
 
     final double limit = 100.0;
     final double costUnderThreshold = 29.9;
@@ -245,7 +244,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     double costOverThreshold = 30.1;
     double remaining = limit - costOverThreshold;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = limit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = limit;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -315,7 +314,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Test
   public void handleInitialCreditsExhaustionBatch_alertsAndDeletesResources_evenWhenUserIsDisabled()
       throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     user.setDisabled(true);
@@ -340,7 +339,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   public void
       handleInitialCreditsExhaustionBatch_alertsAndDeletesResources_evenWhenWorkspaceIsDeleted()
           throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -364,7 +363,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Test
   public void handleInitialCreditsExhaustionBatch_noAlert_ifCostIsBelowLowestThreshold() {
     // set limit so usage is just under the 50% threshold
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -382,7 +381,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
   @Test
   public void handleInitialCreditsExhaustionBatch_doesntThrowNPE_whenWorkspaceIsMissingCreator() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -403,7 +402,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Test
   public void handleInitialCreditsExhaustionBatch_doesntAlert_ifDollarLimitWasOverriddenToOverUse()
       throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -435,11 +434,11 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Test
   public void handleInitialCreditsExhaustionBatch_doesntAlert_ifDollarLimitWasOverriddenToUnderUse()
       throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
-    workspaceFreeTierUsageDao.save(
+    workspaceInitialCreditsUsageDao.save(
         new DbWorkspaceFreeTierUsage(workspace).setUser(user).setCost(300.0));
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
@@ -471,7 +470,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     final double cost2 = 234.56;
     final double sum = cost1 + cost2;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = sum - 0.01;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = sum - 0.01;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace ws1 = createWorkspace(user, proj1);
@@ -495,14 +494,14 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   }
 
   @Test
-  public void handleInitialCreditsExhaustionBatch_alertsAllUsers_ifTheyExceedFreeTierLimit()
+  public void handleInitialCreditsExhaustionBatch_alertsAllUsers_ifTheyExceedInitialCreditsLimit()
       throws MessagingException {
     final String proj1 = "proj-1";
     final String proj2 = "proj-2";
     final double cost1 = 123.45;
     final double cost2 = 234.56;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = Math.min(cost1, cost2) - 0.01;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = Math.min(cost1, cost2) - 0.01;
 
     DbUser user1 = createUser(SINGLE_WORKSPACE_TEST_USER);
     DbWorkspace ws1 = createWorkspace(user1, proj1);
@@ -532,7 +531,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   public void
       handleInitialCreditsExhaustionBatch_alertsOnlyOnce_ifCostKeepIncreasingAboveThreshold()
           throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     final DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -566,7 +565,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Test
   public void handleInitialCreditsExhaustionBatch_singleAlert_forExhaustedAndByoBilling()
       throws Exception {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -590,12 +589,13 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
   @Test
   public void
-      handleInitialCreditsExhaustionBatch_disableFreeTierWorkspacesOnly_whenUserHasMultipleWorkspaces()
+      handleInitialCreditsExhaustionBatch_disableInitialCreditsWorkspacesOnly_whenUserHasMultipleWorkspaces()
           throws MessagingException {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
-    final DbWorkspace freeTierWorkspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
+    final DbWorkspace InitialCreditsWorkspace =
+        createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
     final DbWorkspace userAccountWorkspace =
         new DbWorkspace()
             .setCreator(user)
@@ -611,7 +611,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
-    assertThat(freeTierWorkspace.isInitialCreditsExhausted()).isEqualTo(true);
+    assertThat(InitialCreditsWorkspace.isInitialCreditsExhausted()).isEqualTo(true);
 
     final DbWorkspace retrievedWorkspace =
         workspaceDao.findById(userAccountWorkspace.getWorkspaceId()).get();
@@ -625,7 +625,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = Map.of(String.valueOf(user.getUserId()), 50.0);
 
     workspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
@@ -652,7 +652,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     DbWorkspace workspace = createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = new HashMap<>();
     allBQCosts.put(String.valueOf(user.getUserId()), 50.0);
 
@@ -683,7 +683,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   public void handleInitialCreditsExhaustionBatch_withMissingUsersInRequest_NoNPE()
       throws Exception {
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 300.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 300.0;
 
     DbUser user1 = createUser("user1@test.com");
     DbUser user2 = createUser("user2@test.com");

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -177,8 +177,6 @@ public class ProfileControllerTest extends BaseControllerTest {
   private static final Timestamp TIMESTAMP = FakeClockConfiguration.NOW;
   private static final double TIME_TOLERANCE_MILLIS = 100.0;
   private static final int CURRENT_DUCC_VERSION = 27; // arbitrary for test
-  private static final String AOU_TOS_NOT_ACCEPTED_ERROR_MESSAGE =
-      "No Terms of Service acceptance recorded for user ID";
   private CreateAccountRequest createAccountRequest;
   private User googleUser;
   private static DbUser dbUser;
@@ -1578,14 +1576,14 @@ public class ProfileControllerTest extends BaseControllerTest {
 
   @Test
   public void test_updateAccountProperties_free_tier_quota_no_override() {
-    config.billing.defaultFreeCreditsDollarLimit = 123.45;
+    config.billing.defaultInitialCreditsDollarLimit = 123.45;
 
     final Profile original = createAccountAndDbUserWithAffiliation();
     assertThat(original.getFreeTierDollarQuota()).isWithin(0.01).of(123.45);
 
     // update the default - the user's profile also updates
 
-    config.billing.defaultFreeCreditsDollarLimit = 234.56;
+    config.billing.defaultInitialCreditsDollarLimit = 234.56;
     assertThat(profileService.getProfile(dbUser).getFreeTierDollarQuota())
         .isWithin(0.01)
         .of(234.56);
@@ -1595,14 +1593,14 @@ public class ProfileControllerTest extends BaseControllerTest {
     final AccountPropertyUpdate request =
         new AccountPropertyUpdate()
             .username(FULL_USER_NAME)
-            .freeCreditsLimit(config.billing.defaultFreeCreditsDollarLimit);
+            .freeCreditsLimit(config.billing.defaultInitialCreditsDollarLimit);
     profileService.updateAccountProperties(request);
     verify(mockUserServiceAuditor, never())
         .fireSetInitialCreditsOverride(anyLong(), anyDouble(), anyDouble());
 
     // the user's profile continues to track default changes
 
-    config.billing.defaultFreeCreditsDollarLimit = 345.67;
+    config.billing.defaultInitialCreditsDollarLimit = 345.67;
     assertThat(profileService.getProfile(dbUser).getFreeTierDollarQuota())
         .isWithin(0.01)
         .of(345.67);

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -144,16 +144,16 @@ public class InitialCreditsServiceTest {
   @BeforeEach
   public void setUp() throws MessagingException {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
-    workbenchConfig.billing.freeTierCostAlertThresholds = new ArrayList<>(Doubles.asList(.5, .75));
+    workbenchConfig.billing.initialCreditsCostAlertThresholds = Doubles.asList(.5, .75);
     workbenchConfig.billing.accountId = "free-tier";
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 1000.0;
-    workbenchConfig.billing.freeTierCronUserBatchSize = 10;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 1000.0;
     workbenchConfig.billing.initialCreditsValidityPeriodDays = validityPeriodDays;
     workbenchConfig.billing.initialCreditsExtensionPeriodDays = extensionPeriodDays;
     workbenchConfig.billing.initialCreditsExpirationWarningDays = warningPeriodDays;
-    workbenchConfig.billing.minutesBeforeLastFreeTierJob = 0;
-    workbenchConfig.billing.numberOfDaysToConsiderForFreeTierUsageUpdate = 2L;
+    workbenchConfig.billing.minutesBeforeLastInitialCreditsJob = 0;
+    workbenchConfig.billing.numberOfDaysToConsiderForInitialCreditsUsageUpdate = 2L;
     workbenchConfig.featureFlags.enableInitialCreditsExpiration = true;
+    workbenchConfig.offlineBatch.usersPerCheckInitialCreditsUsageTask = 10;
 
     workspace =
         spyWorkspaceDao.save(
@@ -176,7 +176,7 @@ public class InitialCreditsServiceTest {
     final double limit = 100.0;
     final double costUnderThreshold = 49.5;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = limit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = limit;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -228,14 +228,14 @@ public class InitialCreditsServiceTest {
   public void checkInitialCreditsUsage_altDollarThresholds() {
 
     // set alert thresholds at 30% and 65% instead
-    workbenchConfig.billing.freeTierCostAlertThresholds = new ArrayList<>(Doubles.asList(.3, .65));
+    workbenchConfig.billing.initialCreditsCostAlertThresholds = Doubles.asList(.3, .65);
 
     final double limit = 100.0;
     final double costUnderThreshold = 29.9;
 
     double costOverThreshold = 30.1;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = limit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = limit;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     createWorkspace(user, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -282,7 +282,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void checkInitialCreditsUsage_disabledUserNotIgnored() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
 
@@ -305,7 +305,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void checkInitialCreditsUsage_deletedWorkspaceNotIgnored() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
@@ -330,7 +330,7 @@ public class InitialCreditsServiceTest {
   @Test
   public void checkInitialCreditsUsage_noAlert() {
     // set limit so usage is just under the 50% threshold
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 49.99);
@@ -349,7 +349,7 @@ public class InitialCreditsServiceTest {
   @Test
   public void checkInitialCreditsUsage_workspaceMissingCreatorNoNPE() {
     // set limit so usage is just under the 50% threshold
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 49.99);
@@ -368,7 +368,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void maybeSetDollarLimitOverride_true() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
 
     commitTransaction();
@@ -386,7 +386,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void maybeSetDollarLimitOverride_false() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
 
     assertThat(initialCreditsService.maybeSetDollarLimitOverride(user, 100.0)).isFalse();
@@ -394,7 +394,7 @@ public class InitialCreditsServiceTest {
         .fireSetInitialCreditsOverride(anyLong(), anyDouble(), anyDouble());
     assertWithinBillingTolerance(initialCreditsService.getUserInitialCreditsLimit(user), 100.0);
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 200.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 200.0;
     assertWithinBillingTolerance(initialCreditsService.getUserInitialCreditsLimit(user), 200.0);
 
     assertThat(initialCreditsService.maybeSetDollarLimitOverride(user, 200.0)).isFalse();
@@ -405,7 +405,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void maybeSetDollarLimitOverride_above_usage() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 150.0);
@@ -441,7 +441,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void setFreeTierDollarOverride_under_usage() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 300.0);
@@ -482,7 +482,7 @@ public class InitialCreditsServiceTest {
     final double cost2 = 234.56;
     final double sum = cost1 + cost2;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = sum - 0.01;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = sum - 0.01;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(proj1, cost1);
@@ -518,7 +518,7 @@ public class InitialCreditsServiceTest {
     final double cost1 = 123.45;
     final double cost2 = 234.56;
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = Math.min(cost1, cost2) - 0.01;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = Math.min(cost1, cost2) - 0.01;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(proj1, cost1);
@@ -553,7 +553,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void checkInitialCreditsUsage_dbUpdate() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
 
@@ -598,7 +598,7 @@ public class InitialCreditsServiceTest {
   // Regression test coverage for RW-8328.
   @Test
   public void checkInitialCreditsUsage_singleAlertForExhaustedAndByoBilling() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
 
@@ -628,19 +628,19 @@ public class InitialCreditsServiceTest {
     commitTransaction();
 
     final double initialFreeCreditsDollarLimit = 1.0;
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = initialFreeCreditsDollarLimit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = initialFreeCreditsDollarLimit;
     assertWithinBillingTolerance(
         initialCreditsService.getUserInitialCreditsLimit(user), initialFreeCreditsDollarLimit);
 
     final double fractionalFreeCreditsDollarLimit = 123.456;
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = fractionalFreeCreditsDollarLimit;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = fractionalFreeCreditsDollarLimit;
     assertWithinBillingTolerance(
         initialCreditsService.getUserInitialCreditsLimit(user), fractionalFreeCreditsDollarLimit);
   }
 
   @Test
   public void getUserInitialCreditsLimit_override() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 123.456;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 123.456;
 
     DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
 
@@ -662,7 +662,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void getUserCachedFreeTierUsage() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
@@ -714,14 +714,14 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void userHasRemainingFreeTierCredits_newUser() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     final DbUser user1 = createUser(SINGLE_WORKSPACE_TEST_USER);
     assertThat(initialCreditsService.userHasRemainingInitialCredits(user1)).isTrue();
   }
 
   @Test
   public void userHasRemainingInitialCredits() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user1 = createUser(SINGLE_WORKSPACE_TEST_USER);
     createWorkspace(user1, SINGLE_WORKSPACE_TEST_PROJECT);
@@ -740,13 +740,13 @@ public class InitialCreditsServiceTest {
     assertThat(initialCreditsService.userHasRemainingInitialCredits(user1)).isFalse();
 
     // 100.01 < 200.0
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 200.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 200.0;
     assertThat(initialCreditsService.userHasRemainingInitialCredits(user1)).isTrue();
   }
 
   @Test
   public void test_disableOnlyFreeTierWorkspaces() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     Map<String, Double> allBQCosts = ImmutableMap.of(SINGLE_WORKSPACE_TEST_PROJECT, 100.01);
 
@@ -784,7 +784,7 @@ public class InitialCreditsServiceTest {
 
     commitTransaction();
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = ImmutableMap.of(SINGLE_WORKSPACE_TEST_PROJECT, 50.0);
 
     TestTransaction.start();
@@ -812,7 +812,7 @@ public class InitialCreditsServiceTest {
 
     commitTransaction();
 
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     Map<String, Double> allBQCosts = new HashMap<>();
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, 50.0);
 
@@ -1135,7 +1135,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void test_checkInitialCreditsExtensionEligibility_noRemainingCredits() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     user.setUserInitialCreditsExpiration(
@@ -1152,7 +1152,7 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void test_checkInitialCreditsExtensionEligibility_hasRemainingCredits() {
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
 
     final DbUser user = createUser(SINGLE_WORKSPACE_TEST_USER);
     user.setUserInitialCreditsExpiration(

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -145,7 +145,7 @@ public class InitialCreditsServiceTest {
   public void setUp() throws MessagingException {
     workbenchConfig = WorkbenchConfig.createEmptyConfig();
     workbenchConfig.billing.initialCreditsCostAlertThresholds = Doubles.asList(.5, .75);
-    workbenchConfig.billing.accountId = "free-tier";
+    workbenchConfig.billing.accountId = "initial-credits";
     workbenchConfig.billing.defaultInitialCreditsDollarLimit = 1000.0;
     workbenchConfig.billing.initialCreditsValidityPeriodDays = validityPeriodDays;
     workbenchConfig.billing.initialCreditsExtensionPeriodDays = extensionPeriodDays;

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -216,7 +216,7 @@ public class WorkspaceMapperTest {
             .setGoogleProject(GOOGLE_PROJECT);
 
     workbenchConfig = createEmptyConfig();
-    workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.billing.defaultInitialCreditsDollarLimit = 100.0;
     workbenchConfig.featureFlags.enableInitialCreditsExpiration = true;
   }
 

--- a/api/tools/src/cron/checkInitialCreditUsage.sh
+++ b/api/tools/src/cron/checkInitialCreditUsage.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-curl -X GET 'http://localhost:8081/v1/cron/checkForInitialCreditUsage' \
-  --header "X-AppEngine-Cron: true"

--- a/api/tools/src/cron/checkInitialCreditUsage.sh
+++ b/api/tools/src/cron/checkInitialCreditUsage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -X GET 'http://localhost:8081/v1/cron/checkForInitialCreditUsage' \
+  --header "X-AppEngine-Cron: true"

--- a/ui/src/app/components/apps-panel.spec.tsx
+++ b/ui/src/app/components/apps-panel.spec.tsx
@@ -149,7 +149,7 @@ describe(AppsPanel.name, () => {
   const leoAppsStub = new LeoAppsApiStub();
   let user: UserEvent;
   beforeEach(() => {
-    const freeTierBillingAccountId = 'FreeTierBillingAccountId';
+    const initialCreditsBillingAccountId = 'initialCreditsBillingAccountId';
     registerApiClient(AppsApi, appsStub);
     registerApiClient(NotebooksApi, new NotebooksApiStub());
     registerApiClient(RuntimeApi, runtimeStub);
@@ -159,7 +159,7 @@ describe(AppsPanel.name, () => {
     workspaceStub = {
       ...workspaceDataStub,
       billingStatus: BillingStatus.ACTIVE,
-      billingAccountName: `billingAccounts/${freeTierBillingAccountId}`,
+      billingAccountName: `billingAccounts/${initialCreditsBillingAccountId}`,
     };
     runtimeStore.set({
       workspaceNamespace: workspaceStub.namespace,
@@ -167,7 +167,7 @@ describe(AppsPanel.name, () => {
       runtimeLoaded: true,
     });
     serverConfigStore.set({
-      config: { ...defaultServerConfig, freeTierBillingAccountId },
+      config: { ...defaultServerConfig, initialCreditsBillingAccountId },
     });
 
     user = userEvent.setup();

--- a/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
+++ b/ui/src/app/components/common-env-conf-panels/environment-informed-action-panel.tsx
@@ -26,22 +26,22 @@ import { styles } from './styles';
 interface CostsDrawnFromProps {
   usingInitialCredits: boolean;
   userIsCreator: boolean;
-  creatorFreeCreditsRemaining: number;
+  creatorInitialCreditsRemaining: number;
   billingAccountName: string;
   style?: CSSProperties;
 }
 const CostsDrawnFrom = ({
   usingInitialCredits,
   userIsCreator,
-  creatorFreeCreditsRemaining,
+  creatorInitialCreditsRemaining,
   billingAccountName,
   style,
 }: CostsDrawnFromProps) => {
   const remainingCredits =
-    creatorFreeCreditsRemaining === null ? (
+    creatorInitialCreditsRemaining === null ? (
       <Spinner size={10} />
     ) : (
-      formatUsd(creatorFreeCreditsRemaining)
+      formatUsd(creatorInitialCreditsRemaining)
     );
 
   return cond(
@@ -75,7 +75,7 @@ const CostsDrawnFrom = ({
 };
 
 interface PanelProps {
-  creatorFreeCreditsRemaining: number;
+  creatorInitialCreditsRemaining: number;
   profile: Profile;
   workspace: Workspace;
   analysisConfig: AnalysisConfig;
@@ -86,7 +86,7 @@ interface PanelProps {
   environmentChanged?: boolean;
 }
 export const EnvironmentInformedActionPanel = ({
-  creatorFreeCreditsRemaining,
+  creatorInitialCreditsRemaining,
   profile,
   workspace,
   analysisConfig,
@@ -128,7 +128,7 @@ export const EnvironmentInformedActionPanel = ({
         />
         {showCostsDrawnFromWithCosts && (
           <CostsDrawnFrom
-            {...{ creatorFreeCreditsRemaining }}
+            {...{ creatorInitialCreditsRemaining }}
             usingInitialCredits={isUsingInitialCredits(workspace)}
             userIsCreator={profile.username === workspace.creatorUser.userName}
             billingAccountName={workspace.billingAccountName}
@@ -141,7 +141,7 @@ export const EnvironmentInformedActionPanel = ({
       </FlexRow>
       {!showCostsDrawnFromWithCosts && (
         <CostsDrawnFrom
-          {...{ creatorFreeCreditsRemaining }}
+          {...{ creatorInitialCreditsRemaining }}
           usingInitialCredits={isUsingInitialCredits(workspace)}
           userIsCreator={profile.username === workspace.creatorUser.userName}
           billingAccountName={workspace.billingAccountName}

--- a/ui/src/app/components/configuration-panel.tsx
+++ b/ui/src/app/components/configuration-panel.tsx
@@ -41,7 +41,7 @@ export const ConfigurationPanel = fp.flow(
     profileState: ProfileStore;
   }) => {
     const { namespace, terraName } = workspace;
-    const [creatorFreeCreditsRemaining, setCreatorFreeCreditsRemaining] =
+    const [creatorInitialCreditsRemaining, setCreatorInitialCreditsRemaining] =
       useState(null);
 
     useEffect(() => {
@@ -53,7 +53,7 @@ export const ConfigurationPanel = fp.flow(
             terraName,
             { signal: aborter.signal }
           );
-        setCreatorFreeCreditsRemaining(freeCreditsRemaining);
+        setCreatorInitialCreditsRemaining(freeCreditsRemaining);
       };
 
       fetchFreeCredits();
@@ -71,7 +71,7 @@ export const ConfigurationPanel = fp.flow(
             () => (
               <div>
                 <RuntimeConfigurationPanel
-                  {...{ onClose, profileState, creatorFreeCreditsRemaining }}
+                  {...{ onClose, profileState, creatorInitialCreditsRemaining }}
                   initialPanelContent={runtimeConfPanelInitialState}
                 />
               </div>
@@ -81,7 +81,7 @@ export const ConfigurationPanel = fp.flow(
             <GKEAppConfigurationPanel
               {...{
                 onClose,
-                creatorFreeCreditsRemaining,
+                creatorInitialCreditsRemaining,
                 workspace,
                 profileState,
               }}

--- a/ui/src/app/components/gke-app-configuration-panel.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panel.spec.tsx
@@ -96,7 +96,7 @@ describe(GKEAppConfigurationPanel.name, () => {
     workspaceNamespace: 'aou-rw-1234',
     onClose: jest.fn(),
     initialPanelContent: null,
-    creatorFreeCreditsRemaining: 300,
+    creatorInitialCreditsRemaining: 300,
 
     // Use RSTUDIO_DEFAULT_PROPS for the rest of the props since they shouldn't affect this test
     workspace: rstudioDefaultProps.workspace,

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -58,7 +58,7 @@ describe(CreateCromwell.name, () => {
       config: {
         ...defaultServerConfig,
         freeTierBillingAccountId: freeTierBillingAccountId,
-        defaultFreeCreditsDollarLimit: 100.0,
+        defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },
     });

--- a/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-cromwell.spec.tsx
@@ -22,15 +22,15 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 // tests for behavior specific to Cromwell.  For behavior common to all GKE Apps, see create-gke-app.spec
 describe(CreateCromwell.name, () => {
   const onClose = jest.fn();
-  const freeTierBillingAccountId = 'freetier';
+  const initialCreditsBillingAccountId = 'initial-credits';
 
   const defaultProps: CommonCreateGkeAppProps = {
     onClose,
-    creatorFreeCreditsRemaining: null,
+    creatorInitialCreditsRemaining: null,
     workspace: {
       ...workspaceStubs[0],
       accessLevel: WorkspaceAccessLevel.WRITER,
-      billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     },
     profileState: {
@@ -57,7 +57,7 @@ describe(CreateCromwell.name, () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        freeTierBillingAccountId: freeTierBillingAccountId,
+        initialCreditsBillingAccountId,
         defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -81,7 +81,7 @@ describe(CreateGkeAppButton.name, () => {
       .mockImplementation((): Promise<any> => Promise.resolve());
 
   beforeEach(() => {
-    const freeTierBillingAccountId = 'FreeTierBillingAccountId';
+    const initialCreditsBillingAccountId = 'initialCreditsBillingAccountId';
     const workspaceStub = buildWorkspaceStub();
     const oneMinute = 60 * 1000;
     defaultProps = {
@@ -89,7 +89,7 @@ describe(CreateGkeAppButton.name, () => {
       existingApp: null,
       workspace: {
         ...workspaceStub,
-        billingAccountName: `billingAccounts/${freeTierBillingAccountId}`,
+        billingAccountName: `billingAccounts/${initialCreditsBillingAccountId}`,
         namespace: workspaceNamespace,
         initialCredits: {
           ...workspaceStub.initialCredits,
@@ -101,7 +101,7 @@ describe(CreateGkeAppButton.name, () => {
     };
 
     serverConfigStore.set({
-      config: { ...defaultServerConfig, freeTierBillingAccountId },
+      config: { ...defaultServerConfig, initialCreditsBillingAccountId },
     });
     registerApiClient(AppsApi, new AppsApiStub());
     registerApiClient(DisksApi, new DisksApiStub());

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -128,7 +128,7 @@ describe(CreateGkeApp.name, () => {
       config: {
         ...defaultServerConfig,
         freeTierBillingAccountId: freeTierBillingAccountId,
-        defaultFreeCreditsDollarLimit: 100.0,
+        defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },
     });

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.spec.tsx
@@ -55,16 +55,16 @@ import {
 } from './create-gke-app';
 
 const onClose = jest.fn();
-const freeTierBillingAccountId = 'freetier';
+const initialCreditsBillingAccountId = 'initial-credits';
 const workspace = workspaceStubs[0];
 const oneHour = 1000 * 60 * 60;
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
-  creatorFreeCreditsRemaining: null,
+  creatorInitialCreditsRemaining: null,
   workspace: {
     ...workspace,
     accessLevel: WorkspaceAccessLevel.WRITER,
-    billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+    billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
     cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
     initialCredits: {
       ...workspace.initialCredits,
@@ -127,7 +127,7 @@ describe(CreateGkeApp.name, () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        freeTierBillingAccountId: freeTierBillingAccountId,
+        initialCreditsBillingAccountId,
         defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app.tsx
@@ -122,7 +122,7 @@ export interface CreateGkeAppProps {
   userApps: UserAppEnvironment[];
   appType: AppType;
   onClose: () => void;
-  creatorFreeCreditsRemaining: number | null;
+  creatorInitialCreditsRemaining: number | null;
   workspace: WorkspaceData;
   profileState: ProfileStore;
   disk: Disk | undefined;
@@ -148,7 +148,7 @@ export const CreateGkeApp = ({
   userApps,
   appType,
   onClose,
-  creatorFreeCreditsRemaining,
+  creatorInitialCreditsRemaining,
   workspace,
   profileState,
   disk,
@@ -305,7 +305,7 @@ export const CreateGkeApp = ({
       <div style={{ ...styles.controlSection }}>
         <EnvironmentInformedActionPanel
           {...{
-            creatorFreeCreditsRemaining,
+            creatorInitialCreditsRemaining,
             profile,
             workspace,
           }}

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -57,7 +57,7 @@ describe(CreateRStudio.name, () => {
       config: {
         ...defaultServerConfig,
         freeTierBillingAccountId: freeTierBillingAccountId,
-        defaultFreeCreditsDollarLimit: 100.0,
+        defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },
     });

--- a/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-rstudio.spec.tsx
@@ -20,14 +20,14 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateRStudio } from './create-rstudio';
 
 const onClose = jest.fn();
-const freeTierBillingAccountId = 'freetier';
+const initialCreditsBillingAccountId = 'initial-credits';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
-  creatorFreeCreditsRemaining: null,
+  creatorInitialCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],
     accessLevel: WorkspaceAccessLevel.WRITER,
-    billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+    billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
     cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
   },
   profileState: {
@@ -56,7 +56,7 @@ describe(CreateRStudio.name, () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        freeTierBillingAccountId: freeTierBillingAccountId,
+        initialCreditsBillingAccountId,
         defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },

--- a/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
@@ -57,7 +57,7 @@ describe(CreateSAS.name, () => {
       config: {
         ...defaultServerConfig,
         freeTierBillingAccountId: freeTierBillingAccountId,
-        defaultFreeCreditsDollarLimit: 100.0,
+        defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },
     });

--- a/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-sas.spec.tsx
@@ -20,14 +20,14 @@ import { CommonCreateGkeAppProps } from './create-gke-app';
 import { CreateSAS } from './create-sas';
 
 const onClose = jest.fn();
-const freeTierBillingAccountId = 'freetier';
+const initialCreditsBillingAccountId = 'initial-credits';
 export const defaultProps: CommonCreateGkeAppProps = {
   onClose,
-  creatorFreeCreditsRemaining: null,
+  creatorInitialCreditsRemaining: null,
   workspace: {
     ...workspaceStubs[0],
     accessLevel: WorkspaceAccessLevel.WRITER,
-    billingAccountName: 'billingAccounts/' + freeTierBillingAccountId,
+    billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
     cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
   },
   profileState: {
@@ -56,7 +56,7 @@ describe(CreateSAS.name, () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        freeTierBillingAccountId: freeTierBillingAccountId,
+        initialCreditsBillingAccountId,
         defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -546,7 +546,7 @@ describe(getErrorsAndWarnings.name, () => {
   it('should show a cost warning when the user has enough remaining initial credits', () => {
     const usingInitialCredits = true;
     const creatorFreeCreditsRemaining =
-      serverConfigStore.get().config.defaultFreeCreditsDollarLimit + 1;
+      serverConfigStore.get().config.defaultInitialCreditsDollarLimit + 1;
 
     // want a running cost over $25/hr
 
@@ -569,7 +569,7 @@ describe(getErrorsAndWarnings.name, () => {
   it('should show a cost error when the user does not have enough remaining initial credits', () => {
     const usingInitialCredits = true;
     const creatorFreeCreditsRemaining =
-      serverConfigStore.get().config.defaultFreeCreditsDollarLimit - 1;
+      serverConfigStore.get().config.defaultInitialCreditsDollarLimit - 1;
 
     // want a running cost over $25/hr
 

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -545,7 +545,7 @@ describe(getErrorsAndWarnings.name, () => {
 
   it('should show a cost warning when the user has enough remaining initial credits', () => {
     const usingInitialCredits = true;
-    const creatorFreeCreditsRemaining =
+    const creatorInitialCreditsRemaining =
       serverConfigStore.get().config.defaultInitialCreditsDollarLimit + 1;
 
     // want a running cost over $25/hr
@@ -558,7 +558,7 @@ describe(getErrorsAndWarnings.name, () => {
       'Your runtime is expensive. Are you sure you wish to proceed?';
 
     const { errorMessageContent, warningMessageContent } = getErrorsAndWarnings(
-      { usingInitialCredits, analysisConfig, creatorFreeCreditsRemaining }
+      { usingInitialCredits, analysisConfig, creatorInitialCreditsRemaining }
     );
 
     expect(errorMessageContent).toEqual([]);
@@ -568,7 +568,7 @@ describe(getErrorsAndWarnings.name, () => {
 
   it('should show a cost error when the user does not have enough remaining initial credits', () => {
     const usingInitialCredits = true;
-    const creatorFreeCreditsRemaining =
+    const creatorInitialCreditsRemaining =
       serverConfigStore.get().config.defaultInitialCreditsDollarLimit - 1;
 
     // want a running cost over $25/hr
@@ -581,7 +581,7 @@ describe(getErrorsAndWarnings.name, () => {
       'Your runtime is too expensive. To proceed using free credits, reduce your running costs below'; // $cost
 
     const { errorMessageContent, warningMessageContent } = getErrorsAndWarnings(
-      { usingInitialCredits, analysisConfig, creatorFreeCreditsRemaining }
+      { usingInitialCredits, analysisConfig, creatorInitialCreditsRemaining }
     );
 
     expect(warningMessageContent).toEqual([]);
@@ -884,7 +884,7 @@ describe('RuntimeConfigurationPanel', () => {
       },
       accessLevel: WorkspaceAccessLevel.WRITER,
       billingAccountName:
-        'billingAccounts/' + defaultServerConfig.freeTierBillingAccountId,
+        'billingAccounts/' + defaultServerConfig.initialCreditsBillingAccountId,
       cdrVersionId: CdrVersionsStubVariables.DEFAULT_WORKSPACE_CDR_VERSION_ID,
       googleProject: runtimeApiStub.runtime.googleProject,
     });

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -183,7 +183,7 @@ export const getErrorsAndWarnings = ({
     // the default amount of free credits because (1) this can result in overspend and (2) we have
     // easy access to remaining credits, and not the creator's quota.
     creatorFreeCreditsRemaining >
-      serverConfigStore.get().config.defaultFreeCreditsDollarLimit;
+      serverConfigStore.get().config.defaultInitialCreditsDollarLimit;
 
   const runningCostValidatorWithMessage = () => {
     const maxRunningCost = usingInitialCredits ? 25 : 150;

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -163,7 +163,7 @@ const diskSizeValidatorWithMessage = (
 
 interface ErrorsWarningsProps {
   usingInitialCredits: boolean;
-  creatorFreeCreditsRemaining?: number;
+  creatorInitialCreditsRemaining?: number;
   analysisConfig: AnalysisConfig;
 }
 interface ErrorsWarningsResult {
@@ -172,7 +172,7 @@ interface ErrorsWarningsResult {
 }
 export const getErrorsAndWarnings = ({
   usingInitialCredits,
-  creatorFreeCreditsRemaining = 0,
+  creatorInitialCreditsRemaining = 0,
   analysisConfig,
 }: ErrorsWarningsProps): ErrorsWarningsResult => {
   const costErrorsAsWarnings =
@@ -182,7 +182,7 @@ export const getErrorsAndWarnings = ({
     // use. Allow them to provision a larger runtime (still warn them). Block them if they get below
     // the default amount of free credits because (1) this can result in overspend and (2) we have
     // easy access to remaining credits, and not the creator's quota.
-    creatorFreeCreditsRemaining >
+    creatorInitialCreditsRemaining >
       serverConfigStore.get().config.defaultInitialCreditsDollarLimit;
 
   const runningCostValidatorWithMessage = () => {
@@ -256,7 +256,7 @@ export const getErrorsAndWarnings = ({
 export interface RuntimeConfigurationPanelProps {
   onClose?: () => void;
   initialPanelContent?: PanelContent;
-  creatorFreeCreditsRemaining?: number;
+  creatorInitialCreditsRemaining?: number;
   profileState: ProfileStore;
 }
 export const RuntimeConfigurationPanel = fp.flow(
@@ -270,7 +270,7 @@ export const RuntimeConfigurationPanel = fp.flow(
     profileState: { profile },
     onClose = () => {},
     initialPanelContent,
-    creatorFreeCreditsRemaining,
+    creatorInitialCreditsRemaining,
   }: RuntimeConfigurationPanelProps &
     WithCdrVersions &
     WithCurrentWorkspace) => {
@@ -331,7 +331,7 @@ export const RuntimeConfigurationPanel = fp.flow(
     const { errorMessageContent, warningMessageContent } = getErrorsAndWarnings(
       {
         usingInitialCredits: isUsingInitialCredits(workspace),
-        creatorFreeCreditsRemaining,
+        creatorInitialCreditsRemaining,
         analysisConfig,
       }
     );
@@ -412,7 +412,7 @@ export const RuntimeConfigurationPanel = fp.flow(
               <CreatePanel
                 {...{
                   analysisConfig,
-                  creatorFreeCreditsRemaining,
+                  creatorInitialCreditsRemaining,
                   onClose,
                   profile,
                   requestAnalysisConfig,
@@ -503,7 +503,7 @@ export const RuntimeConfigurationPanel = fp.flow(
                 {...{
                   analysisConfig,
                   attachedPdExists,
-                  creatorFreeCreditsRemaining,
+                  creatorInitialCreditsRemaining,
                   currentRuntime,
                   environmentChanged,
                   errorMessageContent,

--- a/ui/src/app/components/runtime-configuration-panel/create-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/create-panel.spec.tsx
@@ -36,7 +36,7 @@ const defaultProps: CreatePanelProps = {
   profile: ProfileStubVariables.PROFILE_STUB,
   workspace: buildWorkspaceStub(),
   analysisConfig: defaultAnalysisConfig,
-  creatorFreeCreditsRemaining: 0,
+  creatorInitialCreditsRemaining: 0,
   runtimeStatus: RuntimeStatus.RUNNING,
   runtimeCanBeCreated: true,
   setPanelContent,

--- a/ui/src/app/components/runtime-configuration-panel/create-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/create-panel.tsx
@@ -17,7 +17,7 @@ import { PanelContent } from './utils';
 
 export interface CreatePanelProps {
   analysisConfig: AnalysisConfig;
-  creatorFreeCreditsRemaining: number;
+  creatorInitialCreditsRemaining: number;
   onClose: () => void;
   profile: Profile;
   requestAnalysisConfig: (ac: AnalysisConfig) => void;
@@ -29,7 +29,7 @@ export interface CreatePanelProps {
 }
 export const CreatePanel = ({
   analysisConfig,
-  creatorFreeCreditsRemaining,
+  creatorInitialCreditsRemaining,
   onClose,
   profile,
   requestAnalysisConfig,
@@ -49,7 +49,7 @@ export const CreatePanel = ({
       <div data-test-id='runtime-create-panel' style={styles.controlSection}>
         <EnvironmentInformedActionPanel
           {...{
-            creatorFreeCreditsRemaining,
+            creatorInitialCreditsRemaining,
             profile,
             workspace,
             analysisConfig,

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.spec.tsx
@@ -60,7 +60,7 @@ const defaultProps: CustomizePanelProps = {
   allowDataproc: true,
   analysisConfig: defaultAnalysisConfig,
   attachedPdExists: true,
-  creatorFreeCreditsRemaining: 0,
+  creatorInitialCreditsRemaining: 0,
   currentRuntime: defaultGceRuntimeWithPd(),
   environmentChanged: false,
   errorMessageContent: [],

--- a/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel/customize-panel.tsx
@@ -52,7 +52,7 @@ export interface CustomizePanelProps {
   allowDataproc: boolean;
   analysisConfig: AnalysisConfig;
   attachedPdExists: boolean;
-  creatorFreeCreditsRemaining: number;
+  creatorInitialCreditsRemaining: number;
   currentRuntime: Runtime;
   environmentChanged: boolean;
   errorMessageContent: JSX.Element[];
@@ -78,7 +78,7 @@ export const CustomizePanel = ({
   allowDataproc,
   analysisConfig,
   attachedPdExists,
-  creatorFreeCreditsRemaining,
+  creatorInitialCreditsRemaining,
   currentRuntime,
   environmentChanged,
   errorMessageContent,
@@ -133,7 +133,7 @@ export const CustomizePanel = ({
       <div style={styles.controlSection}>
         <EnvironmentInformedActionPanel
           {...{
-            creatorFreeCreditsRemaining,
+            creatorInitialCreditsRemaining,
             profile,
             analysisConfig,
             environmentChanged,

--- a/ui/src/app/pages/workspace/workspace-about.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-about.spec.tsx
@@ -304,9 +304,10 @@ describe('WorkspaceAbout', () => {
   });
 
   it('should see initial credit expiration date', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: new Date('1998-03-17T15:30:00').getTime(),
@@ -315,7 +316,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
       },
     });
     component();
@@ -326,9 +327,10 @@ describe('WorkspaceAbout', () => {
   });
 
   it('should not see initial credit expiration date when enableInitialCreditsExpiration is false', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: new Date('1998-03-17T15:30:00').getTime(),
@@ -337,7 +339,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
         enableInitialCreditsExpiration: false,
       },
     });
@@ -348,6 +350,7 @@ describe('WorkspaceAbout', () => {
   });
 
   it('eligble creator should be able to request extension', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
       creatorUser: {
@@ -355,7 +358,7 @@ describe('WorkspaceAbout', () => {
         givenName: profile.givenName,
         familyName: profile.familyName,
       },
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: nowPlusDays(-1),
@@ -364,7 +367,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
       },
     });
     profileStore.set({
@@ -393,6 +396,7 @@ describe('WorkspaceAbout', () => {
   });
 
   it('ineligble creator should not be able to request extension', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
       creatorUser: {
@@ -400,7 +404,7 @@ describe('WorkspaceAbout', () => {
         givenName: profile.givenName,
         familyName: profile.familyName,
       },
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: nowPlusDays(-1),
@@ -409,7 +413,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
       },
     });
     profileStore.set({
@@ -434,6 +438,7 @@ describe('WorkspaceAbout', () => {
   });
 
   it('non-creator should not be able to request extension', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
       creatorUser: {
@@ -441,7 +446,7 @@ describe('WorkspaceAbout', () => {
         givenName: 'Bob',
         familyName: 'Pop',
       },
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: nowPlusDays(-1),
@@ -450,7 +455,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
       },
     });
     profileStore.set({
@@ -479,6 +484,7 @@ describe('WorkspaceAbout', () => {
   });
 
   it('should not see initial credit expiration section when bypassed', async () => {
+    const initialCreditsBillingAccountId = 'initial-credits';
     currentWorkspaceStore.next({
       ...currentWorkspaceStore.getValue(),
       creatorUser: {
@@ -486,7 +492,7 @@ describe('WorkspaceAbout', () => {
         givenName: 'Bob',
         familyName: 'Pop',
       },
-      billingAccountName: 'billingAccounts/free',
+      billingAccountName: 'billingAccounts/' + initialCreditsBillingAccountId,
       initialCredits: {
         exhausted: false,
         expirationEpochMillis: nowPlusDays(-1),
@@ -496,7 +502,7 @@ describe('WorkspaceAbout', () => {
     serverConfigStore.set({
       config: {
         ...serverConfigStore.get().config,
-        freeTierBillingAccountId: 'free',
+        initialCreditsBillingAccountId,
       },
     });
     component();

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -162,7 +162,7 @@ describe(WorkspaceEdit.name, () => {
       config: {
         ...defaultServerConfig,
         freeTierBillingAccountId: 'freetier',
-        defaultFreeCreditsDollarLimit: 100.0,
+        defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },
     });

--- a/ui/src/app/pages/workspace/workspace-edit.spec.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.spec.tsx
@@ -161,7 +161,7 @@ describe(WorkspaceEdit.name, () => {
     serverConfigStore.set({
       config: {
         ...defaultServerConfig,
-        freeTierBillingAccountId: 'freetier',
+        initialCreditsBillingAccountId: 'initial-credits',
         defaultInitialCreditsDollarLimit: 100.0,
         gsuiteDomain: '',
       },

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -437,7 +437,7 @@ export const WorkspaceEdit = fp.flow(
       const freeTierBillingAccount: BillingAccount = {
         name:
           'billingAccounts/' +
-          serverConfigStore.get().config.freeTierBillingAccountId,
+          serverConfigStore.get().config.initialCreditsBillingAccountId,
         freeTier: true,
         open: true,
         displayName: this.formatFreeTierBillingAccountName(),

--- a/ui/src/app/utils/workspace-utils.tsx
+++ b/ui/src/app/utils/workspace-utils.tsx
@@ -11,7 +11,8 @@ export const EARLIEST_PUBLIC_CDR_VERSION_NUMBER_INCLUDING_AIAN = 8;
 export const isUsingInitialCredits = (workspace: Workspace): boolean => {
   return (
     workspace.billingAccountName ===
-    'billingAccounts/' + serverConfigStore.get().config.freeTierBillingAccountId
+    'billingAccounts/' +
+      serverConfigStore.get().config.initialCreditsBillingAccountId
   );
 };
 

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -69,7 +69,7 @@ const defaultServerConfig: ConfigResponse = {
   enableRasLoginGovLinking: true,
   accessRenewalLookback: 330,
   complianceTrainingRenewalLookback: 30,
-  freeTierBillingAccountId: 'freetier',
+  initialCreditsBillingAccountId: 'initial-credits',
   accessModules: defaultAccessModuleConfig,
   currentDuccVersions: [3, 4],
   tanagraBaseUrl: 'https://test.fake-research-aou.org',

--- a/ui/src/testing/default-server-config.ts
+++ b/ui/src/testing/default-server-config.ts
@@ -62,7 +62,7 @@ const defaultServerConfig: ConfigResponse = {
   publicApiKeyForErrorReports: 'notasecret',
   enableComplianceTraining: true,
   unsafeAllowSelfBypass: false,
-  defaultFreeCreditsDollarLimit: 300,
+  defaultInitialCreditsDollarLimit: 300,
   rasHost: 'https://stsstg.nih.gov/',
   rasClientId: '903cfaeb-57d9-4ef6-5659-04377794ed65',
   enableRasIdMeLinking: false,


### PR DESCRIPTION
Cleaned up language of credit exhaustion cron as much as practical.

This largely involved changing freetrier to initialcredit and changing expiry to exhaustion.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
