### PR TITLE
[risk-low][RW-14370] Log 404 errors (and others) in deleteOldRuntimes

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -27,6 +27,7 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.FirecloudTransforms;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
@@ -144,9 +145,15 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
 
       // Refetch the runtime to ensure freshness,
       // as this iteration may take some time.
-      final LeonardoGetRuntimeResponse runtime =
-          leonardoApiClient.getRuntimeAsService(
-              googleProject, listRuntimeResponse.getRuntimeName());
+      final LeonardoGetRuntimeResponse runtime;
+      try {
+        runtime =
+            leonardoApiClient.getRuntimeAsService(
+                googleProject, listRuntimeResponse.getRuntimeName());
+      } catch (WorkbenchException e) {
+        log.warning(String.format("error refetching runtime '%s': %s", runtimeId, e.getMessage()));
+        continue;
+      }
 
       if (LeonardoRuntimeStatus.UNKNOWN.equals(runtime.getStatus())
           || runtime.getStatus() == null) {


### PR DESCRIPTION
The deleteOldRuntimes cron consistently fails with 404 in Prod.  It's unclear why.  Add logging to help us investigate, as well as ensuring that the cron continues past these errors in individual runtimes.

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
