### PR TITLE
[risk=low][RW-14230] Explicitly set scatter count for v8 too

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -197,6 +197,7 @@ public class WorkbenchConfig {
     public static class LegacyWorkflowConfig extends VersionedConfig {
       public String gatkJarUri;
       // This should not exceed the value of GenomicExtractionService.MAX_EXTRACTION_SCATTER.
+      // TODO: move these back to the base VersionedConfig
       public int minExtractionScatterTasks;
       public float extractionScatterTasksPerSample;
     }

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -362,12 +362,12 @@ public class GenomicExtractionService {
       maybeInputs.put(
           EXTRACT_WORKFLOW_NAME + ".gatk_override",
           "\"" + cohortExtractionConfig.legacyVersions.gatkJarUri + "\"");
-
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".scatter_count", Integer.toString(scatterCount));
     } else {
-      // Added Nov 2024
+      // Added Nov 2024 for v8
       // replaces extraction_uuid and cohort_table_prefix which are now set to this value
       maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".call_set_identifier", "\"" + extractionUuid + "\"");
+      // added Jan 2025: new parameter name for scatter count override in v8
       maybeInputs.put(
           EXTRACT_WORKFLOW_NAME + ".extract_scatter_count_override",
           Integer.toString(scatterCount));

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -334,8 +334,6 @@ public class GenomicExtractionService {
       throw new ServerErrorException();
     }
 
-    Map<String, String> maybeInputs = new HashMap<>();
-    
     // Initial heuristic for scatter count, optimizing to avoid large compute/output shards while
     // keeping overhead low and limiting footprint on shared extraction quota.
     int minScatter =
@@ -347,6 +345,8 @@ public class GenomicExtractionService {
             personIds.size()
                 * cohortExtractionConfig.legacyVersions.extractionScatterTasksPerSample);
     int scatterCount = Ints.constrainToRange(desiredScatter, minScatter, MAX_EXTRACTION_SCATTER);
+
+    Map<String, String> maybeInputs = new HashMap<>();
 
     if (!Strings.isNullOrEmpty(filterSetName)) {
       // If set, apply a joint callset filter during the extraction. There may be multiple such


### PR DESCRIPTION
Running this command took [only ~45 minutes](https://app.terra.bio/#workspaces/aouwgscohortextraction-prod/aouwgscohortextractionprod/job_history/21367ed9-6ebf-4b2b-a5b1-4e6dd50cddea) on this branch
```
./project.rb run-extraction \
--project all-of-us-rw-prod \
--namespace aou-rw-a2626269 \
--dataset_id 117923 \
--person-ids "1123013,1466961" \
--legacy false \
--filter_set echo_full \
--cdr_bq_project fc-aou-cdr-prod-ct \
--wgs_bq_dataset wgs_C2024Q3
```

The [same command on main](https://app.terra.bio/#workspaces/aouwgscohortextraction-prod/aouwgscohortextractionprod/job_history/e82040ac-9f31-4813-8dc0-a5a896898e54) for comparison (TODO capture total time)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
