### PR TITLE
[DT-905][risk=no] Update text for data apps version tooltip

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit-text.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit-text.tsx
@@ -250,8 +250,15 @@ export const toolTipText = {
   ),
   dataAppsSelect: (
     <div>
-      Choose which versions of Cohort Builder, Concept Search and Dataset
-      Builder to use.
+      <div style={{ fontWeight: 'bold' }}>Data Apps V1</div>
+      <div>
+        This version includes the existing Cohort Builder and Dataset Builder.
+      </div>
+      <div style={{ fontWeight: 'bold' }}>Data Apps V2</div>
+      <div>
+        This version includes a test of new Cohort Builder and Dataset Builder
+        features.
+      </div>
     </div>
   ),
   tierSelect: (

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -1781,9 +1781,12 @@ export const WorkspaceEdit = fp.flow(
                   <FlexColumn>
                     <div style={styles.fieldHeader}>
                       Data Apps version
-                      <TooltipTrigger content={toolTipText.dataAppsSelect}>
-                        <InfoIcon style={styles.infoIcon} />
-                      </TooltipTrigger>
+                      {/* Only show tooltip for non-prod envs */}
+                      {environment.shouldShowDisplayTag && (
+                        <TooltipTrigger content={toolTipText.dataAppsSelect}>
+                          <InfoIcon style={styles.infoIcon} />
+                        </TooltipTrigger>
+                      )}
                     </div>
                     <TooltipTrigger
                       content='To use a different version of Data Apps, create a new workspace.'


### PR DESCRIPTION
Also added a conditions to prevent the tooltip from being rendered in prod as we need to update the text again before the prod release.
<img width="756" alt="Screenshot 2025-01-31 at 2 07 10 PM" src="https://github.com/user-attachments/assets/c61b9cc4-84fb-4327-b6ab-076c8084ff26" />
