### PR TITLE
[risk=low][no ticket] Let Spring handle its own dependencies

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,6 +20,9 @@ buildscript {
     // External properties on the default project. Values declared in ext blocks
     // outside of the buildscript block aren't usable here.
     ext {
+        // Note: Spring versions are handled by plugins.
+        // See the plugins and dependencyManagement blocks below.
+
         GAE_VERSION = '2.0.31'
         GOOGLE_AUTH_LIBRARY_VERSION = '1.30.1'
         GSON_VERSION = '2.11.0'
@@ -36,9 +39,6 @@ buildscript {
         OPENTELEMETRY_JAVA_VERSION = '2.8.0'
         OPENTELEMETRY_GOOGLE_VERSION = '0.34.0'
         SPRINGFOX_VERSION = '3.0.0'
-        SPRING_BOOT_VERSION = '3.4.3'
-        SPRING_FRAMEWORK_VERSION = '6.2.4'
-        SPRING_SECURITY_VERSION = '6.4.4'
         SWAGGER_VERSION = '2.2.29'
     }
 
@@ -53,7 +53,10 @@ plugins {
     id 'java'
     id 'war'
 
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'io.spring.dependency-management' version '1.1.7'
+    // keep in sync with the dependencyManagement block below
+    id 'org.springframework.boot' version '3.2.12'
+
     id 'com.diffplug.spotless' version '6.23.3'
     id 'com.google.cloud.tools.appengine-appenginewebxml' version '2.8.0'
     id 'com.google.cloud.tools.jib' version '3.4.2'
@@ -68,10 +71,19 @@ plugins {
     // the newer release version and have AoU-specific modifications re-applied.
     id 'org.hidetake.swagger.generator' version '2.19.2'
     id 'org.owasp.dependencycheck' version '12.1.0'
-    id 'org.springframework.boot' version '3.2.4'
     id 'jacoco'
 }
 
+// relates to the Spring plugin io.spring.dependency-management
+// which has BOM-like properties
+dependencyManagement {
+    dependencies {
+        dependency group: 'org.springframework', name: 'spring-core', version: '6.2.4'
+        // keep in sync with the plugin block above
+        dependency group: 'org.springframework.boot', name: 'spring-boot', version: '3.2.12'
+        dependency group: 'org.springframework.security', name: 'spring-security', version: '6.4.4'
+    }
+}
 
 if (System.getenv("ADD_XLINT_DEPRECATION")) {
   allprojects {
@@ -398,6 +410,35 @@ dependencies {
     // package io.swagger.configuration does not exist
     __swaggerCodegenV3__ "io.swagger.codegen.v3:swagger-codegen-cli:3.0.56"
 
+
+    // Spring versions are set by the dependency management plugin.
+    // See the plugins and dependencyManagement blocks above.
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-tomcat'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.security:spring-security-core'
+    implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.security:spring-security-web'
+    implementation 'org.springframework:spring-aop'
+    implementation 'org.springframework:spring-aspects'
+    implementation 'org.springframework:spring-beans'
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework:spring-core'
+    implementation 'org.springframework:spring-expression'
+    implementation 'org.springframework:spring-jcl'
+    implementation 'org.springframework:spring-jdbc'
+    implementation 'org.springframework:spring-orm'
+    implementation 'org.springframework:spring-test'
+    implementation 'org.springframework:spring-tx'
+    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework:spring-webmvc'
+
+
+
     implementation "ch.qos.logback:logback-classic:$project.ext.LOGBACK_VERSION"
     implementation "ch.qos.logback:logback-core:$project.ext.LOGBACK_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$project.ext.JACKSON_VERSION"
@@ -437,7 +478,6 @@ dependencies {
     // 5.4+ results in a runtime error:
     // java.lang.NoSuchMethodError: 'void org.apache.hc.core5.http.impl.io.DefaultHttpRequestWriterFactory.<init>(org.apache.hc.core5.http.config.Http1Config)'
     implementation "org.apache.httpcomponents.client5:httpclient5:5.3.1"
-    implementation "org.springframework.boot:spring-boot-starter-validation:$project.ext.SPRING_BOOT_VERSION"
     implementation 'commons-codec:commons-codec:1.17.0'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.json:json:20250107'
@@ -486,25 +526,10 @@ dependencies {
     implementation "org.hibernate.orm:hibernate-community-dialects:$project.ext.HIBERNATE_VERSION"
 
     implementation('org.apache.tomcat:tomcat-jdbc:11.0.5')
-    implementation("org.springframework.boot:spring-boot-starter-tomcat:$project.ext.SPRING_BOOT_VERSION")
-    implementation("org.springframework.boot:spring-boot-starter-jdbc:$project.ext.SPRING_BOOT_VERSION") {
-        exclude group: 'com.zaxxer', module: 'HikariCP'
-    }
 
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa:$project.ext.SPRING_BOOT_VERSION") {
-        exclude module: 'spring-boot-starter-tomcat'
-        exclude group: 'org.slf4j', module: 'jul-to-slf4j'
-    }
 
-    implementation("org.springframework.boot:spring-boot-starter-web:$project.ext.SPRING_BOOT_VERSION") {
-        exclude module: 'spring-boot-starter-tomcat'
-        exclude group: 'org.slf4j', module: 'jul-to-slf4j'
-    }
 
-    implementation "org.springframework.retry:spring-retry:2.0.11"
-    implementation "org.springframework.security:spring-security-core:$project.ext.SPRING_SECURITY_VERSION"
-    implementation "org.springframework.security:spring-security-crypto:$project.ext.SPRING_SECURITY_VERSION"
-    implementation "org.springframework.security:spring-security-web:$project.ext.SPRING_SECURITY_VERSION"
+
 
     // updated versions of transitive dependencies to resolve vulnerabilities
 
@@ -516,24 +541,6 @@ dependencies {
     // https://www.cve.org/CVERecord?id=CVE-2023-2976
     implementation 'com.google.guava:guava:33.4.0-jre'
 
-    // https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-8707740
-    implementation 'io.netty:netty-common:4.1.118.Final'
-
-    implementation "org.springframework:spring-aop:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-aspects:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-beans:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-context:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation("org.springframework:spring-core:$project.ext.SPRING_FRAMEWORK_VERSION") {
-      exclude group: 'org.springframework', module: 'spring-jcl'
-    }
-    implementation "org.springframework:spring-expression:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-jcl:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-jdbc:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-orm:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-test:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-tx:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-web:$project.ext.SPRING_FRAMEWORK_VERSION"
-    implementation "org.springframework:spring-webmvc:$project.ext.SPRING_FRAMEWORK_VERSION"
 
     implementation "org.mapstruct:mapstruct:$project.ext.MAPSTRUCT_VERSION"
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
@@ -582,8 +589,8 @@ dependencies {
     // Dependencies for Swagger codegen-generated sources. This should include all dependencies required by Swagger's
     // default okhttp API codegen templates (see https://github.com/swagger-api/swagger-codegen/blob/v2.2.3/samples/client/petstore/spring-stubs/pom.xml)
     // plus any custom templates included in our repo under the SWAGGER_2_TEMPLATE_DIR.
-    generatedCompile "org.springframework.boot:spring-boot-starter-data-rest:$project.ext.SPRING_BOOT_VERSION"
-    generatedCompile "org.springframework.boot:spring-boot-starter-validation:$project.ext.SPRING_BOOT_VERSION"
+    generatedCompile 'org.springframework.boot:spring-boot-starter-data-rest'
+    generatedCompile 'org.springframework.boot:spring-boot-starter-validation'
     generatedCompile "io.springfox:springfox-swagger-ui:$project.ext.SPRINGFOX_VERSION"
     generatedCompile "com.squareup.okhttp3:okhttp:$project.ext.OKHTTP_VERSION"
     generatedCompile "com.squareup.okhttp3:logging-interceptor:$project.ext.OKHTTP_VERSION"
@@ -618,11 +625,9 @@ dependencies {
     testImplementation "org.liquibase:liquibase-core:$project.ext.LIQUIBASE_VERSION"
     testImplementation 'org.bitbucket.radistao.test:before-after-spring-test-runner:0.1.0'
 
-    // Test deps
-    testImplementation("org.springframework.boot:spring-boot-starter-test:$project.ext.SPRING_BOOT_VERSION") {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-        exclude group: 'com.vaadin.external.google', module: 'android-json'
-    }
+    testImplementation 'org.springframework.boot:spring-boot-test'
+    testImplementation 'org.springframework.boot:spring-boot-test-autoconfigure'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.compileJava {


### PR DESCRIPTION
Use the Spring dependency management plugin.  This allows us to stop hard-coding version numbers in many locations.

Downgrade the *specified* version of Spring Boot to match the *actual* version of Spring Boot.  See comments below.

Tested locally by running Local UI and API.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
