### PR TITLE
[risk=low][RW-13727] Add success/fail stats to delete-unshared cron

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -45,19 +45,26 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
 
     // temp timing for batch sizing
     var stopwatch = stopwatchProvider.get().start();
-    workspaceNamespaces.stream()
-        .map(workspaceService::lookupWorkspaceByNamespace)
-        .forEach(this::deleteUnshared);
+    List<DbWorkspace> failedUserRoles =
+        workspaceNamespaces.stream()
+            .map(workspaceService::lookupWorkspaceByNamespace)
+            .filter(
+                (ws) -> {
+                  boolean successUserRoles = deleteUnshared(ws);
+                  return !successUserRoles;
+                })
+            .toList();
     var elapsed = stopwatch.stop().elapsed();
     LOGGER.info(
         String.format(
-            "Deleted unshared environments for %d workspaces in %s.",
-            workspaceNamespaces.size(), formatDurationPretty(elapsed)));
+            "Attempted to delete unshared environments for %d workspaces (%d failures) in %s.",
+            workspaceNamespaces.size(), failedUserRoles.size(), formatDurationPretty(elapsed)));
 
     return ResponseEntity.ok().build();
   }
 
-  private void deleteUnshared(DbWorkspace dbWorkspace) {
+  // return success value
+  private boolean deleteUnshared(DbWorkspace dbWorkspace) {
     // this call often fails on Test.  TODO: investigate.
     final List<UserRole> userRoles;
     try {
@@ -72,7 +79,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               dbWorkspace.getFirecloudName(),
               dbWorkspace.getWorkspaceId(),
               e.getMessage()));
-      return;
+      return false;
     }
 
     var currentUsers = userRoles.stream().map(UserRole::getEmail).collect(Collectors.toSet());
@@ -169,5 +176,6 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             }
           });
     }
+    return true;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -49,9 +49,9 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
         workspaceNamespaces.stream()
             .map(workspaceService::lookupWorkspaceByNamespace)
             .filter(
-                (ws) -> {
-                  boolean successUserRoles = deleteUnshared(ws);
-                  return !successUserRoles;
+                ws -> {
+                  boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
+                  return !successfulGetFirecloudUserRoles;
                 })
             .toList();
     var elapsed = stopwatch.stop().elapsed();
@@ -63,7 +63,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
     return ResponseEntity.ok().build();
   }
 
-  // return success value
+  // return success value of getFirecloudUserRoles()
   private boolean deleteUnshared(DbWorkspace dbWorkspace) {
     // this call often fails on Test.  TODO: investigate.
     final List<UserRole> userRoles;


### PR DESCRIPTION
More debugging info for the failing deleteUnsharedWorkspaceEnvironments cron

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
