### PR TITLE
RW-14213 Fix ./project.rb connect-to-cloud-db --project=<project>

### DIFF
--- a/api/libproject/cloudsqlproxycontext.rb
+++ b/api/libproject/cloudsqlproxycontext.rb
@@ -28,22 +28,24 @@ class CloudSqlProxyContext < ServiceAccountContext
         if common.run(%W{docker kill #{DOCKER_PROXY_NAME}}).success?
           common.warning "found and killed existing cloud sql proxy docker service"
         end
+ 
         docker_container_id = common.capture_stdout(%W{docker run -d
              -u #{ENV["UID"]}
              -v #{@keyfile_path}:/config
-             -p 0.0.0.0:3307:3307
+             --publish 3307:3307 
              --rm
              --name #{DOCKER_PROXY_NAME}
-             gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.2 /cloud_sql_proxy
+             gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.2
+             --address 0.0.0.0
              --port 3307
-             #{instance}
              --credentials-file=/config
+             #{instance}
           }).chomp
       end
       begin
         common.status "waiting up to #{DEADLINE_SEC}s for cloudsql proxy to start..."
         start = Time.now
-        until common.run(maybe_dockerize_mysql_cmd("mysqladmin ping --host 0.0.0.0 --port 3307 --silent")).success?
+        until common.run(maybe_dockerize_mysql_cmd("mysqladmin ping --host 0.0.0.0 --port 3307")).success?
           if Time.now - start >= DEADLINE_SEC
             raise("mysql docker service did not become available after #{DEADLINE_SEC}s")
           end

--- a/api/libproject/mysql_docker.rb
+++ b/api/libproject/mysql_docker.rb
@@ -10,7 +10,8 @@ def maybe_dockerize_mysql_cmd(cmd, interactive=false, tty=false)
 
   # Otherwise, containerize mysql usage. This avoids the requirement for devs to
   # have mysql installed on their workstations.
-  return "docker run " +
+  
+  cmd_with_docker = "docker run " +
       "--rm " +
       (interactive ? "-i " : "") +
       (tty ? "-t " : "") +
@@ -18,4 +19,5 @@ def maybe_dockerize_mysql_cmd(cmd, interactive=false, tty=false)
       "--entrypoint '' " +
       "mariadb:10.11.8 " +
       cmd
+  return cmd_with_docker
 end


### PR DESCRIPTION
The following is how to run cloud SQL locally with both v2 and v1 images

```
docker run \
             -v /tmp/colima/all-of-us-rw-prod@appspot.gserviceaccount.com-key20250107-99283-auwyrp.json:/config \
             --publish 3309:3307 \
             --rm \
             --name qi_cloud_sql \
             gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.2 --address 0.0.0.0 --port 3307 --credentials-file=/config all-of-us-rw-prod:us-central1:workbenchmaindb   
```

```
docker run \
             -v /tmp/colima/all-of-us-rw-prod@appspot.gserviceaccount.com-key20250107-99283-auwyrp.json:/config \
             -p 0.0.0.0:3309:3306 \
             --rm \
             --name qi_cloud_sql_v1 \
             gcr.io/cloudsql-docker/gce-proxy:1.16 /cloud_sql_proxy \
             -instances=all-of-us-rw-prod:us-central1:workbenchmaindb=tcp:0.0.0.0:3306 -credential_file=/config      
```

Tested by running the script locally
```
./project.rb connect-to-cloud-db --project=all-of-us-rw-prod
Reading gcloud configuration...
  account: qi.wang@pmi-ops.org
Creating new key for all-of-us-rw-prod@appspot.gserviceaccount.com @ /tmp/colima/all-of-us-rw-prod@appspot.gserviceaccount.com-key20250107-21921-ccdvmt.json
+ gcloud iam service-accounts keys create /tmp/colima/all-of-us-rw-prod@appspot.gserviceaccount.com-key20250107-21921-ccdvmt.json --iam-account=all-of-us-rw-prod@appspot.gserviceaccount.com --project=all-of-us-rw-prod
created key [f7fd37e43cdac6b716eecd4dbd92297e314fc1fb] of type [json] as [/tmp/colima/all-of-us-rw-prod@appspot.gserviceaccount.com-key20250107-21921-ccdvmt.json] for [all-of-us-rw-prod@appspot.gserviceaccount.com]
waiting up to 120s for cloudsql proxy to start...

Database session will be read-only; use --db-user to change this

Fetch credentials from gs://all-of-us-rw-prod-credentials/vars.env to connect through a different SQL tool
+ docker run --rm -i -t --network host --entrypoint '' mariadb:10.11.8 mysql --host=127.0.0.1 --port=3307 --user=dev-readonly --database= --password=********************
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MySQL connection id is 6024314
Server version: 8.0.31-google (Google)

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MySQL []> ^C
MySQL []> ^DBye
```


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
