### PR TITLE
[risk=low][RW-13727] Mark and skip workspaces which are inaccessible to the GAE SA

### DIFF
--- a/api/db/changelog/db.changelog-251-add-workspace_inaccessible_to_sa.xml
+++ b/api/db/changelog/db.changelog-251-add-workspace_inaccessible_to_sa.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="changelog-251-add-workspace_inaccessible_to_sa">
+    <createTable tableName="workspace_inaccessible_to_sa">
+      <column name="workspace_inaccessible_to_sa_id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="workspace_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="creation_time" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="note" type="varchar(200)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addForeignKeyConstraint
+      baseTableName="workspace_inaccessible_to_sa"
+      baseColumnNames="workspace_id"
+      referencedTableName="workspace"
+      referencedColumnNames="workspace_id"
+      constraintName="fk_workspace_inaccessible_to_sa_workspace_id"
+      onDelete="CASCADE"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -258,6 +258,7 @@
   <include file="changelog/db.changelog-248-add-public-release-number-column.xml"/>
   <include file="changelog/db.changelog-249-add-time-window-start-egress-event.xml"/>
   <include file="changelog/db.changelog-250-add-aian-research-columns.xml"/>
+  <include file="changelog/db.changelog-251-add-workspace_inaccessible_to_sa.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -202,11 +202,14 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               dbWorkspace.getWorkspaceId(),
               e.getMessage()));
 
-      workspaceDao.save(
-          dbWorkspace.setWorkspaceInaccessibleToSa(
-              new DbWorkspaceInaccessibleToSa()
-                  .setWorkspace(dbWorkspace)
-                  .setNote("Failed to get user roles")));
+      // this is not expected to be present, but check just in case, for DB integrity
+      if (dbWorkspace.getWorkspaceInaccessibleToSa() == null) {
+        var inaccessibleToSa =
+            new DbWorkspaceInaccessibleToSa()
+                .setWorkspace(dbWorkspace)
+                .setNote("Failed to get user roles");
+        workspaceDao.save(dbWorkspace.setWorkspaceInaccessibleToSa(inaccessibleToSa));
+      }
 
       return Collections.emptySet();
     }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -371,7 +371,11 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   @Override
   public ResponseEntity<Void> deleteUnsharedWorkspaceEnvironments() {
     List<String> activeNamespaces =
-        workspaceDao.getAllActive().stream().map(DbWorkspace::getWorkspaceNamespace).toList();
+        workspaceDao.getAllActive().stream()
+            // many workspaces (at least on Test) are not accessible to the GAE SA.  Skip these.
+            .filter(ws -> ws.getWorkspaceInaccessibleToSa() == null)
+            .map(DbWorkspace::getWorkspaceNamespace)
+            .toList();
     log.info(
         String.format(
             "Queuing %d active workspaces in batches for deletion of unshared resources",

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.Table;
@@ -109,6 +110,8 @@ public class DbWorkspace {
 
   private AIANResearchType aianResearchType;
   private String aianResearchDetails;
+
+  private DbWorkspaceInaccessibleToSa workspaceInaccessibleToSa;
 
   public DbWorkspace() {
     setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -825,6 +828,21 @@ public class DbWorkspace {
 
   public void setAianResearchDetails(String aianResearchDetails) {
     this.aianResearchDetails = aianResearchDetails;
+  }
+
+  @OneToOne(
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY,
+      mappedBy = "workspace")
+  public DbWorkspaceInaccessibleToSa getWorkspaceInaccessibleToSa() {
+    return workspaceInaccessibleToSa;
+  }
+
+  public DbWorkspace setWorkspaceInaccessibleToSa(
+      DbWorkspaceInaccessibleToSa workspaceInaccessibleToSa) {
+    this.workspaceInaccessibleToSa = workspaceInaccessibleToSa;
+    return this;
   }
 
   @Transient

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
@@ -1,0 +1,66 @@
+package org.pmiops.workbench.db.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Table(name = "workspace_inaccessible_to_sa")
+public class DbWorkspaceInaccessibleToSa {
+
+  private long id;
+  private DbWorkspace workspace;
+  private Timestamp creationTime;
+  private String note;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "workspace_inaccessible_to_sa_id", nullable = false)
+  public long getId() {
+    return id;
+  }
+
+  public DbWorkspaceInaccessibleToSa setId(long workspaceInaccessibleToSaId) {
+    this.id = workspaceInaccessibleToSaId;
+    return this;
+  }
+
+  @OneToOne
+  @JoinColumn(name = "workspace_id", nullable = false)
+  public DbWorkspace getWorkspace() {
+    return workspace;
+  }
+
+  public DbWorkspaceInaccessibleToSa setUser(DbWorkspace workspace) {
+    this.workspace = workspace;
+    return this;
+  }
+
+  @CreatedDate
+  @Column(name = "creation_time", nullable = false)
+  public Timestamp getCreationTime() {
+    return creationTime;
+  }
+
+  public DbWorkspaceInaccessibleToSa setCreationTime(Timestamp creationTime) {
+    this.creationTime = creationTime;
+    return this;
+  }
+
+  @Column(name = "note", nullable = false)
+  public String getNote() {
+    return note;
+  }
+
+  public DbWorkspaceInaccessibleToSa setNote(String note) {
+    this.note = note;
+    return this;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.db.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,8 +11,10 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class) // enables @CreatedDate
 @Table(name = "workspace_inaccessible_to_sa")
 public class DbWorkspaceInaccessibleToSa {
 

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspaceInaccessibleToSa.java
@@ -38,7 +38,7 @@ public class DbWorkspaceInaccessibleToSa {
     return workspace;
   }
 
-  public DbWorkspaceInaccessibleToSa setUser(DbWorkspace workspace) {
+  public DbWorkspaceInaccessibleToSa setWorkspace(DbWorkspace workspace) {
     this.workspace = workspace;
     return this;
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -231,6 +231,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "initialCreditsExhausted", ignore = true)
   @Mapping(target = "usesTanagra", ignore = true)
   @Mapping(target = "vwbWorkspace", ignore = true)
+  @Mapping(target = "workspaceInaccessibleToSa", ignore = true)
   void mergeResearchPurposeIntoWorkspace(
       @MappingTarget DbWorkspace workspace, ResearchPurpose researchPurpose);
 


### PR DESCRIPTION
When this cron runs in Test, we see very many failures because many of the supposedly-active Workspaces are not accessible to the GAE SA when making Terra calls.  (We expect the GAE SA to be an owner in Terra of all active workspaces.)  

We don't see this problem in normal app usage, because our typical pattern for a call like List Workspaces is to first ask Terra which workspaces I can see as a user, and then query the RWB DB for RWB-specific details on each.

The cron however needs to check all workspaces in an environment and does not run in the context of a user.  This is our first need for "List All Workspaces" (aside: we already have List All Runtimes and List All Disks) so it's the first time we're running into this problem.  Instead of asking Terra for the list of workspace we have access to, it starts by iterating over all workspaces in the RWB DB.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
