### PR TITLE
[no ticket][risk=no] Clear workspace when navigating away from workspace.

### DIFF
--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -45,6 +45,7 @@ import {
 } from 'app/utils/access-utils';
 import { AuthorityGuardedAction } from 'app/utils/authorities';
 import { DEMOGRAPHIC_SURVEY_V2_PATH } from 'app/utils/constants';
+import { currentWorkspaceStore } from 'app/utils/navigation';
 
 import {
   authorityGuard,
@@ -138,8 +139,18 @@ const WorkspaceSearchAdminPage = fp.flow(
 )(AdminWorkspaceSearch);
 
 export const SignedInRoutes = () => {
-  const { search } = useLocation();
-  const query = new URLSearchParams(search);
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const [pathName, setPathName] = React.useState(location.pathname);
+  React.useEffect(() => {
+    if (
+      pathName.startsWith('/workspaces/') &&
+      !location.pathname.startsWith('/workspaces/')
+    ) {
+      currentWorkspaceStore.next(null);
+    }
+    setPathName(location.pathname);
+  }, [location]);
 
   return (
     <Switch>


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

When navigating away from workspaces, the invalid billing banners are still visible. This happens because the currentWorkspaceStore is not cleared when navigating away from workspace pages. 

**Before:**

https://github.com/user-attachments/assets/60dedddc-2114-4266-b648-1cda034a9fda

**After:**

https://github.com/user-attachments/assets/4545c04d-743a-43d9-b4dc-b6e1276e75c9



---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
