### PR TITLE
[risk=low][no ticket] Add temp debugging for e2e test

### DIFF
--- a/e2e/utils/runtime-utils.ts
+++ b/e2e/utils/runtime-utils.ts
@@ -33,7 +33,16 @@ export async function waitForSecuritySuspendedStatus(
   const pollPeriod = 20 * 1000;
 
   while (true) {
-    await page.reload({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 });
+    // temp for debugging
+    const reloadStart = Date.now();
+    const reloadResult = await page.reload({
+      waitUntil: ['load', 'domcontentloaded', 'networkidle0'],
+      timeout: 60 * 1000
+    });
+    const reloadEnd = Date.now();
+    logger.info(
+      `Reload ${reloadResult.ok() ? 'succeeded' : 'failed'} after ${(reloadEnd - reloadStart) / 1000} seconds`
+    );
 
     if ((await isSecuritySuspended(page)) === suspended) {
       // Success
@@ -42,6 +51,8 @@ export async function waitForSecuritySuspendedStatus(
 
     const waited = Date.now() - startTime;
     if (waited > timeOut - pollPeriod) {
+      // temp for debugging
+      logger.info(`Waited ${waited / 1000} seconds, longer than timeout of ${timeOut / 1000} seconds`);
       throw new Error(`Timed out waiting for egress security suspension status = ${suspended}`);
     }
     logger.info(`Waited for ${(waited / 1000 / 60).toFixed(2)} minutes`);


### PR DESCRIPTION
The e2e egress suspension test seems to be timing out way too early for a particular step - less than 3 minutes when it should be waiting 25.  Adding some more info to try to figure this out.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
