### PR TITLE
[risk=low][no ticket] rm needsV8GenomicExtractionWorkflow because we have publicReleaseNumber

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -180,7 +180,6 @@
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled",
       "tanagraEnabled": true,
-      "needsV8GenomicExtractionWorkflow": true,
       "vwbTemplateId": "03e0a1e6-ddbc-499f-bdaa-6c0c91dc295a",
       "publicReleaseNumber": 8
     }

--- a/api/config/cdr_config_preprod.json
+++ b/api/config/cdr_config_preprod.json
@@ -279,7 +279,6 @@
       "wgsLongReadsHailT2T": "longreads/hail.mt/T2T",
       "wgsLongReadsJointVcfGRCh38": "longreads/joint_vcf/GRCh38",
       "wgsLongReadsJointVcfT2T": "longreads/joint_vcf/T2T",
-      "needsV8GenomicExtractionWorkflow": true,
       "publicReleaseNumber": 8
     },
     {
@@ -328,7 +327,6 @@
       "wgsLongReadsHailT2T": "longreads/hail.mt/T2T",
       "wgsLongReadsJointVcfGRCh38": "longreads/joint_vcf/GRCh38",
       "wgsLongReadsJointVcfT2T": "longreads/joint_vcf/T2T",
-      "needsV8GenomicExtractionWorkflow": true,
       "tanagraEnabled": true,
       "publicReleaseNumber": -1
     }

--- a/api/config/cdr_config_prod.json
+++ b/api/config/cdr_config_prod.json
@@ -259,7 +259,6 @@
       "wgsClinvarMultiHailPath": "wgs/short_read/snpindel/clinvar/multiMT/hail.mt",
       "wgsClinvarSplitHailPath": "wgs/short_read/snpindel/clinvar/splitMT/hail.mt",
       "wgsClinvarVcfPath": "wgs/short_read/snpindel/clinvar/vcf",
-      "needsV8GenomicExtractionWorkflow": true,
       "publicReleaseNumber": 8
     }
   ]

--- a/api/config/cdr_config_test.json
+++ b/api/config/cdr_config_test.json
@@ -169,7 +169,6 @@
       "wgsCramManifestPath": "wgs/cram/manifest.csv",
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled",
-      "needsV8GenomicExtractionWorkflow": true,
       "publicReleaseNumber": 8
     }
   ]

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -48,14 +48,14 @@
     "operationalTerraWorkspaceBucket": "fc-56d2f6f5-3efa-46f7-8c01-0911fd77f888",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "enableJiraTicketingOnFailure": false,
+    "minExtractionScatterTasks": 20,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 15,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 20,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     },
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-test",

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -48,14 +48,14 @@
     "operationalTerraWorkspaceBucket": "fc-5d8e6afe-9429-44ae-a22a-67b09705d1b4",
     "extractionDestinationDataset": "fc-aou-cdr-preprod-ct.wgs_extraction_destination",
     "enableJiraTicketingOnFailure": true,
+    "minExtractionScatterTasks": 350,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-preprod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 350,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     },
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -48,14 +48,14 @@
     "operationalTerraWorkspaceBucket": "fc-43443354-728d-4523-a31d-acdff4a271b8",
     "extractionDestinationDataset": "fc-aou-cdr-prod-ct.wgs_extraction_destination",
     "enableJiraTicketingOnFailure": true,
+    "minExtractionScatterTasks": 350,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-prod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 4,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 350,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     },
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -48,14 +48,14 @@
     "operationalTerraWorkspaceBucket": "fc-b7045821-7a05-497e-844d-8889625ed10e",
     "extractionDestinationDataset": "fc-aou-cdr-stable-ct.wgs_extraction_destination",
     "enableJiraTicketingOnFailure": true,
+    "minExtractionScatterTasks": 20,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-stable",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 20,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     }
   },
   "cdr": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -49,14 +49,14 @@
     "operationalTerraWorkspaceBucket": "fc-c143d305-0ffd-4ca5-b585-9b222691da6c",
     "extractionDestinationDataset": "fc-aou-cdr-staging-ct.wgs_extraction_destination",
     "enableJiraTicketingOnFailure": true,
+    "minExtractionScatterTasks": 20,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-staging",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 20,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     }
   },
   "cdr": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -48,14 +48,14 @@
     "operationalTerraWorkspaceBucket": "fc-56d2f6f5-3efa-46f7-8c01-0911fd77f888",
     "extractionDestinationDataset": "fc-aou-cdr-synth-test-2.wgs_extracted_cohorts",
     "enableJiraTicketingOnFailure": false,
