### PR TITLE
[risk=low][no ticket] Bump jakarta as far as possible

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -533,7 +533,6 @@ dependencies {
     implementation "org.springframework:spring-webmvc:$project.ext.SPRING_FRAMEWORK_VERSION"
 
     implementation "org.mapstruct:mapstruct:$project.ext.MAPSTRUCT_VERSION"
-    implementation 'jakarta.mail:jakarta.mail-api:2.1.3'
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:$project.ext.MAPSTRUCT_VERSION"
 
     // updated 13 Dec 2023 to most recent passing Sam on 13 Dec
@@ -553,22 +552,29 @@ dependencies {
     implementation "commons-logging:commons-logging:1.3.4"
 
     // jakarta
-    implementation "jakarta.servlet:jakarta.servlet-api:6.0.0"
-    implementation "jakarta.inject:jakarta.inject-api:2.0.1"
-    implementation 'jakarta.mail:jakarta.mail-api:2.1.3'
     implementation 'jakarta.activation:jakarta.activation-api:2.1.3'
     implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
+    implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
+    implementation 'jakarta.mail:jakarta.mail-api:2.1.3'
+    // upgrading to 3.2.0 causes an error
+    // Error creating bean with name 'entityManagerFactory' defined in class path resource
+    // [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: EntityManagerFactory
+    // interface [interface org.hibernate.SessionFactory] seems to conflict with Spring's EntityManagerFactoryInfo
+    // mixin - consider resetting the 'entityManagerFactoryInterface' property to plain
+    // [jakarta.persistence.EntityManagerFactory]
+    // https://stackoverflow.com/questions/78073522/spring-boot-3-2-2-entitymanagerfactory-interface-org-hibernate-sessionfactory-s
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.1.0'
+    implementation 'jakarta.validation:jakarta.validation-api:3.1.0'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
 
-    generatedCompile "jakarta.xml.bind:jakarta.xml.bind-api:4.0.1"
-    generatedCompile "jakarta.inject:jakarta.inject-api:2.0.1"
-    generatedCompile 'jakarta.mail:jakarta.mail-api:2.1.3'
     generatedCompile 'jakarta.annotation:jakarta.annotation-api:3.0.0'
+    generatedCompile 'jakarta.inject:jakarta.inject-api:2.0.1'
+    generatedCompile 'jakarta.mail:jakarta.mail-api:2.1.3'
     generatedCompile 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    generatedCompile 'jakarta.validation:jakarta.validation-api:3.0.2'
-    generatedCompile 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+    generatedCompile 'jakarta.servlet:jakarta.servlet-api:6.1.0'
+    generatedCompile 'jakarta.validation:jakarta.validation-api:3.1.0'
+    generatedCompile 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
 
     // Dependencies for Swagger codegen-generated sources. This should include all dependencies required by Swagger's
     // default okhttp API codegen templates (see https://github.com/swagger-api/swagger-codegen/blob/v2.2.3/samples/client/petstore/spring-stubs/pom.xml)
@@ -595,7 +601,7 @@ dependencies {
     generatedCompile 'io.gsonfire:gson-fire:1.9.0'
 
     // war plugin. Add this to scope of the compile configuration, but do not include in .war file.
-    providedCompile group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.0.0'
+    providedCompile group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.1.0'
 
     __tools__Implementation 'commons-cli:commons-cli:1.9.0'
     __tools__Implementation 'com.opencsv:opencsv:5.9'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -562,7 +562,7 @@ dependencies {
     // interface [interface org.hibernate.SessionFactory] seems to conflict with Spring's EntityManagerFactoryInfo
     // mixin - consider resetting the 'entityManagerFactoryInterface' property to plain
     // [jakarta.persistence.EntityManagerFactory]
-    // https://stackoverflow.com/questions/78073522/spring-boot-3-2-2-entitymanagerfactory-interface-org-hibernate-sessionfactory-s
+    // https://github.com/spring-projects/spring-boot/issues/39753
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     implementation 'jakarta.servlet:jakarta.servlet-api:6.1.0'
     implementation 'jakarta.validation:jakarta.validation-api:3.1.0'


### PR DESCRIPTION
The Jakarta family contains our final Java dependencies with >1 libyear.

Tested locally with no apparent problems.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
