### PR TITLE
[no ticket][risk=no] Handle condition when a runtime is deleted while still polling.

### DIFF
--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -411,8 +411,6 @@ export class LeoRuntimeInitializer {
         this.currentRuntime = null;
         this.onPoll(null);
         if (previousRuntime?.status === RuntimeStatus.DELETING) {
-          this.currentRuntime = null;
-          this.onPoll(null);
           return this.resolve(null);
         }
       } else if (this.isClientError(e)) {

--- a/ui/src/app/utils/leo-runtime-initializer.tsx
+++ b/ui/src/app/utils/leo-runtime-initializer.tsx
@@ -403,13 +403,15 @@ export class LeoRuntimeInitializer {
           )
         );
       } else if (this.isNotFoundError(e)) {
+        /* A not-found error is somewhat expected, if a runtime has recently been deleted or
+            hasn't been created yet. */
         const previousRuntime = { ...this.currentRuntime };
+        this.currentRuntime = null;
+        this.onPoll(null);
         /* In the case where the previousRuntime is not null and its
          * status is DELETING, we should resolve the polling promise,
          * because deleting worked successfully.
          */
-        this.currentRuntime = null;
-        this.onPoll(null);
         if (previousRuntime?.status === RuntimeStatus.DELETING) {
           return this.resolve(null);
         }


### PR DESCRIPTION
In order to test this behavior, create a runtime and then immediately delete it. Previously, this was producing an error, because there was still some polling for a runtime that had been deleted.

Previous Behavior:

https://github.com/user-attachments/assets/220bcfbc-0bd8-4379-8d80-b0b5b7902ee9

New Behavior:

https://github.com/user-attachments/assets/a6a38e01-447c-4e1f-b722-c3ad75c0d47f




<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
