### PR TITLE
[risk=low][RW-13727] Delete resources for unshared-from-ws users 

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -163,7 +163,7 @@
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
     "usersPerCheckInitialCreditsExpirationTask": 50,
-    "workspacesPerDeleteWorkspaceEnvironmentsTask": 100
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -162,7 +162,8 @@
     "unsafeCloudTasksForwardingHost": "http:\/\/localhost:8081",
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 100
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -157,7 +157,8 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "termsOfService": {
     "minimumAcceptedAouVersion": 2

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -157,7 +157,8 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -155,7 +155,8 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -152,7 +152,8 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -163,7 +163,8 @@
   "offlineBatch": {
     "usersPerAuditTask": 20,
     "usersPerSynchronizeAccessTask": 50,
-    "usersPerCheckInitialCreditsExpirationTask": 50
+    "usersPerCheckInitialCreditsExpirationTask": 50,
+    "workspacesPerDeleteWorkspaceEnvironmentsTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -37,7 +38,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
         .map(workspaceService::lookupWorkspaceByNamespace)
         .forEach(
             ws -> {
-              explore(ws);
+              //              explore(ws);
               deleteUnshared(ws);
             });
 
@@ -60,12 +61,11 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
 
     var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
     runtimes.forEach(
-        runtimeResponse ->
+        runtime ->
             LOGGER.info(
                 String.format(
                     "Runtime %s created by user %s",
-                    runtimeResponse.getRuntimeName(),
-                    runtimeResponse.getAuditInfo().getCreator())));
+                    runtime.getRuntimeName(), runtime.getAuditInfo().getCreator())));
 
     var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
     apps.forEach(
@@ -104,26 +104,26 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
         apps.stream().filter(app -> !currentUsers.contains(app.getCreator())).toList();
 
     if (!runtimesToDelete.isEmpty()) {
-      String.format(
-          "Deleting %d runtimes for workspace %s/%s (ID %d) out of %d total",
-          runtimesToDelete.size(),
-          dbWorkspace.getWorkspaceNamespace(),
-          dbWorkspace.getFirecloudName(),
-          dbWorkspace.getWorkspaceId(),
-          runtimes.size());
+      LOGGER.info(
+          String.format(
+              "Deleting %d runtimes for workspace %s/%s (ID %d) out of %d total",
+              runtimesToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              runtimes.size()));
       runtimesToDelete.forEach(
           runtime -> {
-            //            try {
-            //              leonardoApiClient.deleteRuntimeAsService(
-            //                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /*
-            // deleteDisk */ true);
-            //            } catch (WorkbenchException e) {
-            //              LOGGER.warning(
-            //                  String.format(
-            //                      "Failed to delete runtime %s in project %s: %s",
-            //                      runtime.getRuntimeName(), dbWorkspace.getGoogleProject(),
-            // e.getMessage()));
-            //            }
+            try {
+              leonardoApiClient.deleteRuntimeAsService(
+                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /*
+             deleteDisk */ true);
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete runtime %s in project %s: %s",
+                      runtime.getRuntimeName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
           });
     }
 
@@ -138,16 +138,15 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               apps.size()));
       appsToDelete.forEach(
           app -> {
-            //            try {
-            //              leonardoApiClient.deleteAppAsService(
-            //                  app.getAppName(), dbWorkspace, /* deleteDisk */ true);
-            //            } catch (WorkbenchException e) {
-            //              LOGGER.warning(
-            //                  String.format(
-            //                      "Failed to delete app %s in project %s: %s",
-            //                      app.getAppName(), dbWorkspace.getGoogleProject(),
-            // e.getMessage()));
-            //            }
+            try {
+              leonardoApiClient.deleteAppAsService(
+                  app.getAppName(), dbWorkspace, /* deleteDisk */ true);
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete app %s in project %s: %s",
+                      app.getAppName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
           });
     }
 
