### PR TITLE
[risk=low][RW-14230] Split off new GenomicDatasetService from DataSetService

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/DataSetService.java
@@ -17,7 +17,6 @@ import org.pmiops.workbench.model.DataSetPreviewRequest;
 import org.pmiops.workbench.model.DataSetRequest;
 import org.pmiops.workbench.model.DomainWithDomainValues;
 import org.pmiops.workbench.model.ResourceType;
-import org.pmiops.workbench.model.TanagraGenomicDataRequest;
 
 public interface DataSetService {
 
@@ -60,11 +59,6 @@ public interface DataSetService {
   void markDirty(long workspaceId, ResourceType resourceType, long resourceId);
 
   DataDictionaryEntry findDataDictionaryEntry(String fieldName, String domain);
-
-  List<String> getPersonIdsWithWholeGenome(DbDataset dataSet);
-
-  List<String> getTanagraPersonIdsWithWholeGenome(
-      DbWorkspace workspace, TanagraGenomicDataRequest tanagraGenomicDataRequest);
 
   List<DomainWithDomainValues> getValueListFromDomain(Long conceptSetId, String domain);
 

--- a/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetService.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetService.java
@@ -1,0 +1,14 @@
+package org.pmiops.workbench.dataset;
+
+import java.util.List;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.TanagraGenomicDataRequest;
+
+public interface GenomicDatasetService {
+
+  List<String> getPersonIdsWithWholeGenome(DbDataset dataSet);
+
+  List<String> getTanagraPersonIdsWithWholeGenome(
+      DbWorkspace workspace, TanagraGenomicDataRequest tanagraGenomicDataRequest);
+}

--- a/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetServiceImpl.java
@@ -1,0 +1,142 @@
+package org.pmiops.workbench.dataset;
+
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.common.collect.Streams;
+import com.google.gson.Gson;
+import jakarta.inject.Provider;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
+import org.pmiops.workbench.cohortbuilder.ParticipantCriteria;
+import org.pmiops.workbench.cohorts.CohortService;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.BadRequestException;
+import org.pmiops.workbench.model.CohortDefinition;
+import org.pmiops.workbench.model.CriteriaType;
+import org.pmiops.workbench.model.DataSetRequest;
+import org.pmiops.workbench.model.Domain;
+import org.pmiops.workbench.model.SearchGroup;
+import org.pmiops.workbench.model.SearchGroupItem;
+import org.pmiops.workbench.model.SearchParameter;
+import org.pmiops.workbench.model.TanagraGenomicDataRequest;
+import org.pmiops.workbench.tanagra.ApiException;
+import org.pmiops.workbench.tanagra.api.TanagraApi;
+import org.pmiops.workbench.tanagra.model.ExportPreviewRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GenomicDatasetServiceImpl implements GenomicDatasetService {
+  private final BigQueryService bigQueryService;
+  private final CohortService cohortService;
+  private final CohortQueryBuilder cohortQueryBuilder;
+  private final Provider<TanagraApi> tanagraApiProvider;
+
+  public GenomicDatasetServiceImpl(
+      BigQueryService bigQueryService,
+      CohortService cohortService,
+      CohortQueryBuilder cohortQueryBuilder,
+      Provider<TanagraApi> tanagraApiProvider) {
+    this.bigQueryService = bigQueryService;
+    this.cohortService = cohortService;
+    this.cohortQueryBuilder = cohortQueryBuilder;
+    this.tanagraApiProvider = tanagraApiProvider;
+  }
+
+  @Override
+  public List<String> getPersonIdsWithWholeGenome(DbDataset dataSet) {
+    List<ParticipantCriteria> participantCriteriaList;
+    if (Boolean.TRUE.equals(dataSet.getIncludesAllParticipants())) {
+      // Select all participants with WGS data.
+      participantCriteriaList =
+          List.of(
+              new ParticipantCriteria(
+                  new CohortDefinition().addIncludesItem(createHasWgsSearchGroup())));
+    } else {
+      participantCriteriaList =
+          cohortService.findAllByCohortIdIn(dataSet.getCohortIds()).stream()
+              .map(
+                  cohort -> {
+                    final CohortDefinition cohortDefinition =
+                        new Gson().fromJson(cohort.getCriteria(), CohortDefinition.class);
+                    // AND the existing search criteria with participants having genomics data.
+                    cohortDefinition.addIncludesItem(createHasWgsSearchGroup());
+                    return new ParticipantCriteria(cohortDefinition);
+                  })
+              .toList();
+    }
+
+    final QueryJobConfiguration participantIdQuery =
+        cohortQueryBuilder.buildUnionedParticipantIdQuery(participantCriteriaList);
+
+    return Streams.stream(
+            bigQueryService
+                .executeQuery(bigQueryService.filterBigQueryConfig(participantIdQuery))
+                .getValues())
+        .map(personId -> personId.get(0).getValue().toString())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<String> getTanagraPersonIdsWithWholeGenome(
+      DbWorkspace workspace, TanagraGenomicDataRequest tanagraGenomicDataRequest) {
+    List<ParticipantCriteria> participantCriteriaList;
+    final QueryJobConfiguration participantIdQuery;
+    if (Boolean.TRUE.equals(tanagraGenomicDataRequest.isAllParticipants())) {
+      // Select all participants with WGS data.
+      participantCriteriaList =
+          List.of(
+              new ParticipantCriteria(
+                  new CohortDefinition().addIncludesItem(createHasWgsSearchGroup())));
+      participantIdQuery =
+          cohortQueryBuilder.buildUnionedParticipantIdQuery(participantCriteriaList);
+    } else {
+      try {
+        DataSetRequest dataSetRequest =
+            new DataSetRequest()
+                .tanagraCohortIds(tanagraGenomicDataRequest.getCohortIds())
+                .tanagraFeatureSetIds(tanagraGenomicDataRequest.getFeatureSetIds());
+        ExportPreviewRequest exportPreviewRequest =
+            createExportPreviewRequest(dataSetRequest, workspace);
+        String underlayName = "aou" + workspace.getCdrVersion().getBigqueryDataset();
+        String cohortsQuery =
+            tanagraApiProvider
+                .get()
+                .describeExport(exportPreviewRequest, underlayName)
+                .getEntityIdSql();
+        participantIdQuery = cohortQueryBuilder.buildTanagraWGSPersonIdQuery(cohortsQuery);
+      } catch (ApiException e) {
+        throw new BadRequestException("Bad Request: " + e.getMessage());
+      }
+    }
+
+    return Streams.stream(
+            bigQueryService
+                .executeQuery(bigQueryService.filterBigQueryConfig(participantIdQuery))
+                .getValues())
+        .map(personId -> personId.get(0).getValue().toString())
+        .toList();
+  }
+
+  private SearchGroup createHasWgsSearchGroup() {
+    return new SearchGroup()
+        .items(
+            List.of(
+                new SearchGroupItem()
+                    .type(Domain.WHOLE_GENOME_VARIANT.toString())
+                    .addSearchParametersItem(
+                        new SearchParameter()
+                            .domain(Domain.WHOLE_GENOME_VARIANT.toString())
+                            .type(CriteriaType.PPI.toString())
+                            .group(false))));
+  }
+
+  private ExportPreviewRequest createExportPreviewRequest(
+      DataSetRequest dataSetRequest, DbWorkspace dbWorkspace) {
+    return new ExportPreviewRequest()
+        .study(dbWorkspace.getWorkspaceNamespace())
+        .cohorts(dataSetRequest.getTanagraCohortIds())
+        .featureSets(dataSetRequest.getTanagraFeatureSetIds());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/dataset/GenomicDatasetServiceImpl.java
@@ -49,10 +49,8 @@ public class GenomicDatasetServiceImpl implements GenomicDatasetService {
     List<ParticipantCriteria> participantCriteriaList;
     if (Boolean.TRUE.equals(dataSet.getIncludesAllParticipants())) {
       // Select all participants with WGS data.
-      participantCriteriaList =
-          List.of(
-              new ParticipantCriteria(
-                  new CohortDefinition().addIncludesItem(createHasWgsSearchGroup())));
+      var cd = new CohortDefinition().addIncludesItem(createHasWgsSearchGroup());
+      participantCriteriaList = List.of(new ParticipantCriteria(cd));
     } else {
       participantCriteriaList =
           cohortService.findAllByCohortIdIn(dataSet.getCohortIds()).stream()

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig.VersionedConfig;
-import org.pmiops.workbench.dataset.DataSetService;
+import org.pmiops.workbench.dataset.GenomicDatasetService;
 import org.pmiops.workbench.db.dao.WgsExtractCromwellSubmissionDao;
 import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbUser;
@@ -75,8 +75,8 @@ public class GenomicExtractionService {
 
   private static final int EARLIEST_SUPPORTED_LEGACY_METHOD_VERSION = 3;
 
-  private final DataSetService dataSetService;
   private final FireCloudService fireCloudService;
+  private final GenomicDatasetService genomicDatasetService;
   private final JiraService jiraService;
   private final Provider<CloudStorageClient> extractionServiceAccountCloudStorageClientProvider;
   private final Provider<SubmissionsApi> submissionApiProvider;
@@ -90,8 +90,8 @@ public class GenomicExtractionService {
 
   @Autowired
   public GenomicExtractionService(
-      DataSetService dataSetService,
       FireCloudService fireCloudService,
+      GenomicDatasetService genomicDatasetService,
       JiraService jiraService,
       @Qualifier(StorageConfig.GENOMIC_EXTRACTION_STORAGE_CLIENT)
           Provider<CloudStorageClient> extractionServiceAccountCloudStorageClientProvider,
@@ -103,8 +103,8 @@ public class GenomicExtractionService {
       Provider<WorkbenchConfig> workbenchConfigProvider,
       WorkspaceAuthService workspaceAuthService,
       Clock clock) {
-    this.dataSetService = dataSetService;
     this.fireCloudService = fireCloudService;
+    this.genomicDatasetService = genomicDatasetService;
     this.jiraService = jiraService;
     this.submissionApiProvider = submissionsApiProvider;
     this.extractionServiceAccountCloudStorageClientProvider =
@@ -413,9 +413,9 @@ public class GenomicExtractionService {
 
     List<String> personIds =
         isTanagraEnabled
-            ? dataSetService.getTanagraPersonIdsWithWholeGenome(
+            ? genomicDatasetService.getTanagraPersonIdsWithWholeGenome(
                 workspace, tanagraGenomicDataRequest)
-            : dataSetService.getPersonIdsWithWholeGenome(dataSet);
+            : genomicDatasetService.getPersonIdsWithWholeGenome(dataSet);
     if (personIds.isEmpty()) {
       throw new FailedPreconditionException(
           "provided cohort contains no participants with whole genome data");

--- a/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/DataSetServiceTest.java
@@ -3,7 +3,6 @@ package org.pmiops.workbench.dataset;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -524,35 +523,6 @@ public class DataSetServiceTest {
         dataSetServiceImpl.findDataDictionaryEntry("gender", "PERSON");
     assertThat(dataDictionaryEntry).isNotNull();
     assertThat(dataDictionaryEntry.getDescription()).isEqualTo("Gender testing");
-  }
-
-  @Test
-  public void testGetPersonIdsWithWholeGenome_cohorts() {
-    mockPersonIdQuery();
-    DbCohort cohort2 = cohortDao.save(buildSimpleCohort(workspace));
-
-    DbDataset dataset = new DbDataset();
-    dataset.setCohortIds(ImmutableList.of(cohort.getCohortId(), cohort2.getCohortId()));
-    dataSetServiceImpl.getPersonIdsWithWholeGenome(dataset);
-
-    // Two participant criteria, one per cohort.
-    verify(mockCohortQueryBuilder)
-        .buildUnionedParticipantIdQuery(argThat(criteriaList -> criteriaList.size() == 2));
-  }
-
-  @Test
-  public void testGetPersonIdsWithWholeGenome_allParticipants() {
-    mockPersonIdQuery();
-
-    DbDataset dataset = new DbDataset();
-    dataset.setIncludesAllParticipants(true);
-    dataSetServiceImpl.getPersonIdsWithWholeGenome(dataset);
-
-    // Expect one participant criteria: "has WGS".
-    // Note: this is dipping too much into implementation, but options are limited with the high
-    // amount of mocking in this test.
-    verify(mockCohortQueryBuilder)
-        .buildUnionedParticipantIdQuery(argThat(criteriaList -> criteriaList.size() == 1));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/dataset/GenomicDatasetServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/dataset/GenomicDatasetServiceTest.java
@@ -1,0 +1,149 @@
+package org.pmiops.workbench.dataset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValue.Attribute;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.TableResult;
+import com.google.gson.Gson;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.api.BigQueryService;
+import org.pmiops.workbench.cohortbuilder.CohortQueryBuilder;
+import org.pmiops.workbench.cohorts.CohortMapperImpl;
+import org.pmiops.workbench.cohorts.CohortService;
+import org.pmiops.workbench.db.dao.CohortDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.model.CohortDefinition;
+import org.pmiops.workbench.test.CohortDefinitions;
+import org.pmiops.workbench.utils.mappers.CommonMappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Import({
+  CohortMapperImpl.class,
+  CohortService.class,
+  CommonMappers.class,
+  FakeClockConfiguration.class,
+  GenomicDatasetServiceImpl.class,
+})
+public class GenomicDatasetServiceTest {
+
+  private static final QueryJobConfiguration QUERY_JOB_CONFIGURATION_1 =
+      QueryJobConfiguration.newBuilder(
+              "SELECT person_id FROM `${projectId}.${dataSetId}.person` person")
+          .addNamedParameter(
+              "foo",
+              QueryParameterValue.newBuilder()
+                  .setType(StandardSQLTypeName.INT64)
+                  .setValue(Long.toString(101L))
+                  .build())
+          .build();
+
+  @Autowired private GenomicDatasetServiceImpl genomicDatasetService;
+
+  @Autowired private CohortDao cohortDao;
+  @Autowired private UserDao userDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @MockBean private CohortQueryBuilder mockCohortQueryBuilder;
+  @MockBean private BigQueryService mockBigQueryService;
+
+  private DbCohort cohort;
+  private DbWorkspace workspace;
+
+  @BeforeEach
+  public void setUp() {
+    workspace = workspaceDao.save(new DbWorkspace());
+    cohort = cohortDao.save(buildSimpleCohort(workspace));
+    when(mockCohortQueryBuilder.buildParticipantIdQuery(any()))
+        .thenReturn(QUERY_JOB_CONFIGURATION_1);
+  }
+
+  @Test
+  public void testGetPersonIdsWithWholeGenome_cohorts() {
+    mockPersonIdQuery();
+    DbCohort cohort2 = cohortDao.save(buildSimpleCohort(workspace));
+
+    DbDataset dataset = new DbDataset();
+    dataset.setCohortIds(List.of(cohort.getCohortId(), cohort2.getCohortId()));
+    genomicDatasetService.getPersonIdsWithWholeGenome(dataset);
+
+    // Two participant criteria, one per cohort.
+    verify(mockCohortQueryBuilder)
+        .buildUnionedParticipantIdQuery(argThat(criteriaList -> criteriaList.size() == 2));
+  }
+
+  @Test
+  public void testGetPersonIdsWithWholeGenome_allParticipants() {
+    mockPersonIdQuery();
+
+    DbDataset dataset = new DbDataset();
+    dataset.setIncludesAllParticipants(true);
+    genomicDatasetService.getPersonIdsWithWholeGenome(dataset);
+
+    // Expect one participant criteria: "has WGS".
+    // Note: this is dipping too much into implementation, but options are limited with the high
+    // amount of mocking in this test.
+    verify(mockCohortQueryBuilder)
+        .buildUnionedParticipantIdQuery(argThat(criteriaList -> criteriaList.size() == 1));
+  }
+
+  private void mockPersonIdQuery() {
+    final TableResult tableResultMock = mock(TableResult.class);
+
+    final FieldList schema = FieldList.of(List.of(Field.of("person_id", LegacySQLTypeName.STRING)));
+
+    doReturn(
+            List.of(
+                FieldValueList.of(List.of(FieldValue.of(Attribute.PRIMITIVE, "1")), schema),
+                FieldValueList.of(List.of(FieldValue.of(Attribute.PRIMITIVE, "2")), schema)))
+        .when(tableResultMock)
+        .getValues();
+
+    doReturn(tableResultMock).when(mockBigQueryService).executeQuery(any());
+  }
+
+  private DbCohort buildSimpleCohort(DbWorkspace workspace) {
+    final CohortDefinition cohortDefinition = CohortDefinitions.males();
+    final String cohortCriteria = new Gson().toJson(cohortDefinition);
+
+    final DbCohort cohortDbModel = new DbCohort();
+    cohortDbModel.setType("foo");
+    cohortDbModel.setWorkspaceId(workspace.getWorkspaceId());
+    cohortDbModel.setCriteria(cohortCriteria);
+    cohortDbModel.setCreator(buildUser());
+    return cohortDbModel;
+  }
+
+  private DbUser buildUser() {
+    DbUser dbUser = new DbUser();
+    dbUser.setFamilyName("Family Name");
+    dbUser.setContactEmail("xyz@mock.com");
+    return userDao.save(dbUser);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.dataset.DataSetService;
+import org.pmiops.workbench.dataset.GenomicDatasetService;
 import org.pmiops.workbench.db.dao.CdrVersionDao;
 import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -99,7 +99,7 @@ public class GenomicExtractionServiceTest {
   @Autowired WgsExtractCromwellSubmissionDao wgsExtractCromwellSubmissionDao;
   @Autowired WorkspaceDao workspaceDao;
 
-  @MockBean DataSetService mockDataSetService;
+  @MockBean GenomicDatasetService mockGenomicDatasetService;
   @MockBean FireCloudService mockFireCloudService;
   @MockBean JiraService mockJiraService;
   @MockBean MethodConfigurationsApi mockMethodConfigurationsApi;
@@ -457,7 +457,8 @@ public class GenomicExtractionServiceTest {
 
   @Test
   public void submitExtractionJob() throws ApiException {
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(List.of("1", "2", "3"));
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any()))
+        .thenReturn(List.of("1", "2", "3"));
     genomicExtractionService.submitGenomicExtractionJob(targetWorkspace, dataset, null);
 
     ArgumentCaptor<FirecloudMethodConfiguration> argument =
@@ -486,7 +487,7 @@ public class GenomicExtractionServiceTest {
 
   @Test
   public void submitExtractionJob_outputVcfsInCorrectBucket() throws ApiException {
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(List.of("1"));
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any())).thenReturn(List.of("1"));
     genomicExtractionService.submitGenomicExtractionJob(targetWorkspace, dataset, null);
 
     ArgumentCaptor<FirecloudMethodConfiguration> argument =
@@ -505,7 +506,8 @@ public class GenomicExtractionServiceTest {
   public void submitExtractionJob_many() throws ApiException {
     final List<String> largePersonIdList =
         LongStream.range(1, 376).boxed().map(Object::toString).toList();
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(largePersonIdList);
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any()))
+        .thenReturn(largePersonIdList);
     genomicExtractionService.submitGenomicExtractionJob(targetWorkspace, dataset, null);
 
     ArgumentCaptor<FirecloudMethodConfiguration> argument =
@@ -520,7 +522,8 @@ public class GenomicExtractionServiceTest {
 
   @Test
   public void submitExtractionJob_v8() throws ApiException {
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(List.of("1", "2", "3"));
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any()))
+        .thenReturn(List.of("1", "2", "3"));
 
     DbCdrVersion cdrV8 =
         cdrVersionDao.save(
@@ -546,7 +549,8 @@ public class GenomicExtractionServiceTest {
 
   @Test
   public void submitExtractionJob_noWgsData() {
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(Collections.emptyList());
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any()))
+        .thenReturn(Collections.emptyList());
 
     assertThrows(
         FailedPreconditionException.class,
@@ -557,7 +561,8 @@ public class GenomicExtractionServiceTest {
   public void submitExtractionJob_tooManySamples() {
     final List<String> largePersonIdList =
         LongStream.range(1, 6_000).boxed().map(Object::toString).toList();
-    when(mockDataSetService.getPersonIdsWithWholeGenome(any())).thenReturn(largePersonIdList);
+    when(mockGenomicDatasetService.getPersonIdsWithWholeGenome(any()))
+        .thenReturn(largePersonIdList);
 
     assertThrows(
         FailedPreconditionException.class,

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -99,8 +99,8 @@ public class GenomicExtractionServiceTest {
   @Autowired WgsExtractCromwellSubmissionDao wgsExtractCromwellSubmissionDao;
   @Autowired WorkspaceDao workspaceDao;
 
-  @MockBean GenomicDatasetService mockGenomicDatasetService;
   @MockBean FireCloudService mockFireCloudService;
+  @MockBean GenomicDatasetService mockGenomicDatasetService;
   @MockBean JiraService mockJiraService;
   @MockBean MethodConfigurationsApi mockMethodConfigurationsApi;
   @MockBean SubmissionsApi mockSubmissionsApi;
@@ -115,10 +115,10 @@ public class GenomicExtractionServiceTest {
   @TestConfiguration
   @Import({
     AccessTierServiceImpl.class,
-    GenomicExtractionService.class,
-    GenomicExtractionMapperImpl.class,
     CommonMappers.class,
-    WorkspaceAuthService.class
+    GenomicExtractionMapperImpl.class,
+    GenomicExtractionService.class,
+    WorkspaceAuthService.class,
   })
   static class Configuration {
     @Bean


### PR DESCRIPTION
DataSetService does a lot, and the GenomicExtractionService only needs a small piece of it.  Instead depend on this new GenomicDatasetService.  Alt: bring this in to GenomicExtractionService?

Motivated by running into Spring dependency issues from needing to include DataSetService while prototyping a "run genomic extraction" tool.

Tested locally by running a Genomic Extraction.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
