### PR TITLE
[risk=low] RW-14160 don't fail startup script if we fail to update git config

### DIFF
--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -50,6 +50,7 @@ EOF
 
 # Ignore error if this fails. This is a best-effort attempt to set the global gitignore for users.
 sudo -E -u jupyter /usr/bin/git config --global core.excludesfile ${ignore_file} || true
+# Ignore error if this fails. This is a best-effort attempt to clean up trash for users.
 sudo -E -u jupyter rm -rf /home/jupyter/.local/share/Trash/files/* || true
 
 # Initialize a default nextflow config. Don't overwrite in case the user has

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -50,7 +50,7 @@ EOF
 
 # Ignore error if this fails. This is a best-effort attempt to set the global gitignore for users.
 sudo -E -u jupyter /usr/bin/git config --global core.excludesfile ${ignore_file} || true
-sudo -E -u jupyter rm -rf ~/.local/share/Trash/files/* || true
+sudo -E -u jupyter rm -rf /home/jupyter/.local/share/Trash/files/* || true
 
 # Initialize a default nextflow config. Don't overwrite in case the user has
 # customized their nextflow config file on their PD.

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -50,6 +50,7 @@ EOF
 
 # Ignore error if this fails. This is a best-effort attempt to set the global gitignore for users.
 sudo -E -u jupyter /usr/bin/git config --global core.excludesfile ${ignore_file} || true
+sudo -E -u jupyter rm -rf ~/.local/share/Trash/files/* || true
 
 # Initialize a default nextflow config. Don't overwrite in case the user has
 # customized their nextflow config file on their PD.

--- a/api/src/main/webapp/static/initialize_notebook_runtime.sh
+++ b/api/src/main/webapp/static/initialize_notebook_runtime.sh
@@ -48,7 +48,8 @@ cat <<EOF | sudo -E -u jupyter tee ${ignore_file}
 !LICENSE*
 EOF
 
-sudo -E -u jupyter /usr/bin/git config --global core.excludesfile ${ignore_file}
+# Ignore error if this fails. This is a best-effort attempt to set the global gitignore for users.
+sudo -E -u jupyter /usr/bin/git config --global core.excludesfile ${ignore_file} || true
 
 # Initialize a default nextflow config. Don't overwrite in case the user has
 # customized their nextflow config file on their PD.


### PR DESCRIPTION
For https://precisionmedicineinitiative.atlassian.net/browse/RW-14160, user's jupyter startup script failed due to
```
INFO 2024-12-20T00:31:09.029004785Z [resource.labels.instanceId: 8215461924201628842] startup-script-url: error: failed to write new configuration file /home/jupyter/.gitconfig.lock
INFO 2024-12-20T00:31:09.029334382Z [resource.labels.instanceId: 8215461924201628842] startup-script-url: Installation failed: not a git repository!
```

Think updating gitconfig should be best effort thing, it doesn't need to fail startup

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
