### PR TITLE
[no ticket][risk=no] Update admin page to account for missing expiration time

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-common.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-common.tsx
@@ -649,7 +649,7 @@ export const InitialCreditBypassSwitch = ({
   label,
 }: InitialCreditBypassSwitchProps) => {
   const hasExpired = expirationEpochMillis <= Date.now();
-  const date = formatDate(expirationEpochMillis, '-');
+  const date = formatDate(expirationEpochMillis, '');
   return (
     <FlexColumn style={{ paddingTop: '1.5rem' }}>
       <label style={{ ...commonStyles.label, padding: 0 }}>{label}</label>
@@ -660,7 +660,7 @@ export const InitialCreditBypassSwitch = ({
             ? 'Credits will not expire'
             : hasExpired
             ? `Credits expired on ${date}`
-            : `Credits will expire on ${date}`
+            : `Credits will expire${date ? ` on ${date}` : ''}`
         }
         checked={currentlyBypassed}
         onToggle={onChange}


### PR DESCRIPTION
When a user has their initial credit expiration bypassed, the UI will currently show "credits will expire on -" when unbypassed. This is because expiration time is not exposed to bypassed users. This changes it so it will show ""credits will expire" in this case.

Current Case:

https://github.com/user-attachments/assets/67e3df23-622f-4f25-8e98-a7044e627257

Updated Case:

https://github.com/user-attachments/assets/460254f3-0489-42e4-8ba9-fb0c940318fd





In the future, explore whether expiration date needs to be filtered out in these cases.



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
