### PR TITLE
[no ticket][risk=no] Make eligibility based on workspace owner's initial credit eligibility.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.initialcredits;
 
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.pmiops.workbench.db.dao.WorkspaceDao.WorkspaceCostView;
 
 import jakarta.annotation.Nullable;
@@ -10,7 +9,6 @@ import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
@@ -21,7 +19,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.mapstruct.Named;
 import org.pmiops.workbench.actionaudit.auditors.UserServiceAuditor;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
@@ -391,28 +388,6 @@ public class InitialCreditsService {
                     workbenchConfigProvider.get().billing.initialCreditsExtensionPeriodDays)));
     userInitialCreditsExpiration.setExtensionTime(clockNow());
     return userDao.save(user);
-  }
-
-  @Named("checkInitialCreditsExtensionEligibility")
-  public boolean checkInitialCreditsExtensionEligibility(DbUser dbUser) {
-    DbUserInitialCreditsExpiration initialCreditsExpiration =
-        dbUser.getUserInitialCreditsExpiration();
-    Instant now = Instant.now();
-    WorkbenchConfig.BillingConfig billingConfig = workbenchConfigProvider.get().billing;
-
-    return initialCreditsExpiration != null
-        && initialCreditsExpiration.getExtensionTime() == null
-        && initialCreditsExpiration.getCreditStartTime() != null
-        && now.isAfter(
-            initialCreditsExpiration
-                .getExpirationTime()
-                .toInstant()
-                .minus(billingConfig.initialCreditsExpirationWarningDays, DAYS))
-        && now.isBefore(
-            initialCreditsExpiration
-                .getCreditStartTime()
-                .toInstant()
-                .plus(billingConfig.initialCreditsExtensionPeriodDays, DAYS));
   }
 
   private void checkExpiration(DbUser user) {

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.utils.mappers;
 
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.pmiops.workbench.utils.BillingUtils.isInitialCredits;
 
 import com.google.common.base.Strings;
@@ -9,7 +8,6 @@ import jakarta.inject.Provider;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Clock;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
@@ -19,7 +17,6 @@ import org.pmiops.workbench.api.Etags;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.BillingStatus;
@@ -154,24 +151,8 @@ public class CommonMappers {
   }
 
   @Named("checkInitialCreditsExtensionEligibility")
-  public boolean checkInitialCreditsExtensionEligibility(DbUser dbUser) {
-    DbUserInitialCreditsExpiration initialCreditsExpiration =
-        dbUser.getUserInitialCreditsExpiration();
-    Instant now = Instant.now();
-    WorkbenchConfig.BillingConfig billingConfig = workbenchConfigProvider.get().billing;
-
-    return initialCreditsExpiration != null
-        && initialCreditsExpiration.getExtensionTime() == null
-        && initialCreditsExpiration.getCreditStartTime() != null
-        && now.isAfter(
-            initialCreditsExpiration
-                .getExpirationTime()
-                .toInstant()
-                .minus(billingConfig.initialCreditsExpirationWarningDays, DAYS))
-        && now.isBefore(
-            initialCreditsExpiration
-                .getCreditStartTime()
-                .toInstant()
-                .plus(billingConfig.initialCreditsExtensionPeriodDays, DAYS));
+  public boolean checkInitialCreditsExtensionEligibility(
+      DbUser dbUser, @Context InitialCreditsService initialCreditsService) {
+    return initialCreditsService.checkInitialCreditsExtensionEligibility(dbUser);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -53,6 +53,10 @@ public interface WorkspaceMapper {
   // Should change to contactEmail or institutionalEmail
   @Mapping(target = "creatorUser.email", ignore = true)
   @Mapping(
+      target = "initialCredits.eligibleForExtension",
+      source = "dbWorkspace.creator",
+      qualifiedByName = "checkInitialCreditsExtensionEligibility")
+  @Mapping(
       target = "initialCredits.expirationEpochMillis",
       source = "dbWorkspace.creator",
       qualifiedByName = "getInitialCreditsExpiration")
@@ -135,6 +139,7 @@ public interface WorkspaceMapper {
   @Mapping(
       target = "creatorUser.email",
       ignore = true) // need to work with security before exposing
+  @Mapping(target = "initialCredits.eligibleForExtension", ignore = true)
   @Mapping(target = "initialCredits.expired", source = "dbWorkspace.initialCreditsExpired")
   @Mapping(
       target = "initialCredits.expirationEpochMillis",

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -13141,6 +13141,9 @@ components:
     InitialCreditResponse:
       type: object
       properties:
+        eligibleForExtension:
+          type: boolean
+          description: Whether the workspace's owner is eligible for an extension
         exhausted:
           type: boolean
         expired:

--- a/ui/src/app/pages/workspace/invalid-billing-banner-maybe.spec.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner-maybe.spec.tsx
@@ -72,7 +72,8 @@ describe('InvalidBillingBanner', () => {
     exhausted: boolean,
     expired: boolean,
     expiringSoon: boolean,
-    ownedByMe: boolean
+    ownedByMe: boolean,
+    eligibleForExtension: boolean
   ) => {
     // Set expiration date to be in the past if expired, in the future if not.
     // If expiring soon, set it to be within the warning threshold, and just outside otherwise.
@@ -86,6 +87,7 @@ describe('InvalidBillingBanner', () => {
         exhausted,
         expired,
         expirationEpochMillis: plusDays(Date.now(), daysUntilExpiration),
+        eligibleForExtension,
       },
       creatorUser: ownedByMe ? me : someOneElse,
     });
@@ -118,7 +120,14 @@ describe('InvalidBillingBanner', () => {
     const expired = false;
     const expiringSoon = true;
     const ownedByMe = true;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = true;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(true);
 
     component();
@@ -138,7 +147,14 @@ describe('InvalidBillingBanner', () => {
     const expired = false;
     const expiringSoon = true;
     const ownedByMe = false;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = true;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(true);
 
     component();
@@ -157,7 +173,14 @@ describe('InvalidBillingBanner', () => {
     const expired = true;
     const expiringSoon = false;
     const ownedByMe = true;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = true;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(true);
 
     component();
@@ -176,7 +199,14 @@ describe('InvalidBillingBanner', () => {
     const expired = true;
     const expiringSoon = false;
     const ownedByMe = false;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = true;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(true);
 
     component();
@@ -195,7 +225,14 @@ describe('InvalidBillingBanner', () => {
     const expired = true;
     const expiringSoon = false;
     const ownedByMe = true;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = false;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(false);
 
     component();
@@ -214,7 +251,14 @@ describe('InvalidBillingBanner', () => {
     const expired = true;
     const expiringSoon = false;
     const ownedByMe = false;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = false;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(false);
 
     component();
@@ -234,7 +278,14 @@ describe('InvalidBillingBanner', () => {
     const expired = false;
     const expiringSoon = false;
     const ownedByMe = true;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = false;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(false);
 
     component();
@@ -253,7 +304,14 @@ describe('InvalidBillingBanner', () => {
     const expired = false;
     const expiringSoon = false;
     const ownedByMe = false;
-    setupWorkspace(exhausted, expired, expiringSoon, ownedByMe);
+    const eligibleForExtension = false;
+    setupWorkspace(
+      exhausted,
+      expired,
+      expiringSoon,
+      ownedByMe,
+      eligibleForExtension
+    );
     setProfileExtensionEligibility(false);
 
     component();

--- a/ui/src/app/pages/workspace/invalid-billing-banner-maybe.tsx
+++ b/ui/src/app/pages/workspace/invalid-billing-banner-maybe.tsx
@@ -217,7 +217,8 @@ export const InvalidBillingBannerMaybe = fp.flow(
   const { creatorUser } = workspace || {};
   const [showExtensionModal, setShowExtensionModal] = React.useState(false);
   const isCreator = profile?.username === workspace?.creatorUser?.userName;
-  const isEligibleForExtension = profile?.eligibleForInitialCreditsExtension;
+  const isEligibleForExtension =
+    workspace?.initialCredits?.eligibleForExtension;
   const isExpired =
     workspace?.initialCredits.expirationEpochMillis < Date.now();
   const isExpiringSoon =


### PR DESCRIPTION
Made workspace initial credit banners based on the extension status of the creator rather than the active user.

To test this, share a workspace between two users. Make the creator eligible for an extension by adding a record in the workbench.user_initial_credits_expiration table that has an expiration time in the past and no value for extension time.

Make the other user ineligible by adding a record in the workbench.user_initial_credits_expiration table that has expiration and extension time in the past.

Navigate to the workspace as the non-creator, and ensure that you see a banner mentioning extension.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
