### PR TITLE
[risk=no][RW-13850] Add UI to check for VWB workspace creation and show a dialog

### DIFF
--- a/ui/src/app/components/icons.tsx
+++ b/ui/src/app/components/icons.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as fp from 'lodash/fp';
 import { faCircle, faCopy } from '@fortawesome/free-regular-svg-icons';
 import {
+  faArrowUpRightFromSquare,
   faBan,
   faCaretRight,
   faCheck,
@@ -202,4 +203,8 @@ export const CommunityIcon = ({ size = 25, ...props }) => (
     style={{ width: size, height: size }}
     {...props}
   />
+);
+
+export const NewWindowIcon = (props) => (
+  <Icon shape={faArrowUpRightFromSquare} {...props} />
 );

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -343,7 +343,7 @@ export interface WorkspaceEditState {
   workspaceCreationErrorMessage: string;
   dataAppsVersion: DataAppsVersions;
   unavailableTier?: string;
-  showWorkspaceCreatedPopup?: boolean;
+  showWorkspaceCreatedModal?: boolean;
   vwbWorkspaceId?: string;
 }
 
@@ -381,7 +381,7 @@ export const WorkspaceEdit = fp.flow(
         workspaceCreationError: false,
         workspaceCreationErrorMessage: '',
         dataAppsVersion: this.initializeDataAppsVersion(props),
-        showWorkspaceCreatedPopup: false,
+        showWorkspaceCreatedModal: false,
       };
     }
 
@@ -1227,7 +1227,8 @@ export const WorkspaceEdit = fp.flow(
 
         if (workspace.vwbWorkspace) {
           this.setState({
-            showWorkspaceCreatedPopup: true,
+            showWorkspaceCreatedModal: true,
+            showConfirmationModal: false,
             loading: false,
             vwbWorkspaceId: updatedWorkspace.namespace,
           });
@@ -1510,7 +1511,7 @@ export const WorkspaceEdit = fp.flow(
         workspaceCreationError,
         workspaceCreationErrorMessage,
         unavailableTier,
-        showWorkspaceCreatedPopup,
+        showWorkspaceCreatedModal,
       } = this.state;
       const {
         cdrVersionTiersResponse,
@@ -1526,26 +1527,24 @@ export const WorkspaceEdit = fp.flow(
             {loading && (
               <SpinnerOverlay overrideStylesOverlay={styles.spinner} />
             )}
-            {showWorkspaceCreatedPopup && (
+            {showWorkspaceCreatedModal && (
               <Modal>
-                <ModalTitle>Workspace ready in Verily Workbench</ModalTitle>
+                <ModalTitle>Open in Verily Workbench</ModalTitle>
                 <ModalBody>
-                  Your workspace "{this.state.workspace.name}" has been
-                  successfully created. Start exploring your new research
-                  environment.
-                  <br />
+                  Your workspace <strong>{this.state.workspace.name}</strong> is
+                  ready. Open it in Verily Workbench to get started.
                 </ModalBody>
 
                 <ModalFooter>
                   <Button
-                    type='secondaryLight'
+                    type='secondary'
                     onClick={() => {
-                      this.setState({ showWorkspaceCreatedPopup: false });
+                      this.setState({ showWorkspaceCreatedModal: false });
                       this.props.navigate(['/workspaces']);
                     }}
-                    style={{ marginRight: '10px' }}
+                    style={{ marginRight: '10px', height: '40px' }}
                   >
-                    Stay here
+                    Back to List
                   </Button>
                   <Button
                     type='primary'
@@ -1556,9 +1555,9 @@ export const WorkspaceEdit = fp.flow(
                         'noopener noreferrer'
                       )
                     }
+                    style={{ height: '40px' }}
                   >
-                    Take me there{' '}
-                    <NewWindowIcon style={{ marginLeft: '5px' }} />
+                    Open <NewWindowIcon style={{ marginLeft: '5px' }} />
                   </Button>
                 </ModalFooter>
               </Modal>

--- a/ui/src/environments/environment-type.ts
+++ b/ui/src/environments/environment-type.ts
@@ -65,6 +65,10 @@ export interface EnvironmentBase {
   // Pass auth token in iframe url
   // WARNING: This is insecure and should only be enabled for local environments
   tanagraLocalAuth: boolean;
+
+  // The URL to use when making API requests against the vwb UI.
+  // This is used to redirect users to the vwb UI after creating a workspace.
+  vwbUiUrl: string;
 }
 
 export interface Environment extends EnvironmentBase {

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,4 +21,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 99999999999,
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: true,
+  vwbUiUrl: 'https://terra-devel-ui-terra.api.verily.com',
 };

--- a/ui/src/environments/environment.preprod.ts
+++ b/ui/src/environments/environment.preprod.ts
@@ -19,4 +19,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
+  vwbUiUrl: 'https://workbench.verily.com',
 };

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -19,4 +19,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 12 * 60 * 60, // 12 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
+  vwbUiUrl: 'https://workbench.verily.com',
 };

--- a/ui/src/environments/environment.stable.ts
+++ b/ui/src/environments/environment.stable.ts
@@ -19,4 +19,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: false,
   tanagraLocalAuth: false,
+  vwbUiUrl: 'https://workbench.verily.com',
 };

--- a/ui/src/environments/environment.staging.ts
+++ b/ui/src/environments/environment.staging.ts
@@ -19,4 +19,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: false,
+  vwbUiUrl: 'https://terra-devel-ui-terra.api.verily.com',
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,4 +23,5 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: false,
+  vwbUiUrl: 'https://terra-devel-ui-terra.api.verily.com',
 };


### PR DESCRIPTION
The dialog will guide the user to VWB

I tested the change by creating an AoU workspace which redirected correctly to the workspace screen. When I created a Verily Workbench workspace I get the dialog here:

<img width="460" alt="image" src="https://github.com/user-attachments/assets/8cc0eb31-ff74-48de-b7dc-0db0742ad1ae" />



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
