### PR TITLE
[no ticket][risk=no] Remove billing status from api and db.

### DIFF
--- a/api/db/changelog/db.changelog-251-remove-billing-status.xml
+++ b/api/db/changelog/db.changelog-251-remove-billing-status.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="eric" id="db.changelog-251-remove-billing-status">
+    <dropColumn tableName="workspace" columnName="billing_status"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -258,6 +258,7 @@
   <include file="changelog/db.changelog-248-add-public-release-number-column.xml"/>
   <include file="changelog/db.changelog-249-add-time-window-start-egress-event.xml"/>
   <include file="changelog/db.changelog-250-add-aian-research-columns.xml"/>
+  <include file="changelog/db.changelog-251-remove-billing-status.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -28,6 +28,7 @@ import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.RecentResourceRequest;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.model.WorkspaceResource;
@@ -58,6 +59,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
   private final DataSetService dataSetService;
   private final CohortService cohortService;
   private final CohortReviewService cohortReviewService;
+  private final InitialCreditsService initialCreditsService;
 
   private int distinctWorkspaceLimit = 5;
 
@@ -73,7 +75,8 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       UserRecentResourceService userRecentResourceService,
       WorkspaceAuthService workspaceAuthService,
       WorkspaceDao workspaceDao,
-      WorkspaceResourceMapper workspaceResourceMapper) {
+      WorkspaceResourceMapper workspaceResourceMapper,
+      InitialCreditsService initialCreditsService) {
     this.cloudStorageClient = cloudStorageClient;
     this.cohortService = cohortService;
     this.cohortReviewService = cohortReviewService;
@@ -85,6 +88,7 @@ public class UserMetricsController implements UserMetricsApiDelegate {
     this.workspaceAuthService = workspaceAuthService;
     this.workspaceDao = workspaceDao;
     this.workspaceResourceMapper = workspaceResourceMapper;
+    this.initialCreditsService = initialCreditsService;
   }
 
   @VisibleForTesting
@@ -276,7 +280,8 @@ public class UserMetricsController implements UserMetricsApiDelegate {
         conceptSetService,
         dataSetService,
         cloudStorageClient,
-        workspaceUsers);
+        workspaceUsers,
+        initialCreditsService);
   }
 
   private Optional<BlobId> uriToBlobId(String uri) {

--- a/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserMetricsController.java
@@ -71,24 +71,24 @@ public class UserMetricsController implements UserMetricsApiDelegate {
       ConceptSetService conceptSetService,
       DataSetService dataSetService,
       FireCloudService fireCloudService,
+      InitialCreditsService initialCreditsService,
       Provider<DbUser> userProvider,
       UserRecentResourceService userRecentResourceService,
       WorkspaceAuthService workspaceAuthService,
       WorkspaceDao workspaceDao,
-      WorkspaceResourceMapper workspaceResourceMapper,
-      InitialCreditsService initialCreditsService) {
+      WorkspaceResourceMapper workspaceResourceMapper) {
     this.cloudStorageClient = cloudStorageClient;
     this.cohortService = cohortService;
     this.cohortReviewService = cohortReviewService;
     this.conceptSetService = conceptSetService;
     this.dataSetService = dataSetService;
     this.fireCloudService = fireCloudService;
+    this.initialCreditsService = initialCreditsService;
     this.userProvider = userProvider;
     this.userRecentResourceService = userRecentResourceService;
     this.workspaceAuthService = workspaceAuthService;
     this.workspaceDao = workspaceDao;
     this.workspaceResourceMapper = workspaceResourceMapper;
-    this.initialCreditsService = initialCreditsService;
   }
 
   @VisibleForTesting

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.pmiops.workbench.db.model.DbFeaturedWorkspace.DbFeaturedCategory;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.DisseminateResearchEnum;
 import org.pmiops.workbench.model.ResearchOutcomeEnum;
 import org.pmiops.workbench.model.SpecificPopulationEnum;
@@ -93,7 +92,6 @@ public class DbWorkspace {
   private Boolean reviewRequested;
   private Boolean approved;
   private Timestamp timeRequested;
-  private Short billingStatus = DbStorageEnums.billingStatusToStorage(BillingStatus.ACTIVE);
   private String billingAccountName;
   private String googleProject;
   private boolean adminLocked;
@@ -650,19 +648,6 @@ public class DbWorkspace {
   @Transient
   public boolean isActive() {
     return WorkspaceActiveStatus.ACTIVE.equals(getWorkspaceActiveStatusEnum());
-  }
-
-  @Deprecated(since = "September 2024", forRemoval = true)
-  @Column(name = "billing_status")
-  public BillingStatus getBillingStatus() {
-    return (initialCreditsExhausted || initialCreditsExpired
-        ? BillingStatus.INACTIVE
-        : BillingStatus.ACTIVE);
-  }
-
-  public DbWorkspace setBillingStatus(BillingStatus billingStatus) {
-    this.billingStatus = DbStorageEnums.billingStatusToStorage(billingStatus);
-    return this;
   }
 
   @Column(name = "billing_account_name")

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -368,7 +368,7 @@ public class InitialCreditsService {
   }
 
   public DbUser extendInitialCreditsExpiration(DbUser user) {
-    if(!workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration) {
+    if (!workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration) {
       throw new BadRequestException("Initial credits extension is disabled.");
     }
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -36,7 +36,6 @@ import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.utils.BillingUtils;
 import org.pmiops.workbench.utils.CostComparisonUtils;
 import org.slf4j.Logger;
@@ -454,7 +453,6 @@ public class InitialCreditsService {
         .forEach(
             ws -> {
               ws.setInitialCreditsExpired(true);
-              ws.setBillingStatus(BillingStatus.INACTIVE);
               workspaceDao.save(ws);
               deleteAppsAndRuntimesInWorkspace(ws);
             });
@@ -513,7 +511,6 @@ public class InitialCreditsService {
         .forEach(
             ws -> {
               ws.setInitialCreditsExhausted(false);
-              ws.setBillingStatus(BillingStatus.ACTIVE);
               workspaceDao.save(ws);
             });
   }

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -368,6 +368,9 @@ public class InitialCreditsService {
   }
 
   public DbUser extendInitialCreditsExpiration(DbUser user) {
+    if(!workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration) {
+      throw new BadRequestException("Initial credits extension is disabled.");
+    }
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();
     // This handles the case existing users that have not yet been migrated but also those who have

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -282,10 +282,12 @@ public class InitialCreditsService {
    *     institutionally.
    */
   public Optional<Timestamp> getCreditsExpiration(DbUser user) {
-    return Optional.ofNullable(user.getUserInitialCreditsExpiration())
-        .filter(exp -> !exp.isBypassed()) // If the expiration is bypassed, return empty.
-        .filter(exp -> !institutionService.shouldBypassForCreditsExpiration(user))
-        .map(DbUserInitialCreditsExpiration::getExpirationTime);
+    return workbenchConfigProvider.get().featureFlags.enableInitialCreditsExpiration
+        ? Optional.ofNullable(user.getUserInitialCreditsExpiration())
+            .filter(exp -> !exp.isBypassed()) // If the expiration is bypassed, return empty.
+            .filter(exp -> !institutionService.shouldBypassForCreditsExpiration(user))
+            .map(DbUserInitialCreditsExpiration::getExpirationTime)
+        : Optional.empty();
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -143,9 +143,11 @@ public class CommonMappers {
   }
 
   @Named("getBillingStatus")
-  public BillingStatus getBillingStatus(DbWorkspace dbWorkspace, @Context InitialCreditsService initialCreditsService) {
+  public BillingStatus getBillingStatus(
+      DbWorkspace dbWorkspace, @Context InitialCreditsService initialCreditsService) {
     return (isInitialCredits(dbWorkspace.getBillingAccountName(), workbenchConfigProvider.get())
-            && (dbWorkspace.isInitialCreditsExhausted() || initialCreditsService.areUserCreditsExpired(dbWorkspace.getCreator())))
+            && (dbWorkspace.isInitialCreditsExhausted()
+                || initialCreditsService.areUserCreditsExpired(dbWorkspace.getCreator())))
         ? BillingStatus.INACTIVE
         : BillingStatus.ACTIVE;
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/CommonMappers.java
@@ -143,9 +143,9 @@ public class CommonMappers {
   }
 
   @Named("getBillingStatus")
-  public BillingStatus getBillingStatus(DbWorkspace dbWorkspace) {
+  public BillingStatus getBillingStatus(DbWorkspace dbWorkspace, @Context InitialCreditsService initialCreditsService) {
     return (isInitialCredits(dbWorkspace.getBillingAccountName(), workbenchConfigProvider.get())
-            && (dbWorkspace.isInitialCreditsExhausted() || dbWorkspace.isInitialCreditsExpired()))
+            && (dbWorkspace.isInitialCreditsExhausted() || initialCreditsService.areUserCreditsExpired(dbWorkspace.getCreator())))
         ? BillingStatus.INACTIVE
         : BillingStatus.ACTIVE;
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -205,7 +205,6 @@ public interface WorkspaceMapper {
   @Mapping(target = "adminLockedReason", ignore = true)
   @Mapping(target = "approved", ignore = true)
   @Mapping(target = "billingAccountName", ignore = true)
-  @Mapping(target = "billingStatus", ignore = true)
   @Mapping(target = "cdrVersion", ignore = true)
   @Mapping(target = "cohorts", ignore = true)
   @Mapping(target = "conceptSets", ignore = true)

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -32,7 +32,15 @@ import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentWorkspaceDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.model.*;
+import org.pmiops.workbench.db.model.DbAccessTier;
+import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.db.model.DbCohort;
+import org.pmiops.workbench.db.model.DbConceptSet;
+import org.pmiops.workbench.db.model.DbDataset;
+import org.pmiops.workbench.db.model.DbFeaturedWorkspace;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbUserRecentWorkspace;
+import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
@@ -42,7 +50,6 @@ import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.Workspace;
@@ -483,14 +490,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       DbUser creator = workspace.getCreator();
       boolean hasInitialCreditsRemaining =
           initialCreditsService.userHasRemainingFreeTierCredits(creator);
-      workspace.setBillingStatus(
-          hasInitialCreditsRemaining ? BillingStatus.ACTIVE : BillingStatus.INACTIVE);
       workspace.setInitialCreditsExhausted(!hasInitialCreditsRemaining);
       workspace.setInitialCreditsExpired(initialCreditsService.areUserCreditsExpired(creator));
-    } else {
-      // At this point, we can assume that a user provided billing account is open since we
-      // throw a BadRequestException if a closed one is provided
-      workspace.setBillingStatus(BillingStatus.ACTIVE);
     }
   }
 
@@ -595,7 +596,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         .forEach(
             ws -> {
               ws.setInitialCreditsExhausted(exhausted);
-              ws.setBillingStatus(exhausted ? BillingStatus.INACTIVE : BillingStatus.ACTIVE);
               workspaceDao.save(ws);
             });
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.db.model.DbDataset;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.CohortReview;
 import org.pmiops.workbench.model.ResourceType;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
@@ -27,17 +28,20 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
   private final ConceptSetService conceptSetService;
   private final DataSetDao dataSetDao;
   private final WorkspaceResourceMapper workspaceResourceMapper;
+  private final InitialCreditsService initialCreditsService;
 
   @Autowired
   public WorkspaceResourcesServiceImpl(
       CohortReviewService cohortReviewService,
       ConceptSetService conceptSetService,
       DataSetDao dataSetDao,
-      WorkspaceResourceMapper workspaceResourceMapper) {
+      WorkspaceResourceMapper workspaceResourceMapper,
+      InitialCreditsService initialCreditsService) {
     this.cohortReviewService = cohortReviewService;
     this.conceptSetService = conceptSetService;
     this.dataSetDao = dataSetDao;
     this.workspaceResourceMapper = workspaceResourceMapper;
+    this.initialCreditsService = initialCreditsService;
   }
 
   @Override
@@ -64,7 +68,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
               .map(
                   cohort ->
                       workspaceResourceMapper.fromDbCohort(
-                          dbWorkspace, workspaceAccessLevel, cohort))
+                          dbWorkspace, workspaceAccessLevel, cohort, initialCreditsService))
               .collect(Collectors.toList()));
     }
     if (resourceTypes.contains(ResourceType.COHORT_REVIEW)) {
@@ -76,7 +80,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
               .map(
                   cohortReview ->
                       workspaceResourceMapper.fromCohortReview(
-                          dbWorkspace, workspaceAccessLevel, cohortReview))
+                          dbWorkspace, workspaceAccessLevel, cohortReview, initialCreditsService))
               .collect(Collectors.toList()));
     }
     if (resourceTypes.contains(ResourceType.CONCEPT_SET)) {
@@ -86,7 +90,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
               .map(
                   dbConceptSet ->
                       workspaceResourceMapper.fromDbConceptSet(
-                          dbWorkspace, workspaceAccessLevel, dbConceptSet))
+                          dbWorkspace, workspaceAccessLevel, dbConceptSet, initialCreditsService))
               .collect(Collectors.toList()));
     }
     if (resourceTypes.contains(ResourceType.DATASET)) {
@@ -97,7 +101,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
               .map(
                   dbDataset ->
                       workspaceResourceMapper.fromDbDataset(
-                          dbWorkspace, workspaceAccessLevel, dbDataset))
+                          dbWorkspace, workspaceAccessLevel, dbDataset, initialCreditsService))
               .collect(Collectors.toList()));
     }
     if (resourceTypes.stream().anyMatch(resourceType -> !supportedTypes.contains(resourceType))) {

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
@@ -35,13 +35,14 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
       CohortReviewService cohortReviewService,
       ConceptSetService conceptSetService,
       DataSetDao dataSetDao,
-      WorkspaceResourceMapper workspaceResourceMapper,
-      InitialCreditsService initialCreditsService) {
+      InitialCreditsService initialCreditsService,
+      WorkspaceResourceMapper workspaceResourceMapper
+      ) {
     this.cohortReviewService = cohortReviewService;
     this.conceptSetService = conceptSetService;
     this.dataSetDao = dataSetDao;
-    this.workspaceResourceMapper = workspaceResourceMapper;
     this.initialCreditsService = initialCreditsService;
+    this.workspaceResourceMapper = workspaceResourceMapper;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
@@ -36,8 +36,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
       ConceptSetService conceptSetService,
       DataSetDao dataSetDao,
       InitialCreditsService initialCreditsService,
-      WorkspaceResourceMapper workspaceResourceMapper
-      ) {
+      WorkspaceResourceMapper workspaceResourceMapper) {
     this.cohortReviewService = cohortReviewService;
     this.conceptSetService = conceptSetService;
     this.dataSetDao = dataSetDao;

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
@@ -48,7 +48,6 @@ import org.pmiops.workbench.initialcredits.WorkspaceInitialCreditUsageService;
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.ExpiredInitialCreditsEventRequest;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.test.FakeClock;
@@ -569,10 +568,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
     // Simulate the user attaching their own billing account to the previously free tier workspace.
     workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
-    workspaceDao.save(
-        workspace
-            .setBillingAccountName(fullBillingAccountName("byo-account"))
-            .setBillingStatus(BillingStatus.ACTIVE));
+    workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
     cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiry(
         buildExpiredInitialCreditsEventRequest(
@@ -594,7 +590,6 @@ class CloudTaskInitialCreditsExpiryControllerTest {
             .setWorkspaceNamespace("some other namespace")
             .setGoogleProject("other project")
             .setBillingAccountName("some other account")
-            .setBillingStatus(BillingStatus.ACTIVE)
             .setInitialCreditsExhausted(false);
     workspaceDao.save(userAccountWorkspace);
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -82,7 +82,7 @@ public class UserMetricsControllerTest {
   @Mock private DataSetService mockDataSetService;
   @Mock private Provider<DbUser> mockUserProvider;
   @Mock private FireCloudService mockFireCloudService;
-  @Mock private WorkspaceAuthService workspaceAuthService;
+  @Mock private WorkspaceAuthService mockWorkspaceAuthService;
   @Mock private InitialCreditsService mockInitialCreditsService;
 
   @Autowired private AccessTierDao accessTierDao;
@@ -252,7 +252,7 @@ public class UserMetricsControllerTest {
             mockInitialCreditsService,
             mockUserProvider,
             mockUserRecentResourceService,
-            workspaceAuthService,
+            mockWorkspaceAuthService,
             workspaceDao,
             workspaceResourceMapper);
     userMetricsController.setDistinctWorkspaceLimit(5);

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -42,6 +42,7 @@ import org.pmiops.workbench.db.model.DbUserRecentlyModifiedResource.DbUserRecent
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudStorageClient;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.Domain;
 import org.pmiops.workbench.model.FileDetail;
@@ -82,6 +83,7 @@ public class UserMetricsControllerTest {
   @Mock private Provider<DbUser> mockUserProvider;
   @Mock private FireCloudService mockFireCloudService;
   @Mock private WorkspaceAuthService workspaceAuthService;
+  @Mock private InitialCreditsService mockInitialCreditsService;
 
   @Autowired private AccessTierDao accessTierDao;
   @Autowired private CdrVersionDao cdrVersionDao;
@@ -251,7 +253,8 @@ public class UserMetricsControllerTest {
             mockUserRecentResourceService,
             workspaceAuthService,
             workspaceDao,
-            workspaceResourceMapper);
+            workspaceResourceMapper,
+            mockInitialCreditsService);
     userMetricsController.setDistinctWorkspaceLimit(5);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/UserMetricsControllerTest.java
@@ -249,12 +249,12 @@ public class UserMetricsControllerTest {
             mockConceptSetService,
             mockDataSetService,
             mockFireCloudService,
+            mockInitialCreditsService,
             mockUserProvider,
             mockUserRecentResourceService,
             workspaceAuthService,
             workspaceDao,
-            workspaceResourceMapper,
-            mockInitialCreditsService);
+            workspaceResourceMapper);
     userMetricsController.setDistinctWorkspaceLimit(5);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -132,7 +132,6 @@ import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AnnotationType;
 import org.pmiops.workbench.model.ArchivalStatus;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.CloneWorkspaceRequest;
 import org.pmiops.workbench.model.Cohort;
 import org.pmiops.workbench.model.CohortAnnotationDefinition;
@@ -1173,7 +1172,6 @@ public class WorkspacesControllerTest {
             workspace.getNamespace(),
             workspace.getTerraName(),
             DbStorageEnums.workspaceActiveStatusToStorage(WorkspaceActiveStatus.ACTIVE));
-    dbWorkspace.setBillingStatus(BillingStatus.INACTIVE);
     doReturn(true)
         .when(mockInitialCreditsService)
         .userHasRemainingFreeTierCredits(

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -56,7 +56,6 @@ import org.pmiops.workbench.initialcredits.InitialCreditsExpiryTaskMatchers.User
 import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.BillingStatus;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -615,10 +614,7 @@ public class InitialCreditsServiceTest {
     // Simulate the user attaching their own billing account to the previously free tier workspace.
     TestTransaction.start();
     workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
-    workspaceDao.save(
-        workspace
-            .setBillingAccountName(fullBillingAccountName("byo-account"))
-            .setBillingStatus(BillingStatus.ACTIVE));
+    workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
     commitTransaction();
   }
@@ -758,8 +754,7 @@ public class InitialCreditsServiceTest {
             .setCreator(user)
             .setWorkspaceNamespace("some other namespace")
             .setGoogleProject("other project")
-            .setBillingAccountName("some other account")
-            .setBillingStatus(BillingStatus.ACTIVE);
+            .setBillingAccountName("some other account");
     workspaceDao.save(userAccountWorkspace);
 
     commitTransaction();

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -1007,9 +1007,7 @@ public class InitialCreditsServiceTest {
         assertThrows(
             BadRequestException.class,
             () -> initialCreditsService.extendInitialCreditsExpiration(user));
-    assertEquals(
-        "Initial credits extension is disabled.",
-        exception.getMessage());
+    assertEquals("Initial credits extension is disabled.", exception.getMessage());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -146,6 +146,7 @@ public class InitialCreditsServiceTest {
     workbenchConfig.billing.initialCreditsExpirationWarningDays = warningPeriodDays;
     workbenchConfig.billing.minutesBeforeLastFreeTierJob = 0;
     workbenchConfig.billing.numberOfDaysToConsiderForFreeTierUsageUpdate = 2L;
+    workbenchConfig.featureFlags.enableInitialCreditsExpiration = true;
 
     workspace =
         spyWorkspaceDao.save(
@@ -994,6 +995,21 @@ public class InitialCreditsServiceTest {
             false,
             null,
             NOW));
+  }
+
+  @Test
+  public void test_extendInitialCreditsExpiration_extensionDisabled() {
+    workbenchConfig.featureFlags.enableInitialCreditsExpiration = false;
+
+    DbUser user = spyUserDao.save(new DbUser());
+
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> initialCreditsService.extendInitialCreditsExpiration(user));
+    assertEquals(
+        "Initial credits extension is disabled.",
+        exception.getMessage());
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -6,7 +6,9 @@ import static org.pmiops.workbench.config.WorkbenchConfig.createEmptyConfig;
 import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +56,7 @@ import org.pmiops.workbench.model.WorkspaceResponse;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessLevel;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceListResponse;
+import org.pmiops.workbench.test.FakeClock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -91,6 +94,8 @@ public class WorkspaceMapperTest {
       Set.of(ResearchOutcomeEnum.DECREASE_ILLNESS_BURDEN);
   private static final String DISSEMINATE_FINDINGS_OTHER = "Everywhere except MIT.";
   private static final String ACCESS_TIER_SHORT_NAME = "registered";
+  private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
+  private static final FakeClock CLOCK = new FakeClock(START_INSTANT, ZoneId.systemDefault());
 
   private DbWorkspace sourceDbWorkspace;
   private RawlsWorkspaceDetails sourceFirecloudWorkspace;
@@ -131,6 +136,11 @@ public class WorkspaceMapperTest {
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public WorkbenchConfig workbenchConfig() {
       return workbenchConfig;
+    }
+
+    @Bean
+    public Clock clock() {
+      return CLOCK;
     }
   }
 
@@ -205,6 +215,7 @@ public class WorkspaceMapperTest {
 
     workbenchConfig = createEmptyConfig();
     workbenchConfig.billing.defaultFreeCreditsDollarLimit = 100.0;
+    workbenchConfig.featureFlags.enableInitialCreditsExpiration = true;
   }
 
   @Test
@@ -349,7 +360,7 @@ public class WorkspaceMapperTest {
       BillingStatus expectedStatus) {
     workbenchConfig.billing.accountId = INITIAL_CREDITS_BILLING_ACCOUNT_NAME;
     sourceDbWorkspace.setInitialCreditsExhausted(exhausted);
-    sourceDbWorkspace.setInitialCreditsExpired(expired);
+    CLOCK.setInstant(INITIAL_CREDITS_EXPIRATION_TIMESTAMP.toInstant().plusSeconds(expired ? 1 : -1));
     sourceDbWorkspace.setBillingAccountName(fullBillingAccountName(billingAccount));
     Workspace x =
         workspaceMapper.toApiWorkspace(

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/WorkspaceMapperTest.java
@@ -360,7 +360,8 @@ public class WorkspaceMapperTest {
       BillingStatus expectedStatus) {
     workbenchConfig.billing.accountId = INITIAL_CREDITS_BILLING_ACCOUNT_NAME;
     sourceDbWorkspace.setInitialCreditsExhausted(exhausted);
-    CLOCK.setInstant(INITIAL_CREDITS_EXPIRATION_TIMESTAMP.toInstant().plusSeconds(expired ? 1 : -1));
+    CLOCK.setInstant(
+        INITIAL_CREDITS_EXPIRATION_TIMESTAMP.toInstant().plusSeconds(expired ? 1 : -1));
     sourceDbWorkspace.setBillingAccountName(fullBillingAccountName(billingAccount));
     Workspace x =
         workspaceMapper.toApiWorkspace(


### PR DESCRIPTION
Billing status is not being used from the api, so this PR removes it and replaces UI conversion to rely on feature flag and expiration and exhaustion fields rather than billing status field.

In order to have this field stick around, billing status would need to be able to tell whether the creator's institution has expiration bypassed. That is unnecessarily difficult especially since billing status as a whole will soon be removed.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
