### PR TITLE
[risk=low][RW-13727] Get all ws as service

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -44,6 +44,7 @@ import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
 import org.pmiops.workbench.utils.BillingUtils;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
+import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -78,6 +79,7 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   private final TaskQueueService taskQueueService;
   private final UserDao userDao;
   private final WorkspaceDao workspaceDao;
+  private final WorkspaceService workspaceService;
 
   @Autowired
   OfflineEnvironmentsController(
@@ -90,7 +92,8 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
       Provider<WorkbenchConfig> configProvider,
       TaskQueueService taskQueueService,
       UserDao userDao,
-      WorkspaceDao workspaceDao) {
+      WorkspaceDao workspaceDao,
+      WorkspaceService workspaceService) {
     this.clock = clock;
     this.configProvider = configProvider;
     this.fireCloudService = firecloudService;
@@ -101,6 +104,7 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
     this.taskQueueService = taskQueueService;
     this.userDao = userDao;
     this.workspaceDao = workspaceDao;
+    this.workspaceService = workspaceService;
   }
 
   /**
@@ -371,7 +375,9 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   @Override
   public ResponseEntity<Void> deleteUnsharedWorkspaceEnvironments() {
     List<String> activeNamespaces =
-        workspaceDao.getAllActive().stream().map(DbWorkspace::getWorkspaceNamespace).toList();
+        workspaceService.getWorkspacesAsService().stream()
+            .map(ws -> ws.getWorkspace().getNamespace())
+            .toList();
     log.info(
         String.format(
             "Queuing %d active workspaces in batches for deletion of unshared resources",

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -114,6 +114,8 @@ public interface FireCloudService {
 
   List<RawlsWorkspaceListResponse> getWorkspaces();
 
+  List<RawlsWorkspaceListResponse> getWorkspacesAsService();
+
   void deleteWorkspace(String workspaceNamespace, String firecloudName);
 
   FirecloudManagedGroupWithMembers getGroup(String groupName);

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -479,6 +479,15 @@ public class FireCloudServiceImpl implements FireCloudService {
   }
 
   @Override
+  public List<RawlsWorkspaceListResponse> getWorkspacesAsService() {
+    return rawlsRetryHandler.run(
+        (context) ->
+            serviceAccountWorkspaceApiProvider
+                .get()
+                .listWorkspaces(FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
+  }
+
+  @Override
   public void deleteWorkspace(String workspaceNamespace, String firecloudName) {
     retryHandler.run(
         (context) -> {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -95,6 +95,7 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
 
   @Override
   public List<WorkspaceResponse> getWorkspacesAsService() {
+    logger.warn("getWorkspacesAsService not implemented in VWB");
     return Collections.emptyList();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -94,6 +94,11 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  public List<WorkspaceResponse> getWorkspacesAsService() {
+    return Collections.emptyList();
+  }
+
+  @Override
   public List<WorkspaceResponse> getFeaturedWorkspaces() {
     logger.warn("getFeaturedWorkspaces not implemented in VWB");
     return Collections.emptyList();

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -35,6 +35,8 @@ public interface WorkspaceService {
 
   List<WorkspaceResponse> getWorkspaces();
 
+  List<WorkspaceResponse> getWorkspacesAsService();
+
   /**
    * Get all Featured workspaces from the DB.
    *

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -183,6 +183,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  public List<WorkspaceResponse> getWorkspacesAsService() {
+    return workspaceMapper.toApiWorkspaceResponseList(
+        workspaceDao, fireCloudService.getWorkspacesAsService(), initialCreditsService);
+  }
+
+  @Override
   public String getPublishedWorkspacesGroupEmail() {
     // All users with CT access also have RT access, so we know that any user with access to
     // workspaces will be a member of the RT Auth Domain Group.  Therefore, we can use this group


### PR DESCRIPTION
When this cron runs in Test, we see very many failures because many of the supposedly-active Workspaces are not accessible to the GAE SA when making Terra calls. (We expect the GAE SA to be an owner in Terra of all active workspaces.)

We don't see this problem in normal app usage, because our typical pattern for a call like List Workspaces is to first ask Terra which workspaces I can see as a user, and then query the RWB DB for RWB-specific details on each.

The cron however needs to check all workspaces in an environment and does not run in the context of a user. This is our first need for "List All Workspaces" (aside: we already have List All Runtimes and List All Disks) so it's the first time we're running into this problem. Instead of asking Terra for the list of workspace we have access to, it starts by iterating over all workspaces in the RWB DB.

This PR switches that logic to match our standard practice: first ask Terra about all the workspaces the SA has access to, and then iterate.  Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