@@ -170,16 +169,15 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               disks.size()));
       disksToDelete.forEach(
           disk -> {
-            //            try {
-            //              leonardoApiClient.deletePersistentDiskAsService(
-            //                  dbWorkspace.getGoogleProject(), disk.getName());
-            //            } catch (WorkbenchException e) {
-            //              LOGGER.warning(
-            //                  String.format(
-            //                      "Failed to delete disk %s in project %s: %s",
-            //                      disk.getName(), dbWorkspace.getGoogleProject(),
-            // e.getMessage()));
-            //            }
+            try {
+              leonardoApiClient.deletePersistentDiskAsService(
+                  dbWorkspace.getGoogleProject(), disk.getName());
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete disk %s in project %s: %s",
+                      disk.getName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
           });
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -1,0 +1,186 @@
+package org.pmiops.workbench.api;
+
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApiDelegate {
+  private static final Logger LOGGER =
+      Logger.getLogger(CloudTaskEnvironmentsController.class.getName());
+
+  private final LeonardoApiClient leonardoApiClient;
+  private final WorkspaceService workspaceService;
+
+  @Autowired
+  public CloudTaskEnvironmentsController(
+      LeonardoApiClient leonardoApiClient, WorkspaceService workspaceService) {
+    this.leonardoApiClient = leonardoApiClient;
+    this.workspaceService = workspaceService;
+  }
+
+  @Override
+  public ResponseEntity<Void> ctDeleteUnsharedWorkspaceEnvironments(
+      List<String> workspaceNamespaces) {
+    LOGGER.info(
+        String.format(
+            "Deleting unshared environments for %d workspaces.", workspaceNamespaces.size()));
+
+    workspaceNamespaces.stream()
+        .map(workspaceService::lookupWorkspaceByNamespace)
+        .forEach(
+            ws -> {
+              explore(ws);
+              deleteUnshared(ws);
+            });
+
+    return ResponseEntity.ok().build();
+  }
+
+  private void explore(DbWorkspace dbWorkspace) {
+    LOGGER.info(
+        String.format(
+            "Exploring workspace %s/%s (ID %d)",
+            dbWorkspace.getWorkspaceNamespace(),
+            dbWorkspace.getFirecloudName(),
+            dbWorkspace.getWorkspaceId()));
+
+    var roles =
+        workspaceService.getFirecloudUserRoles(
+            dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
+    roles.forEach(
+        ur -> LOGGER.info(String.format("Role %s for user %s", ur.getRole(), ur.getEmail())));
+
+    var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
+    runtimes.forEach(
+        runtimeResponse ->
+            LOGGER.info(
+                String.format(
+                    "Runtime %s created by user %s",
+                    runtimeResponse.getRuntimeName(),
+                    runtimeResponse.getAuditInfo().getCreator())));
+
+    var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
+    apps.forEach(
+        app ->
+            LOGGER.info(
+                String.format(
+                    "App %s (%s) created by user %s",
+                    app.getAppName(), app.getAppType(), app.getCreator())));
+
+    var disks = leonardoApiClient.listDisksByProjectAsService(dbWorkspace.getGoogleProject());
+    disks.forEach(
+        disk ->
+            LOGGER.info(
+                String.format(
+                    "Disk %s created by user %s",
+                    disk.getName(), disk.getAuditInfo().getCreator())));
+  }
+
+  private void deleteUnshared(DbWorkspace dbWorkspace) {
+    var currentUsers =
+        workspaceService
+            .getFirecloudUserRoles(
+                dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
+            .stream()
+            .map(UserRole::getEmail)
+            .collect(Collectors.toSet());
+
+    var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
+    var runtimesToDelete =
+        runtimes.stream()
+            .filter(runtime -> !currentUsers.contains(runtime.getAuditInfo().getCreator()))
+            .toList();
+
+    var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
+    var appsToDelete =
+        apps.stream().filter(app -> !currentUsers.contains(app.getCreator())).toList();
+
+    if (!runtimesToDelete.isEmpty()) {
+      String.format(
+          "Deleting %d runtimes for workspace %s/%s (ID %d) out of %d total",
+          runtimesToDelete.size(),
+          dbWorkspace.getWorkspaceNamespace(),
+          dbWorkspace.getFirecloudName(),
+          dbWorkspace.getWorkspaceId(),
+          runtimes.size());
+      runtimesToDelete.forEach(
+          runtime -> {
+            //            try {
+            //              leonardoApiClient.deleteRuntimeAsService(
+            //                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /*
+            // deleteDisk */ true);
+            //            } catch (WorkbenchException e) {
+            //              LOGGER.warning(
+            //                  String.format(
+            //                      "Failed to delete runtime %s in project %s: %s",
+            //                      runtime.getRuntimeName(), dbWorkspace.getGoogleProject(),
+            // e.getMessage()));
+            //            }
+          });
+    }
+
+    if (!appsToDelete.isEmpty()) {
+      LOGGER.info(
+          String.format(
+              "Deleting %d apps for workspace %s/%s (ID %d) out of %d total",
+              appsToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              apps.size()));
+      appsToDelete.forEach(
+          app -> {
+            //            try {
+            //              leonardoApiClient.deleteAppAsService(
+            //                  app.getAppName(), dbWorkspace, /* deleteDisk */ true);
+            //            } catch (WorkbenchException e) {
+            //              LOGGER.warning(
+            //                  String.format(
+            //                      "Failed to delete app %s in project %s: %s",
+            //                      app.getAppName(), dbWorkspace.getGoogleProject(),
+            // e.getMessage()));
+            //            }
+          });
+    }
+
+    // check disks after runtime and app deletion, because these will delete their associated disks
+
+    var disks = leonardoApiClient.listDisksByProjectAsService(dbWorkspace.getGoogleProject());
+    var disksToDelete =
+        disks.stream()
+            .filter(disk -> !currentUsers.contains(disk.getAuditInfo().getCreator()))
+            .toList();
+
+    if (!disksToDelete.isEmpty()) {
+      LOGGER.info(
+          String.format(
+              "Deleting %d disks for workspace %s/%s (ID %d) out of %d total",
+              disksToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              disks.size()));
+      disksToDelete.forEach(
+          disk -> {
+            //            try {
+            //              leonardoApiClient.deletePersistentDiskAsService(
+            //                  dbWorkspace.getGoogleProject(), disk.getName());
+            //            } catch (WorkbenchException e) {
+            //              LOGGER.warning(
+            //                  String.format(
+            //                      "Failed to delete disk %s in project %s: %s",
+            //                      disk.getName(), dbWorkspace.getGoogleProject(),
+            // e.getMessage()));
+            //            }
+          });
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.utils.LogFormatters.formatDurationPretty;
+
 import com.google.common.base.Stopwatch;
 import jakarta.inject.Provider;
 import java.util.List;
@@ -41,15 +43,16 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
         String.format(
             "Deleting unshared environments for %d workspaces.", workspaceNamespaces.size()));
 
-    stopwatchProvider.get().start();
+    // temp timing for batch sizing
+    var stopwatch = stopwatchProvider.get().start();
     workspaceNamespaces.stream()
         .map(workspaceService::lookupWorkspaceByNamespace)
         .forEach(this::deleteUnshared);
-    var elapsed = stopwatchProvider.get().stop().elapsed();
+    var elapsed = stopwatch.stop().elapsed();
     LOGGER.info(
         String.format(
             "Deleted unshared environments for %d workspaces in %s.",
-            workspaceNamespaces.size(), elapsed));
+            workspaceNamespaces.size(), formatDurationPretty(elapsed)));
 
     return ResponseEntity.ok().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -53,8 +53,8 @@ import org.springframework.web.bind.annotation.RestController;
  * Workbench service account.
  */
 @RestController
-public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
-  private static final Logger log = Logger.getLogger(OfflineRuntimeController.class.getName());
+public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDelegate {
+  private static final Logger log = Logger.getLogger(OfflineEnvironmentsController.class.getName());
 
   // On the n'th day of inactivity on a PD, a notification is sent.
   private static final Set<Integer> INACTIVE_DISK_NOTIFY_THRESHOLDS_DAYS = ImmutableSet.of(14);
@@ -77,7 +77,7 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
   private final Clock clock;
 
   @Autowired
-  OfflineRuntimeController(
+  OfflineEnvironmentsController(
       FireCloudService firecloudService,
       InitialCreditsService initialCreditsService,
       MailService mailService,

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineRuntimeController.java
@@ -178,7 +178,8 @@ public class OfflineRuntimeController implements OfflineRuntimeApiDelegate {
         continue;
       }
 
-      leonardoApiClient.deleteRuntimeAsService(googleProject, runtime.getRuntimeName());
+      leonardoApiClient.deleteRuntimeAsService(
+          googleProject, runtime.getRuntimeName(), /* deleteDisk */ false);
     }
     log.info(
         String.format(

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -410,6 +410,8 @@ public class WorkbenchConfig {
     public Integer usersPerSynchronizeAccessTask;
     // Number of users to process within a single check initial credits expiration task.
     public Integer usersPerCheckInitialCreditsExpirationTask;
+    // Number of workspaces to process within a single delete workspace environments task.
+    public Integer workspacesPerDeleteWorkspaceEnvironmentsTask;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -153,4 +153,11 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
           + "FROM DbWorkspace w "
           + "WHERE w.creator.userId in (:creatoridList)")
   Set<String> getGoogleProjectForUserList(@Param("creatoridList") List<Long> creatorIdList);
+
+  List<DbWorkspace> getAllByActiveStatusEquals(short status);
+
+  default List<DbWorkspace> getAllActive() {
+    return getAllByActiveStatusEquals(
+        DbStorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE));
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -54,7 +54,8 @@ public interface LeonardoApiClient {
       throws WorkbenchException;
 
   /** Deletes a notebook runtime as the appengine SA, to be used only for admin operations */
-  void deleteRuntimeAsService(String googleProject, String runtimeName) throws WorkbenchException;
+  void deleteRuntimeAsService(String googleProject, String runtimeName, boolean deleteDisk)
+      throws WorkbenchException;
 
   /**
    * Stops all runtimes created by the user, if any can be stopped. Returns the count of stopped
@@ -141,6 +142,9 @@ public interface LeonardoApiClient {
    * @param deleteDisk whether the app's persistent disk should also be deleted
    */
   void deleteApp(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
+      throws WorkbenchException;
+
+  void deleteAppAsService(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
       throws WorkbenchException;
 
   int deleteUserAppsAsService(String userEmail);

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClient.java
@@ -13,10 +13,14 @@ import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.notebooks.model.StorageLink;
 
 /**
- * Encapsulate Leonardo's Notebooks API interaction details and provide a simple/mockable interface
- * for internal use.
+ * Encapsulate Leonardo's API interaction details and provide a simple/mockable interface for
+ * internal use.
  */
 public interface LeonardoApiClient {
+  //
+  // Runtime endpoints
+  //
+
   /**
    * lists all runtimes in the environment as the appengine SA, to be used only for admin operations
    */
@@ -62,6 +66,10 @@ public interface LeonardoApiClient {
   LeonardoGetRuntimeResponse getRuntime(String googleProject, String runtimeName)
       throws WorkbenchException;
 
+  //
+  // Welder endpoints - "notebooks" client
+  //
+
   /** Send files over to notebook runtime */
   void localizeForRuntime(String googleProject, String runtimeName, Map<String, String> fileList)
       throws WorkbenchException;
@@ -78,6 +86,10 @@ public interface LeonardoApiClient {
   StorageLink createStorageLinkForApp(
       String googleProject, String appName, StorageLink storageLink);
 
+  //
+  // Disk endpoints
+  //
+
   /** Deletes a persistent disk */
   void deletePersistentDisk(String googleProject, String diskName) throws WorkbenchException;
 
@@ -92,6 +104,16 @@ public interface LeonardoApiClient {
   /** List all persistent disks owned by authenticated user in google project */
   List<ListPersistentDiskResponse> listPersistentDiskByProjectCreatedByCreator(
       String googleProject);
+
+  /** List all persistent disks */
+  List<ListPersistentDiskResponse> listDisksAsService();
+
+  /** List all persistent disks in google project */
+  List<ListPersistentDiskResponse> listDisksByProjectAsService(String googleProject);
+
+  //
+  // Apps endpoints
+  //
 
   /**
    * Creates Leonardo app owned by the current authenticated user.
@@ -121,18 +143,20 @@ public interface LeonardoApiClient {
   void deleteApp(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
       throws WorkbenchException;
 
+  int deleteUserAppsAsService(String userEmail);
+
+  //
+  // Status endpoints
+  //
+
   /**
    * @return true if Leonardo service is okay, false otherwise.
    */
   boolean getLeonardoStatus();
 
-  int deleteUserAppsAsService(String userEmail);
-
-  /** List all persistent disks */
-  List<ListPersistentDiskResponse> listDisksAsService();
-
-  /** List all persistent disks in google project */
-  List<ListPersistentDiskResponse> listDisksByProjectAsService(String googleProject);
+  //
+  // Resources endpoints
+  //
 
   void deleteAllResources(String googleProject, boolean deleteDisk);
 }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -367,11 +367,11 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   }
 
   @Override
-  public void deleteRuntimeAsService(String googleProject, String runtimeName) {
+  public void deleteRuntimeAsService(String googleProject, String runtimeName, boolean deleteDisk) {
     RuntimesApi runtimesApi = serviceRuntimesApiProvider.get();
     legacyLeonardoRetryHandler.run(
         (context) -> {
-          runtimesApi.deleteRuntime(googleProject, runtimeName, /* deleteDisk */ false);
+          runtimesApi.deleteRuntime(googleProject, runtimeName, deleteDisk);
           return null;
         });
   }
@@ -708,6 +708,18 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
   public void deleteApp(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
       throws WorkbenchException {
     AppsApi appsApi = appsApiProvider.get();
+
+    leonardoRetryHandler.run(
+        context -> {
+          appsApi.deleteApp(dbWorkspace.getGoogleProject(), appName, deleteDisk);
+          return null;
+        });
+  }
+
+  @Override
+  public void deleteAppAsService(String appName, DbWorkspace dbWorkspace, boolean deleteDisk)
+      throws WorkbenchException {
+    AppsApi appsApi = serviceAppsApiProvider.get();
 
     leonardoRetryHandler.run(
         context -> {

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -16,7 +16,6 @@ import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.upsertLeonardoLa
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import jakarta.inject.Provider;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
@@ -24,14 +23,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiException;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi;
 import org.broadinstitute.dsde.workbench.client.leonardo.api.DisksApi;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.UpdateDiskRequest;
@@ -52,7 +49,6 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCreateRuntimeRe
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoMachineConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoUpdateDataprocConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoUpdateGceConfig;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoUpdateRuntimeRequest;
@@ -80,19 +76,6 @@ import org.springframework.stereotype.Service;
 public class LeonardoApiClientImpl implements LeonardoApiClient {
   // The Leonardo user role who creates Leonardo APP or disks.
   private static final String LEONARDO_CREATOR_ROLE = "creator";
-
-  // Keep in sync with
-  // https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/runtimeModels.scala#L162
-  private static final Set<LeonardoRuntimeStatus> STOPPABLE_RUNTIME_STATUSES =
-      ImmutableSet.of(
-          LeonardoRuntimeStatus.RUNNING,
-          LeonardoRuntimeStatus.STARTING,
-          LeonardoRuntimeStatus.UPDATING);
-
-  // Keep in sync with
-  // https://github.com/DataBiosphere/leonardo/blob/807c024d8e8be86b782e519319520ca3b3705a52/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala#L522C42-L522C42
-  private static final Set<AppStatus> DELETABLE_APP_STATUSES =
-      Set.of(AppStatus.STATUS_UNSPECIFIED, AppStatus.RUNNING, AppStatus.ERROR);
 
   private static final Logger log = Logger.getLogger(LeonardoApiClientImpl.class.getName());
 
@@ -396,7 +379,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
     }
     List<Boolean> results =
         runtimes.stream()
-            .filter(r -> STOPPABLE_RUNTIME_STATUSES.contains(r.getStatus()))
+            .filter(LeonardoStatusUtils::canStopRuntime)
             .filter(
                 r -> {
                   if (!userEmail.equals(r.getAuditInfo().getCreator())) {
@@ -755,7 +738,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
 
     List<Boolean> results =
         apps.stream()
-            .filter(r -> DELETABLE_APP_STATUSES.contains(r.getStatus()))
+            .filter(LeonardoStatusUtils::canDeleteApp)
             .filter(
                 r ->
                     r.getAppType()

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoStatusUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoStatusUtils.java
@@ -1,0 +1,80 @@
+package org.pmiops.workbench.leonardo;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AppStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListAppResponse;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.model.UserAppEnvironment;
+
+public class LeonardoStatusUtils {
+
+  // Keep in sync with Leonardo's runtimeModels.scala
+
+  private static final Set<LeonardoRuntimeStatus> STOPPABLE_LEO_RUNTIME_STATUSES =
+      ImmutableSet.of(
+          LeonardoRuntimeStatus.UNKNOWN,
+          LeonardoRuntimeStatus.RUNNING,
+          LeonardoRuntimeStatus.STARTING,
+          LeonardoRuntimeStatus.UPDATING);
+
+  private static final Set<LeonardoRuntimeStatus> DELETABLE_LEO_RUNTIME_STATUSES =
+      ImmutableSet.of(
+          LeonardoRuntimeStatus.UNKNOWN,
+          LeonardoRuntimeStatus.RUNNING,
+          LeonardoRuntimeStatus.STARTING,
+          LeonardoRuntimeStatus.UPDATING,
+          LeonardoRuntimeStatus.ERROR,
+          LeonardoRuntimeStatus.STOPPING,
+          LeonardoRuntimeStatus.STOPPED);
+
+  // Keep in sync with Leonardo's kubernetesModels.scala
+
+  private static final Set<AppStatus> DELETABLE_LEO_APP_STATUSES =
+      Set.of(AppStatus.STATUS_UNSPECIFIED, AppStatus.RUNNING, AppStatus.ERROR);
+
+  private static final Set<org.pmiops.workbench.model.AppStatus> DELETABLE_RWB_APP_STATUSES =
+      Set.of(
+          org.pmiops.workbench.model.AppStatus.STATUS_UNSPECIFIED,
+          org.pmiops.workbench.model.AppStatus.RUNNING,
+          org.pmiops.workbench.model.AppStatus.ERROR);
+
+  // Keep in sync with Leonardo's diskmodels.scala
+
+  private static final Set<DiskStatus> DELETABLE_LEO_DISK_STATUSES =
+      Set.of(DiskStatus.FAILED, DiskStatus.READY);
+
+  private static final Set<org.pmiops.workbench.model.DiskStatus> ACTIVE_RWB_DISK_STATUSES =
+      ImmutableSet.of(
+          org.pmiops.workbench.model.DiskStatus.READY,
+          org.pmiops.workbench.model.DiskStatus.CREATING,
+          org.pmiops.workbench.model.DiskStatus.RESTORING);
+
+  public static boolean canStopRuntime(LeonardoListRuntimeResponse response) {
+    return STOPPABLE_LEO_RUNTIME_STATUSES.contains(response.getStatus());
+  }
+
+  public static boolean canDeleteRuntime(LeonardoListRuntimeResponse response) {
+    return DELETABLE_LEO_RUNTIME_STATUSES.contains(response.getStatus());
+  }
+
+  public static boolean canDeleteApp(ListAppResponse response) {
+    return DELETABLE_LEO_APP_STATUSES.contains(response.getStatus());
+  }
+
+  public static boolean canDeleteApp(UserAppEnvironment app) {
+    return DELETABLE_RWB_APP_STATUSES.contains(app.getStatus());
+  }
+
+  public static boolean isActiveDisk(Disk disk) {
+    return ACTIVE_RWB_DISK_STATUSES.contains(disk.getStatus());
+  }
+
+  public static boolean canDeleteDisk(ListPersistentDiskResponse disk) {
+    return DELETABLE_LEO_DISK_STATUSES.contains(disk.getStatus());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
@@ -1,13 +1,11 @@
 package org.pmiops.workbench.leonardo;
 
-import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -16,7 +14,6 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
 import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
-import org.pmiops.workbench.model.DiskStatus;
 
 public final class PersistentDiskUtils {
   private static final Logger log = Logger.getLogger(PersistentDiskUtils.class.getName());
@@ -24,10 +21,6 @@ public final class PersistentDiskUtils {
   // See https://cloud.google.com/compute/pricing
   private static final Map<DiskType, Double> DISK_PRICE_PER_GB_MONTH =
       Map.of(DiskType.STANDARD, .04, DiskType.SSD, .17);
-
-  // https://github.com/DataBiosphere/leonardo/blob/3774547f2018e056e9af42142a10ac004cfe1ee8/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/diskModels.scala#L60
-  private static final Set<DiskStatus> ACTIVE_DISK_STATUSES =
-      ImmutableSet.of(DiskStatus.READY, DiskStatus.CREATING, DiskStatus.RESTORING);
 
   private PersistentDiskUtils() {}
 
@@ -55,9 +48,7 @@ public final class PersistentDiskUtils {
     // Disk maybe in incorrect state if having additional active state disks.
 
     List<Disk> activeDisks =
-        disksToValidate.stream()
-            .filter(d -> ACTIVE_DISK_STATUSES.contains(d.getStatus()))
-            .collect(Collectors.toList());
+        disksToValidate.stream().filter(LeonardoStatusUtils::isActiveDisk).toList();
     if (activeDisks.size() > (AppType.values().length + 1)) {
       String diskNameList =
           activeDisks.stream().map(Disk::getName).collect(Collectors.joining(","));

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -274,7 +274,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   public AdminRuntimeFields deleteRuntime(String workspaceNamespace, String runtimeNameToDelete) {
     final String googleProject =
         getWorkspaceByNamespaceOrThrow(workspaceNamespace).getGoogleProject();
-    leonardoApiClient.deleteRuntimeAsService(googleProject, runtimeNameToDelete);
+    leonardoApiClient.deleteRuntimeAsService(
+        googleProject, runtimeNameToDelete, /* deleteDisk */ false);
 
     // fetch again to confirm deletion
     LeonardoGetRuntimeResponse refreshedRuntime =

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2374,7 +2374,7 @@ paths:
   /v1/cron/deleteOldRuntimes:
     get:
       tags:
-      - offlineRuntime
+      - offlineEnvironments
       - cron
       description: Endpoint meant to be called offline to trigger runtime checks and
         cleanup. Enforces upgrade by deletion and re-creation for older runtime deployments.
@@ -2388,7 +2388,7 @@ paths:
   /v1/cron/checkPersistentDisks:
     get:
       tags:
-      - offlineRuntime
+      - offlineEnvironments
       - cron
       description: 'Endpoint meant to be called offline to check for old / detached
         persistent disks. Notifies workspace owners at configurable intervals about

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2400,6 +2400,19 @@ paths:
         204:
           description: Disks were checked and handled successfully.
           content: {}
+  /v1/cron/deleteUnsharedWorkspaceEnvironments:
+    get:
+      tags:
+        - offlineEnvironments
+        - cron
+      description: 'Endpoint meant to be called offline to delete Runtimes, Apps, and Disks for
+        users who have been removed from workspaces. Only executable via App Engine cronjob.'
+      operationId: deleteUnsharedWorkspaceEnvironments
+      security: []
+      responses:
+        204:
+          description: Environments and Disks were deleted successfully, where appropriate.
+          content: {}
   /v1/cron/bulkAuditProjectAccess:
     get:
       tags:
@@ -4390,6 +4403,28 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UserIdList'
+        required: true
+      responses:
+        200:
+          description: Check Credits Expiration For User IDs Task Ran Successfully
+          content: { }
+      x-codegen-request-body-name: request
+  /v1/cloudTask/deleteUnsharedWorkspaceEnvironments:
+    post:
+      tags:
+        - cloudTaskEnvironments
+        - cloudTask
+      description: |
+        Run the business logic to delete Runtimes, Apps, and Disks for
+        users who have been removed from workspaces
+      operationId: ctDeleteUnsharedWorkspaceEnvironments
+      security: [ ]
+      requestBody:
+        description: Workspaces to check for unshared environments and disks.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceNamespaceList'
         required: true
       responses:
         200:
@@ -11727,6 +11762,10 @@ components:
       items:
         type: integer
         format: int64
+    WorkspaceNamespaceList:
+      type: array
+      items:
+        type: string
     ProcessEgressEventRequest:
       required:
       - eventId

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -85,3 +85,10 @@ cron:
   schedule: 1st mon of sep 17:00
   timezone: UTC
   target: api
+- description: >
+    Check the Runtimes, Apps, and Disks of all active Workspaces and delete those created by users
+    who no longer have access to the Workspaces.
+  url: /v1/cron/deleteUnsharedWorkspaceEnvironments
+  schedule: every day 19:30
+  timezone: America/Chicago
+  target: api

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -128,3 +128,15 @@ queue:
   retry_parameters:
     task_retry_limit: 1
     task_age_limit: 5m
+
+- name: deleteUnsharedWorkspaceEnvironmentsQueue
+  target: api
+
+  # rate parameters
+  bucket_size: 500
+  rate: 1/s
+  max_concurrent_requests: 100
+
+  retry_parameters:
+    task_retry_limit: 1
+    task_age_limit: 5ms

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
@@ -76,7 +76,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 
 @DataJpaTest
-public class OfflineRuntimeControllerTest {
+public class OfflineEnvironmentsControllerTest {
   private static final Instant NOW = FakeClockConfiguration.NOW.toInstant();
   private static final Duration RUNTIME_MAX_AGE = Duration.ofDays(14);
   private static final Duration RUNTIME_IDLE_MAX_AGE = Duration.ofDays(7);
@@ -86,7 +86,7 @@ public class OfflineRuntimeControllerTest {
   @Import({
     FakeClockConfiguration.class,
     LeonardoMapperImpl.class,
-    OfflineRuntimeController.class,
+    OfflineEnvironmentsController.class,
   })
   static class Configuration {
     @Bean
@@ -100,7 +100,7 @@ public class OfflineRuntimeControllerTest {
   @MockBean private LeonardoApiClient mockLeonardoApiClient;
   @MockBean private MailService mockMailService;
 
-  @Autowired private OfflineRuntimeController controller;
+  @Autowired private OfflineEnvironmentsController controller;
 
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private CdrVersionDao cdrVersionDao;

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
@@ -234,7 +234,7 @@ public class OfflineEnvironmentsControllerTest {
     stubRuntimes(Collections.emptyList());
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -242,7 +242,7 @@ public class OfflineEnvironmentsControllerTest {
     stubRuntimes(List.of(runtimeWithAge(Duration.ofHours(10))));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -250,7 +250,7 @@ public class OfflineEnvironmentsControllerTest {
     stubRuntimes(List.of(runtimeWithAge(RUNTIME_MAX_AGE.plusMinutes(5))));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -261,7 +261,7 @@ public class OfflineEnvironmentsControllerTest {
             runtimeWithAgeAndIdle(RUNTIME_IDLE_MAX_AGE.minusMinutes(10), Duration.ofHours(10))));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -271,7 +271,7 @@ public class OfflineEnvironmentsControllerTest {
         List.of(runtimeWithAgeAndIdle(RUNTIME_IDLE_MAX_AGE.plusMinutes(15), Duration.ofHours(10))));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -282,7 +282,7 @@ public class OfflineEnvironmentsControllerTest {
             runtimeWithAgeAndIdle(RUNTIME_IDLE_MAX_AGE.plusMinutes(15), Duration.ofMinutes(15))));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test
@@ -292,7 +292,7 @@ public class OfflineEnvironmentsControllerTest {
             runtimeWithAge(RUNTIME_MAX_AGE.plusDays(10)).status(LeonardoRuntimeStatus.DELETING)));
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
-    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), any());
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
@@ -36,7 +36,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.db.dao.AccessTierDao;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -87,6 +89,8 @@ public class OfflineEnvironmentsControllerTest {
     FakeClockConfiguration.class,
     LeonardoMapperImpl.class,
     OfflineEnvironmentsController.class,
+    TaskQueueService.class,
+    WorkbenchLocationConfigService.class,
   })
   static class Configuration {
     @Bean

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -407,7 +407,8 @@ public class WorkspaceAdminServiceTest {
     workspaceAdminService.deleteRuntime(WORKSPACE_NAMESPACE, testLeoRuntime.getRuntimeName());
 
     verify(mockLeonardoApiClient)
-        .deleteRuntimeAsService(GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName());
+        .deleteRuntimeAsService(
+            GOOGLE_PROJECT_ID, testLeoRuntime.getRuntimeName(), /* deleteDisk */ false);
     verify(mockLeonardoRuntimeAuditor)
         .fireDeleteRuntime(GOOGLE_PROJECT_ID, testLeoListRuntimeResponse.getRuntimeName());
   }

--- a/api/tools/src/cron/deleteUnsharedWorkspaceEnvironments.sh
+++ b/api/tools/src/cron/deleteUnsharedWorkspaceEnvironments.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -X GET 'http://localhost:8081/v1/cron/deleteUnsharedWorkspaceEnvironments' \
+  --header "X-AppEngine-Cron: true"


### PR DESCRIPTION
Add a daily Cron job which checks all active workspaces in batches via Cloud Tasks, to delete Runtimes, GKE Apps, and Disks for users who are no longer collaborators on workspaces.

This is the offline cleanup task in RW-13727, which also specifies an interactive cleanup in the AC.  Depending on how aggressive we want to be, we may instead decide that this PR is sufficient, and an additional interactive cleanup isn't necessary. 

Tested locally.  The check-and-delete process took about 5s per workspace in the Local environment.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