+    "minExtractionScatterTasks": 20,
+    "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 15,
-      "methodLogicalVersion": 3,
-      "minExtractionScatterTasks": 20,
-      "extractionScatterTasksPerSample": 4
+      "methodLogicalVersion": 3
     },
     "cdrv8plus": {
       "methodNamespace": "aouwgscohortextraction-test",

--- a/api/db/changelog/db.changelog-253-rm-needs-v8-genomic-extraction-workflow.xml
+++ b/api/db/changelog/db.changelog-253-rm-needs-v8-genomic-extraction-workflow.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="thibault" id="db.changelog-253-rm-needs-v8-genomic-extraction-workflow">
+    <dropColumn tableName="cdr_version" columnName="needs_v8_genomic_extraction_workflow"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -260,6 +260,7 @@
   <include file="changelog/db.changelog-250-add-aian-research-columns.xml"/>
   <include file="changelog/db.changelog-251-remove-billing-status.xml"/>
   <include file="changelog/db.changelog-252-add-vwb-tier-group-access-tier-table.xml"/>
+  <include file="changelog/db.changelog-253-rm-needs-v8-genomic-extraction-workflow.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -178,6 +178,9 @@ public class WorkbenchConfig {
     public String operationalTerraWorkspaceBucket;
     public String extractionDestinationDataset;
     public boolean enableJiraTicketingOnFailure;
+    // This should not exceed the value of GenomicExtractionService.MAX_EXTRACTION_SCATTER.
+    public int minExtractionScatterTasks;
+    public float extractionScatterTasksPerSample;
 
     public abstract static class VersionedConfig {
       // 'method' values refer to both the stored Method and the generated Method Configuration
@@ -196,16 +199,10 @@ public class WorkbenchConfig {
     // for extraction workflows compatible with CDR v7 and earlier
     public static class LegacyWorkflowConfig extends VersionedConfig {
       public String gatkJarUri;
-      // This should not exceed the value of GenomicExtractionService.MAX_EXTRACTION_SCATTER.
-      // TODO: move these back to the base VersionedConfig
-      public int minExtractionScatterTasks;
-      public float extractionScatterTasksPerSample;
     }
 
     // for extraction workflows compatible with CDR v8 and later
-    public static class CDRv8PlusConfig extends VersionedConfig {
-      // TODO: do we need any specific config for v8?
-    }
+    public static class CDRv8PlusConfig extends VersionedConfig {}
 
     public LegacyWorkflowConfig legacyVersions;
     public CDRv8PlusConfig cdrv8plus;

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbCdrVersion.java
@@ -61,8 +61,6 @@ public class DbCdrVersion {
   private String wgsLongReadsJointVcfGRCh38;
   private String wgsLongReadsJointVcfT2T;
 
-  private Boolean needsV8GenomicExtractionWorkflow;
-
   private String vwbTemplateId;
 
   private int publicReleaseNumber;
@@ -499,17 +497,6 @@ public class DbCdrVersion {
     return this;
   }
 
-  @Column(name = "needs_v8_genomic_extraction_workflow")
-  public Boolean getNeedsV8GenomicExtractionWorkflow() {
-    return needsV8GenomicExtractionWorkflow;
-  }
-
-  public DbCdrVersion setNeedsV8GenomicExtractionWorkflow(
-      Boolean needsV8GenomicExtractionWorkflow) {
-    this.needsV8GenomicExtractionWorkflow = needsV8GenomicExtractionWorkflow;
-    return this;
-  }
-
   @Column(name = "vwb_template_id")
   public String getVwbTemplateId() {
     return vwbTemplateId;
@@ -525,8 +512,9 @@ public class DbCdrVersion {
     return publicReleaseNumber;
   }
 
-  public void setPublicReleaseNumber(int publicReleaseNumber) {
+  public DbCdrVersion setPublicReleaseNumber(int publicReleaseNumber) {
     this.publicReleaseNumber = publicReleaseNumber;
+    return this;
   }
 
   @Override
@@ -573,7 +561,7 @@ public class DbCdrVersion {
         wgsLongReadsHailT2T,
         wgsLongReadsJointVcfGRCh38,
         wgsLongReadsJointVcfT2T,
-        needsV8GenomicExtractionWorkflow,
+        publicReleaseNumber,
         vwbTemplateId);
   }
 
@@ -628,7 +616,6 @@ public class DbCdrVersion {
         && Objects.equals(wgsLongReadsHailT2T, that.wgsLongReadsHailT2T)
         && Objects.equals(wgsLongReadsJointVcfGRCh38, that.wgsLongReadsJointVcfGRCh38)
         && Objects.equals(wgsLongReadsJointVcfT2T, that.wgsLongReadsJointVcfT2T)
-        && Objects.equals(needsV8GenomicExtractionWorkflow, that.needsV8GenomicExtractionWorkflow)
         && Objects.equals(vwbTemplateId, that.vwbTemplateId);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -402,8 +402,7 @@ public class GenomicExtractionService {
 
     // we use different workflows based on the CDR version:
     // one version for v7 or earlier, and one for v8 or later
-    boolean useLegacyWorkflow =
-        !Boolean.TRUE.equals(cdrVersion.getNeedsV8GenomicExtractionWorkflow());
+    boolean useLegacyWorkflow = cdrVersion.getPublicReleaseNumber() <= 7;
 
     List<String> personIds =
         workspace.isCDRAndWorkspaceTanagraEnabled()

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -327,13 +327,9 @@ public class GenomicExtractionService {
     // Initial heuristic for scatter count, optimizing to avoid large compute/output shards while
     // keeping overhead low and limiting footprint on shared extraction quota.
     int minScatter =
-        Math.min(
-            cohortExtractionConfig.legacyVersions.minExtractionScatterTasks,
-            MAX_EXTRACTION_SCATTER);
+        Math.min(cohortExtractionConfig.minExtractionScatterTasks, MAX_EXTRACTION_SCATTER);
     int desiredScatter =
-        Math.round(
-            personIds.size()
-                * cohortExtractionConfig.legacyVersions.extractionScatterTasksPerSample);
+        Math.round(personIds.size() * cohortExtractionConfig.extractionScatterTasksPerSample);
     int scatterCount = Ints.constrainToRange(desiredScatter, minScatter, MAX_EXTRACTION_SCATTER);
 
     Map<String, String> maybeInputs = new HashMap<>();

--- a/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
+++ b/api/src/main/java/org/pmiops/workbench/tools/cdrconfig/CdrVersionVO.java
@@ -54,8 +54,6 @@ public class CdrVersionVO {
   public String wgsLongReadsJointVcfGRCh38;
   public String wgsLongReadsJointVcfT2T;
 
-  public Boolean needsV8GenomicExtractionWorkflow;
-
   public String vwbTemplateId;
 
   public int publicReleaseNumber;

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -537,9 +537,9 @@ public class GenomicExtractionServiceTest {
         cdrVersionDao.save(
             new DbCdrVersion()
                 .setCdrVersionId(8)
+                .setPublicReleaseNumber(8)
                 .setBigqueryProject("bigquery_project")
-                .setWgsBigqueryDataset("wgs_dataset")
-                .setNeedsV8GenomicExtractionWorkflow(true));
+                .setWgsBigqueryDataset("wgs_dataset"));
     targetWorkspace = workspaceDao.save(targetWorkspace.setCdrVersion(cdrV8));
 
     TanagraGenomicDataRequest tanagraRequest = null;

--- a/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/genomics/GenomicExtractionServiceTest.java
@@ -168,12 +168,12 @@ public class GenomicExtractionServiceTest {
     workbenchConfig.wgsCohortExtraction.operationalTerraWorkspaceName =
         "operationalTerraWorkspaceName";
     workbenchConfig.wgsCohortExtraction.extractionDestinationDataset = "extract-proj.extract-ds";
+    workbenchConfig.wgsCohortExtraction.minExtractionScatterTasks = 100;
+    workbenchConfig.wgsCohortExtraction.extractionScatterTasksPerSample = 4;
     workbenchConfig.wgsCohortExtraction.legacyVersions.methodName = "methodName";
     workbenchConfig.wgsCohortExtraction.legacyVersions.methodNamespace = "methodNamespace";
     workbenchConfig.wgsCohortExtraction.legacyVersions.methodRepoVersion = 10;
     workbenchConfig.wgsCohortExtraction.legacyVersions.methodLogicalVersion = 3;
-    workbenchConfig.wgsCohortExtraction.legacyVersions.minExtractionScatterTasks = 100;
-    workbenchConfig.wgsCohortExtraction.legacyVersions.extractionScatterTasksPerSample = 4;
     workbenchConfig.wgsCohortExtraction.cdrv8plus.methodName = "v8MethodName";
     workbenchConfig.wgsCohortExtraction.cdrv8plus.methodNamespace = "v8MethodNamespace";
     workbenchConfig.wgsCohortExtraction.cdrv8plus.methodRepoVersion = 1;


### PR DESCRIPTION
Tested locally by running 7 and v8 extraction workflows, and observing in Job Manager that the parameter lists were appropriate for each.  For example, v7 has `gatk_override` but v8 does not.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
