### PR TITLE
[no ticket][risk=no] Fix issue with deploy script

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -49,6 +49,5 @@ ENV PATH="/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 
 RUN gem install logger
 RUN  gem install concurrent-ruby -v 1.3.4
-# Force a lower concurrent-ruby version, as we only have Ruby 2.3.
 RUN gem install activesupport -v 6.1.4.6 --conservative
 RUN gem install jira-ruby

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -47,6 +47,8 @@ RUN curl -L -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-
   && unzip /tmp/gradle.zip -d /opt/gradle
 ENV PATH="/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 
+RUN gem install logger
+RUN  gem install concurrent-ruby -v 1.3.4
 # Force a lower concurrent-ruby version, as we only have Ruby 2.3.
-RUN gem install activesupport -v 6.1.4.6
+RUN gem install activesupport -v 6.1.4.6 --conservative
 RUN gem install jira-ruby

--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -1,5 +1,6 @@
 require "open3"
 require "set"
+require "logger"
 require_relative "../../aou-utils/serviceaccounts"
 require_relative "../../aou-utils/utils/common"
 require_relative "../../aou-utils/workbench"
@@ -34,11 +35,11 @@ def get_live_gae_version(project, validate_version=true)
   services = Set["api", "default"]
   actives = JSON.parse(versions).select{|v| v["traffic_split"] == 1.0}
   active_services = actives.map{|v| v["service"]}.to_set
-  
+
   # This is a temporary fix until these services exist in all environments
   active_services.delete("tanagra-ui")
   active_services.delete("tanagra-api")
-  
+
   if actives.empty?
     common.warning "Found 0 active GAE services in project '#{project}'"
     return nil
@@ -49,12 +50,12 @@ def get_live_gae_version(project, validate_version=true)
   end
 
   versions = actives.map{|v| v["id"]}.to_set
-  
+
   # Iterate over versions and delete any that start with "tanagra-"
   versions.each do |version|
     versions.delete(version) if version.start_with?("tanagra-")
   end
-  
+
   if versions.length != 1
     common.warning "Found varying IDs across GAE services in project '#{project}': " +
                    "[#{versions.to_a.join(', ')}]"


### PR DESCRIPTION
Recently there was a bug introduced in concurrent-ruby v1.3.5 that removed a dependency on logger. This is causing an issue with jira-ruby that results the following error:
`/var/lib/gems/3.2.0/gems/activesupport-6.1.4.6/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
          ^^^^^^^^^^
	from /var/lib/gems/3.2.0/gems/activesupport-6.1.4.6/lib/active_support/logger_thread_safe_level.rb:9:in <module:ActiveSupport>'
	from /var/lib/gems/3.2.0/gems/activesupport-6.1.4.6/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /var/lib/gems/3.2.0/gems/activesupport-6.1.4.6/lib/active_support/logger_silence.rb:5:in `<top (required)>'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /var/lib/gems/3.2.0/gems/activesupport-6.1.4.6/lib/active_support/logger.rb:3:in `<top (required)>'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:86:in `require'`

Information about the bug and fix can be found here:
https://github.com/rails/rails/pull/54264#issuecomment-2596149819 

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
