### PR TITLE
[risk=low][RW-13727] Delay new cron in higher environments, and add try/catch

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -58,10 +58,24 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
   }
 
   private void deleteUnshared(DbWorkspace dbWorkspace) {
-    var currentUsers =
-        workspaceService
-            .getFirecloudUserRoles(
-                dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
+    // this call often fails on Test.  TODO: investigate.
+    final List<UserRole> userRoles;
+    try {
+      userRoles =
+          workspaceService.getFirecloudUserRoles(
+              dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
+    } catch (WorkbenchException e) {
+      LOGGER.warning(
+          String.format(
+              "Failed to get user roles for workspace %s/%s (ID %d): %s",
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              e.getMessage()));
+      return;
+    }
+
+    var currentUsers =userRoles
             .stream()
             .map(UserRole::getEmail)
             .collect(Collectors.toSet());

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -75,10 +75,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
       return;
     }
 
-    var currentUsers =userRoles
-            .stream()
-            .map(UserRole::getEmail)
-            .collect(Collectors.toSet());
+    var currentUsers = userRoles.stream().map(UserRole::getEmail).collect(Collectors.toSet());
 
     var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
     var runtimesToDelete =

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -89,6 +89,6 @@ cron:
     Check the Runtimes, Apps, and Disks of all active Workspaces and delete those created by users
     who no longer have access to the Workspaces.
   url: /v1/cron/deleteUnsharedWorkspaceEnvironments
-  schedule: 1st mon of sep 17:00
+  schedule: 1st mon of jan 17:00
   timezone: America/Chicago
   target: api

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -89,6 +89,6 @@ cron:
     Check the Runtimes, Apps, and Disks of all active Workspaces and delete those created by users
     who no longer have access to the Workspaces.
   url: /v1/cron/deleteUnsharedWorkspaceEnvironments
-  schedule: every day 19:30
+  schedule: 1st mon of sep 17:00
   timezone: America/Chicago
   target: api

--- a/api/src/main/webapp/WEB-INF/cron_test.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_test.yaml
@@ -8,3 +8,10 @@ cron:
   schedule: every 24 hours
   timezone: UTC
   target: api
+- description: >
+    Check the Runtimes, Apps, and Disks of all active Workspaces and delete those created by users
+    who no longer have access to the Workspaces.
+  url: /v1/cron/deleteUnsharedWorkspaceEnvironments
+  schedule: every day 19:30
+  timezone: America/Chicago
+  target: api


### PR DESCRIPTION
The new `/v1/cloudTask/deleteUnsharedWorkspaceEnvironments` has a large number of failures.  Add some protections while we investigate:
* Don't run in higher environments (set to a single date well into the future)
* Add a try/catch around the problematic get user roles call

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
