### PR TITLE
[risk=low][no ticket] Converted "loop over get" DB calls to "get all in", plus some other cleanups

### DIFF
--- a/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
+++ b/api/src/bigquerytest/java/org/pmiops/workbench/api/DataSetControllerBQTest.java
@@ -853,7 +853,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.CONDITION),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.NONE))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertThat(code).contains(expected);
 
@@ -890,7 +890,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.CONDITION, Domain.PROCEDURE),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.NONE))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 3, Domain.CONDITION, 1L);
   }
@@ -909,7 +909,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.CONDITION),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.NONE))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.CONDITION, 1L);
   }
@@ -928,7 +928,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.CONDITION),
                             true,
                             ImmutableList.of(PrePackagedConceptSetEnum.NONE))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.CONDITION, 1L);
   }
@@ -947,7 +947,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.PERSON),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.PERSON))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.PERSON, 1L);
   }
@@ -966,7 +966,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.SURVEY),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.SURVEY))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.SURVEY, 2L);
   }
@@ -986,7 +986,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.SURVEY),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.SURVEY_BASICS))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
   }
@@ -1009,7 +1009,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(
                                 PrePackagedConceptSetEnum.SURVEY_BASICS,
                                 PrePackagedConceptSetEnum.FITBIT_HEART_RATE_LEVEL))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
     assertThat(code).contains(expectedFitbitHrLevel);
@@ -1041,7 +1041,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.SURVEY),
                             false,
                             prePackagedConceptSetEnumList)),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertThat(code.replaceAll("[ \\s]", "")).contains(expectedConceptId.replaceAll(" ", ""));
   }
@@ -1060,7 +1060,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.FITBIT_HEART_RATE_LEVEL),
                             false,
                             ImmutableList.of(PrePackagedConceptSetEnum.NONE))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.FITBIT_HEART_RATE_LEVEL, 1L);
   }
@@ -1081,7 +1081,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(
                                 PrePackagedConceptSetEnum.PERSON,
                                 PrePackagedConceptSetEnum.FITBIT_HEART_RATE_LEVEL))),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.CONDITION, 1L);
   }
@@ -1100,7 +1100,7 @@ public class DataSetControllerBQTest extends BigQueryBaseTest {
                             ImmutableList.of(Domain.SURVEY),
                             false,
                             ImmutableList.of())),
-                workspaceDao.get(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
+                workspaceDao.getRequired(WORKSPACE_NAMESPACE, WORKSPACE_NAME)));
 
     assertAndExecutePythonQuery(code, 1, Domain.SURVEY, 1L);
   }

--- a/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessModuleServiceImpl.java
@@ -63,7 +63,8 @@ public class AccessModuleServiceImpl implements AccessModuleService {
 
   @Override
   public void updateAllBypassTimes(long userId) {
-    dbAccessModulesProvider.get().stream()
+    dbAccessModulesProvider
+        .get()
         .forEach(module -> updateBypassTime(userId, module.getName(), true));
   }
 
@@ -93,8 +94,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
             "Setting %s(uid: %d) for module %s bypass status to %s",
             user.getUsername(), userId, accessModule.getName(), isBypassed));
 
-    userAccessModuleToUpdate.setBypassTime(newBypassTime);
-    userAccessModuleDao.save(userAccessModuleToUpdate);
+    userAccessModuleDao.save(userAccessModuleToUpdate.setBypassTime(newBypassTime));
     userServiceAuditor.fireAdministrativeBypassTime(
         user.getUserId(),
         accessModuleNameMapper.bypassAuditPropertyFromStorage(accessModule.getName()),
@@ -112,9 +112,8 @@ public class AccessModuleServiceImpl implements AccessModuleService {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
     DbUserAccessModule userAccessModuleToUpdate =
-        retrieveUserAccessModuleOrCreate(dbUser, dbAccessModule);
-    userAccessModuleToUpdate =
-        userAccessModuleDao.save(userAccessModuleToUpdate.setCompletionTime(timestamp));
+        userAccessModuleDao.save(
+            retrieveUserAccessModuleOrCreate(dbUser, dbAccessModule).setCompletionTime(timestamp));
     if (accessModuleName.equals(DbAccessModuleName.RAS_ID_ME)
         || accessModuleName.equals(DbAccessModuleName.RAS_LOGIN_GOV)) {
       updateCompletionTime(dbUser, DbAccessModuleName.IDENTITY, timestamp);
@@ -136,8 +135,7 @@ public class AccessModuleServiceImpl implements AccessModuleService {
       DbUser user, DbAccessModuleName accessModuleName) {
     DbAccessModule dbAccessModule =
         getDbAccessModuleOrThrow(dbAccessModulesProvider.get(), accessModuleName);
-    DbUserAccessModule userAccessModule = retrieveUserAccessModuleOrCreate(user, dbAccessModule);
-    return maybeReturnAccessModule(userAccessModule);
+    return maybeReturnAccessModule(retrieveUserAccessModuleOrCreate(user, dbAccessModule));
   }
 
   private Optional<AccessModuleStatus> maybeReturnAccessModule(

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -44,19 +44,19 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             "Deleting unshared environments for %d workspaces.", workspaceNamespaces.size()));
 
     var stopwatch = stopwatchProvider.get().start();
-    List<DbWorkspace> failedUserRoles =
+    long failedUserRoles =
         workspaceService.lookupWorkspacesByNamespace(workspaceNamespaces).stream()
             .filter(
                 ws -> {
                   boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
                   return !successfulGetFirecloudUserRoles;
                 })
-            .toList();
+            .count();
     var elapsed = stopwatch.stop().elapsed();
     LOGGER.info(
         String.format(
             "Attempted to delete unshared environments for %d workspaces (%d failures) in %s.",
-            workspaceNamespaces.size(), failedUserRoles.size(), formatDurationPretty(elapsed)));
+            workspaceNamespaces.size(), failedUserRoles, formatDurationPretty(elapsed)));
 
     return ResponseEntity.ok().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -45,8 +45,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
 
     var stopwatch = stopwatchProvider.get().start();
     List<DbWorkspace> failedUserRoles =
-        workspaceNamespaces.stream()
-            .map(workspaceService::lookupWorkspaceByNamespace)
+        workspaceService.lookupWorkspacesByNamespace(workspaceNamespaces).stream()
             .filter(
                 ws -> {
                   boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -322,7 +322,7 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
             .collect(Collectors.toList());
 
     // Lookup these users in the database, so we can get their contact email, etc.
-    List<DbUser> dbUsers = userDao.findUserByUsernameIn(notifyUsernames);
+    List<DbUser> dbUsers = userDao.findUsersByUsernameIn(notifyUsernames);
     if (dbUsers.size() != notifyUsernames.size()) {
       log.warning(
           "failed to lookup one or more users in the database: "

--- a/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/UserAdminController.java
@@ -4,7 +4,6 @@ import jakarta.annotation.Nullable;
 import jakarta.inject.Provider;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessSyncService;
 import org.pmiops.workbench.actionaudit.ActionAuditQueryService;
@@ -125,7 +124,7 @@ public class UserAdminController implements UserAdminApiDelegate {
                 taskQueueService.groupAndPushSynchronizeAccessTasks(
                     userService.findUsersByUsernames(request.getUsernames()).stream()
                         .map(DbUser::getUserId)
-                        .collect(Collectors.toList()))));
+                        .toList())));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -861,15 +861,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
 
   @Override
   public ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesV2(
-      String ns, String id, List<String> rtStrings) {
-    return getWorkspaceResourcesImpl(
-        ns, id, rtStrings.stream().map(ResourceType::fromValue).collect(Collectors.toList()));
-  }
-
-  ResponseEntity<WorkspaceResourceResponse> getWorkspaceResourcesImpl(
-      String workspaceNamespace,
-      String workspaceTerraName,
-      List<ResourceType> resourceTypesToFetch) {
+      String workspaceNamespace, String workspaceTerraName, List<String> resourceTypeStrings) {
     WorkspaceAccessLevel workspaceAccessLevel =
         workspaceAuthService.enforceWorkspaceAccessLevel(
             workspaceNamespace, workspaceTerraName, WorkspaceAccessLevel.READER);
@@ -881,10 +873,13 @@ public class WorkspacesController implements WorkspacesApiDelegate {
     WorkspaceResourceResponse workspaceResourceResponse = new WorkspaceResourceResponse();
     workspaceResourceResponse.addAll(
         workspaceResourcesService.getWorkspaceResources(
-            dbWorkspace, workspaceAccessLevel, resourceTypesToFetch));
+            dbWorkspace,
+            workspaceAccessLevel,
+            resourceTypeStrings.stream().map(ResourceType::fromValue).toList()));
     return ResponseEntity.ok(workspaceResourceResponse);
   }
 
+  @Override
   public ResponseEntity<WorkspaceCreatorFreeCreditsRemainingResponse>
       getWorkspaceCreatorFreeCreditsRemaining(
           String workspaceNamespace, String workspaceTerraName) {

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -1,8 +1,12 @@
 package org.pmiops.workbench.db.dao;
 
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.pmiops.workbench.db.model.DbUser;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
@@ -20,11 +24,16 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
    */
   DbUser findUserByUsername(String username);
 
-  List<DbUser> findUserByUsernameIn(List<String> username);
+  List<DbUser> findUsersByUsernameIn(Collection<String> username);
+
+  default Map<String, DbUser> getUsersMappedByUsernames(Collection<String> usernames) {
+    return findUsersByUsernameIn(usernames).stream()
+        .collect(Collectors.toMap(DbUser::getUsername, Function.identity()));
+  }
 
   DbUser findUserByUserId(long userId);
 
-  List<DbUser> findUserByUserIdIn(List<Long> userIds);
+  List<DbUser> findUsersByUserIdIn(List<Long> userIds);
 
   @Query("SELECT user.id FROM DbUser user")
   List<Long> findUserIds();
@@ -61,7 +70,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   List<DbUser> findUsersBySearchStringAndTier(
       @Param("term") String term, Sort sort, @Param("shortName") String accessTierShortName);
 
-  Set<DbUser> findUserByUsernameInAndDisabledFalse(List<String> usernames);
+  Set<DbUser> findUsersByUsernameInAndDisabledFalse(List<String> usernames);
 
   @Query(
       "SELECT u FROM DbUser u "

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -2,7 +2,9 @@ package org.pmiops.workbench.db.dao;
 
 import com.google.api.services.oauth2.model.Userinfo;
 import jakarta.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -148,6 +150,8 @@ public interface UserService {
 
   // same as the above, but throw NotFoundException if not found
   DbUser getByUsernameOrThrow(String username);
+
+  Map<String, DbUser> getUsersMappedByUsernames(Collection<String> usernames);
 
   Optional<DbUser> getByDatabaseId(long databaseId);
 

--- a/api/src/main/java/org/pmiops/workbench/exfiltration/EgressEventServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/exfiltration/EgressEventServiceImpl.java
@@ -5,7 +5,6 @@ import static org.pmiops.workbench.exfiltration.ExfiltrationUtils.gkeServiceName
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
-import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
@@ -67,42 +66,45 @@ public class EgressEventServiceImpl implements EgressEventService {
     // Lookup workspace by googleProject name, and set the workspaceNamespace in EgressEvent.
     Optional<DbWorkspace> dbWorkspaceMaybe =
         workspaceDao.getByGoogleProject(event.getProjectName());
-    String workspaceNamespace;
-    if (dbWorkspaceMaybe.isEmpty()) {
-      logger.warning(
-          String.format(
-              "Workspace not found by given Google Project Id: %s", event.getProjectName()));
-      workspaceNamespace = NOT_FOUND_WORKSPACE_NAMESPACE;
-    } else {
-      workspaceNamespace = dbWorkspaceMaybe.get().getWorkspaceNamespace();
-    }
 
-    Optional<DbUser> egressUser = findEgressUsers(event);
+    String workspaceNamespace =
+        dbWorkspaceMaybe
+            .map(DbWorkspace::getWorkspaceNamespace)
+            .orElseGet(
+                () -> {
+                  logger.warning(
+                      String.format(
+                          "Workspace not found by given Google Project Id: %s",
+                          event.getProjectName()));
+                  return NOT_FOUND_WORKSPACE_NAMESPACE;
+                });
 
-    // This would happen if we receive a second GKE Egress for the same event when the app is being
-    // STOPPED,
-    // we just audit in this case since we can't know the user
-    if (egressUser.isEmpty()) {
-      logger.warning(
-          String.format(
-              "An egress event happened for workspace: %s, but we're unable to find a user for it. "
-                  + "This could be because it was triggered by a GKE up that is currently not running.",
-              workspaceNamespace));
-      this.egressEventAuditor.fireEgressEvent(event);
-    }
+    Optional<DbUser> egressUserMaybe = findEgressUser(event);
 
-    logger.warning(
-        String.format(
-            "Received an egress event from workspace namespace %s, googleProject %s (%.2fMiB, username %s)",
-            workspaceNamespace,
-            event.getProjectName(),
-            event.getEgressMib(),
-            egressUser.get().getUsername()));
-    this.egressEventAuditor.fireEgressEventForUser(event, egressUser.get());
+    egressUserMaybe.ifPresentOrElse(
+        user -> {
+          logger.warning(
+              String.format(
+                  "Received an egress event from workspace namespace %s, googleProject %s (%.2fMiB, username %s)",
+                  workspaceNamespace,
+                  event.getProjectName(),
+                  event.getEgressMib(),
+                  user.getUsername()));
+          egressEventAuditor.fireEgressEventForUser(event, user);
+        },
+        () -> {
+          // This would happen if we receive a second GKE Egress for the same event when the app is
+          // being STOPPED,  we just audit in this case since we can't know the user
+          logger.warning(
+              String.format(
+                  "An egress event happened for workspace: %s, but we're unable to find a user for it. "
+                      + "This could be because it was triggered by a GKE app that is currently not running.",
+                  workspaceNamespace));
+          egressEventAuditor.fireEgressEvent(event);
+        });
 
-    Optional<DbEgressEvent> maybeEvent =
-        this.maybePersistSumoEgressEvent(event, Optional.of(egressUser.get()), dbWorkspaceMaybe);
-    maybeEvent.ifPresent(e -> taskQueueService.pushEgressEventTask(e.getEgressEventId(), false));
+    maybePersistSumoEgressEvent(event, egressUserMaybe, dbWorkspaceMaybe)
+        .ifPresent(e -> taskQueueService.pushEgressEventTask(e.getEgressEventId(), false));
   }
 
   @Override
@@ -114,7 +116,7 @@ public class EgressEventServiceImpl implements EgressEventService {
               "An egress event happened for workspace: %s, but we're unable to find a user %s.",
               egressEvent.getVwbWorkspaceId(), egressEvent.getUserEmail()));
     }
-    this.egressEventAuditor.fireVwbEgressEvent(egressEvent, egressUser.get());
+    egressEventAuditor.fireVwbEgressEvent(egressEvent, egressUser.get());
     DbEgressEvent event =
         egressEventDao.save(
             new DbEgressEvent()
@@ -130,14 +132,12 @@ public class EgressEventServiceImpl implements EgressEventService {
                         // Mebibytes (2^20 bytes) -> Megabytes (10^6 bytes)
                         .map(mib -> (float) (mib * ((1 << 20) / 1e6)))
                         .orElse(null))
-                .setEgressWindowSeconds(
-                    Optional.ofNullable(egressEvent.getTimeWindowDuration()).orElse(null))
+                .setEgressWindowSeconds(egressEvent.getTimeWindowDuration())
                 .setStatus(DbEgressEventStatus.PENDING));
     taskQueueService.pushEgressEventTask(event.getEgressEventId(), true);
   }
 
-  @NotNull
-  private Optional<DbUser> findEgressUsers(SumologicEgressEvent event) {
+  private Optional<DbUser> findEgressUser(SumologicEgressEvent event) {
 
     // This case is when the Egress is from a GCE cluster.
     if (StringUtils.isNotEmpty(event.getVmPrefix())

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -154,6 +155,12 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   @Override
   public DbWorkspace lookupWorkspaceByNamespace(String workspaceNamespace) {
     logger.warn("lookupWorkspaceByNamespace not implemented in VWB");
+    return null;
+  }
+
+  @Override
+  public List<DbWorkspace> lookupWorkspacesByNamespace(Collection<String> workspaceNamespaces) {
+    logger.warn("lookupWorkspacesByNamespace not implemented in VWB");
     return null;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -1,5 +1,6 @@
 package org.pmiops.workbench.workspaces;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,8 @@ public interface WorkspaceService {
   Map<String, DbWorkspace> getWorkspacesByGoogleProject(Set<String> keySet);
 
   DbWorkspace lookupWorkspaceByNamespace(String workspaceNamespace);
+
+  List<DbWorkspace> lookupWorkspacesByNamespace(Collection<String> workspaceNamespaces);
 
   /**
    * This call will create a Study in the Tanagra application. A Tanagra Study is equivalent to a

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -644,14 +644,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
 
   @Override
   public List<DbUser> getWorkspaceOwnerList(DbWorkspace dbWorkspace) {
-    var ownerUsernames =
+    return userDao.findUsersByUsernameIn(
         getFirecloudUserRoles(dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
             .stream()
             .filter(userRole -> userRole.getRole() == WorkspaceAccessLevel.OWNER)
             .map(UserRole::getEmail)
-            .toList();
-
-    return userDao.findUsersByUsernameIn(ownerUsernames);
+            .toList());
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/resources/WorkspaceResourcesServiceImpl.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.workspaces.resources;
 
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class WorkspaceResourcesServiceImpl implements WorkspaceResourcesService 
       WorkspaceAccessLevel workspaceAccessLevel,
       List<ResourceType> resourceTypes) {
     List<ResourceType> supportedTypes =
-        ImmutableList.of(
+        List.of(
             ResourceType.COHORT,
             ResourceType.COHORT_REVIEW,
             ResourceType.CONCEPT_SET,

--- a/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
+++ b/api/src/test/java/org/pmiops/workbench/actionaudit/auditors/EgressEventAuditorTest.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -90,7 +91,8 @@ public class EgressEventAuditorTest {
     dbUser = new DbUser();
     dbUser.setUserId(USER_ID);
     dbUser.setUsername(USER_EMAIL);
-    when(mockUserDao.findUserByUsername(USER_EMAIL)).thenReturn(dbUser);
+    when(mockUserDao.findUsersByUsernameIn(Collections.singletonList(USER_EMAIL)))
+        .thenReturn(List.of(dbUser));
 
     dbWorkspace = new DbWorkspace();
     dbWorkspace.setWorkspaceId(WORKSPACE_ID);
@@ -109,7 +111,7 @@ public class EgressEventAuditorTest {
         new SumologicEgressEvent()
             .projectName(EGRESS_EVENT_PROJECT_NAME)
             .vmPrefix(EGRESS_EVENT_VM_PREFIX)
-            .timeWindowStart(0l)
+            .timeWindowStart(0L)
             .egressMib(12.3)
             .gceEgressMib(0.0)
             .dataprocMasterEgressMib(10.0)
@@ -118,15 +120,15 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.USER);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.DETECT_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.agentIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentIdMaybe).collect(Collectors.toSet()))
         .containsExactly(USER_ID);
-    assertThat(events.stream().map(event -> event.agentEmailMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentEmailMaybe).collect(Collectors.toSet()))
         .containsExactly(USER_EMAIL);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     // We should have distinct event rows with values from the egress event.
@@ -136,7 +138,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEventTargetProperty.EGRESS_MIB.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly("12.3");
     assertThat(
@@ -145,7 +147,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEventTargetProperty.VM_NAME.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly(EGRESS_EVENT_VM_PREFIX);
   }
@@ -156,7 +158,7 @@ public class EgressEventAuditorTest {
         new SumologicEgressEvent()
             .projectName(EGRESS_EVENT_PROJECT_NAME)
             .vmPrefix(EGRESS_EVENT_VM_PREFIX)
-            .timeWindowStart(0l)
+            .timeWindowStart(0L)
             .egressMib(12.3)
             .gceEgressMib(0.0)
             .dataprocMasterEgressMib(10.0)
@@ -166,15 +168,15 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.USER);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.DETECT_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.agentIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentIdMaybe).collect(Collectors.toSet()))
         .containsExactly(USER_ID);
-    assertThat(events.stream().map(event -> event.agentEmailMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentEmailMaybe).collect(Collectors.toSet()))
         .containsExactly(USER_EMAIL);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     // We should have distinct event rows with values from the egress event.
@@ -184,7 +186,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEventTargetProperty.EGRESS_MIB.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly("12.3");
     assertThat(
@@ -193,7 +195,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEventTargetProperty.VM_NAME.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly(EGRESS_EVENT_VM_PREFIX);
   }
@@ -203,13 +205,13 @@ public class EgressEventAuditorTest {
     // When the workspace lookup doesn't succeed, the event is filed w/ a system agent and an
     // empty target ID.
     when(workspaceDao.getByGoogleProject(GOOGLE_PROJECT)).thenReturn(Optional.empty());
-    assertThrows(
-        BadRequestException.class,
-        () ->
-            egressEventAuditor.fireEgressEvent(
-                new SumologicEgressEvent()
-                    .projectName(EGRESS_EVENT_PROJECT_NAME)
-                    .vmPrefix(EGRESS_EVENT_VM_PREFIX)));
+    var event =
+        new SumologicEgressEvent()
+            .projectName(EGRESS_EVENT_PROJECT_NAME)
+            .vmPrefix(EGRESS_EVENT_VM_PREFIX);
+
+    assertThrows(BadRequestException.class, () -> egressEventAuditor.fireEgressEvent(event));
+
     verify(mockActionAuditService).send(eventsCaptor.capture());
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
@@ -217,15 +219,12 @@ public class EgressEventAuditorTest {
     // for the egress event.
     assertThat(
             events.stream()
-                .map(event -> event.agentEmailMaybe())
+                .map(ActionAuditEvent::agentEmailMaybe)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toSet()))
+                .toList())
         .isEmpty();
     assertThat(
-            events.stream()
-                .map(event -> event.targetIdMaybe())
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet()))
+            events.stream().map(ActionAuditEvent::targetIdMaybe).filter(Objects::nonNull).toList())
         .isEmpty();
 
     // We expect to see an audit event row with a comment describing the issue encountered when
@@ -233,10 +232,10 @@ public class EgressEventAuditorTest {
     assertThat(
             events.stream()
                 .filter(
-                    event ->
-                        event.targetPropertyMaybe()
+                    e ->
+                        e.targetPropertyMaybe()
                             == EgressEventCommentTargetProperty.COMMENT.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .findFirst()
                 .get())
         .contains("Failed to find workspace");
@@ -255,11 +254,11 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.SYSTEM);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.REMEDIATE_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     // We should have distinct event rows with values from the egress event.
@@ -269,8 +268,8 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.REMEDIATION.getPropertyName())
-                .map(event -> event.newValueMaybe())
-                .collect(Collectors.toSet()))
+                .map(ActionAuditEvent::newValueMaybe)
+                .toList())
         .isEmpty();
     assertThat(
             events.stream()
@@ -279,8 +278,8 @@ public class EgressEventAuditorTest {
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.SUSPEND_COMPUTE_DURATION_MIN
                                 .getPropertyName())
-                .map(event -> event.newValueMaybe())
-                .collect(Collectors.toSet()))
+                .map(ActionAuditEvent::newValueMaybe)
+                .toList())
         .isEmpty();
   }
 
@@ -300,11 +299,11 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.SYSTEM);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.REMEDIATE_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     // We should have distinct event rows with values from the egress event.
@@ -314,7 +313,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.REMEDIATION.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly("suspend_compute");
     assertThat(
@@ -324,7 +323,7 @@ public class EgressEventAuditorTest {
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.SUSPEND_COMPUTE_DURATION_MIN
                                 .getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly("15");
   }
@@ -344,11 +343,11 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.SYSTEM);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.REMEDIATE_HIGH_EGRESS_EVENT);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     // We should have distinct event rows with values from the egress event.
@@ -358,7 +357,7 @@ public class EgressEventAuditorTest {
                     event ->
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.REMEDIATION.getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .collect(Collectors.toSet()))
         .containsExactly("disable_user");
     assertThat(
@@ -368,9 +367,9 @@ public class EgressEventAuditorTest {
                         event.targetPropertyMaybe()
                             == EgressEscalationTargetProperty.SUSPEND_COMPUTE_DURATION_MIN
                                 .getPropertyName())
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList()))
+                .toList())
         .isEmpty();
   }
 
@@ -391,13 +390,13 @@ public class EgressEventAuditorTest {
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
     // Ensure all events have the expected set of constant fields.
-    assertThat(events.stream().map(event -> event.agentType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentType).collect(Collectors.toSet()))
         .containsExactly(AgentType.ADMINISTRATOR);
-    assertThat(events.stream().map(event -> event.agentEmailMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::agentEmailMaybe).collect(Collectors.toSet()))
         .containsExactly(ActionAuditTestConfig.ADMINISTRATOR_EMAIL);
-    assertThat(events.stream().map(event -> event.actionType()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::actionType).collect(Collectors.toSet()))
         .containsExactly(ActionType.EDIT);
-    assertThat(events.stream().map(event -> event.targetIdMaybe()).collect(Collectors.toSet()))
+    assertThat(events.stream().map(ActionAuditEvent::targetIdMaybe).collect(Collectors.toSet()))
         .containsExactly(WORKSPACE_ID);
 
     assertThat(events).hasSize(1);
@@ -410,10 +409,11 @@ public class EgressEventAuditorTest {
 
   @Test
   public void testFailedParsing() {
+    String badContents = "asdf";
     // When the inbound request parsing fails, an event is logged at the system agent.
     when(workspaceDao.getByGoogleProject(GOOGLE_PROJECT)).thenReturn(null);
     egressEventAuditor.fireFailedToParseEgressEventRequest(
-        new SumologicEgressEventRequest().eventsJsonArray("asdf"));
+        new SumologicEgressEventRequest().eventsJsonArray(badContents));
     verify(mockActionAuditService).send(eventsCaptor.capture());
     Collection<ActionAuditEvent> events = eventsCaptor.getValue();
 
@@ -424,10 +424,10 @@ public class EgressEventAuditorTest {
                         EgressEventCommentTargetProperty.COMMENT
                             .getPropertyName()
                             .equals(event.targetPropertyMaybe()))
-                .map(event -> event.newValueMaybe())
-                .findFirst()
-                .get())
-        .contains("Failed to parse egress event");
+                .map(ActionAuditEvent::newValueMaybe)
+                .findFirst())
+        .hasValue(
+            "Failed to parse egress event JSON from SumoLogic. Field contents: " + badContents);
   }
 
   @Test
@@ -445,7 +445,7 @@ public class EgressEventAuditorTest {
                         EgressEventCommentTargetProperty.COMMENT
                             .getPropertyName()
                             .equals(event.targetPropertyMaybe()))
-                .map(event -> event.newValueMaybe())
+                .map(ActionAuditEvent::newValueMaybe)
                 .findFirst()
                 .get())
         .contains("Received bad API key");

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExpiryControllerTest.java
@@ -567,7 +567,6 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
     // Simulate the user attaching their own billing account to the previously free tier workspace.
-    workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
     workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
     cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiry(

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -2889,7 +2889,8 @@ public class WorkspacesControllerTest {
         workspace.getTerraName(),
         LOGGED_IN_USER_EMAIL,
         WorkspaceAccessLevel.OWNER);
-    DbWorkspace dbWorkspace = workspaceDao.get(workspace.getNamespace(), workspace.getTerraName());
+    DbWorkspace dbWorkspace =
+        workspaceDao.getRequired(workspace.getNamespace(), workspace.getTerraName());
     workspaceService.updateRecentWorkspaces(dbWorkspace);
     ResponseEntity<RecentWorkspaceResponse> recentWorkspaceResponseEntity =
         workspacesController.getUserRecentWorkspaces();

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserDaoTest.java
@@ -347,7 +347,7 @@ public class UserDaoTest {
     taylor.setUsername("captain");
     taylor = userDao.save(taylor);
 
-    assertThat(userDao.findUserByUsernameIn(ImmutableList.of("afunk123", "bobo1")))
+    assertThat(userDao.findUsersByUsernameIn(ImmutableList.of("afunk123", "bobo1")))
         .containsExactly(alice, bob);
   }
 

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -614,7 +614,6 @@ public class InitialCreditsServiceTest {
 
     // Simulate the user attaching their own billing account to the previously free tier workspace.
     TestTransaction.start();
-    workspace = workspaceDao.findDbWorkspaceByWorkspaceId(workspace.getWorkspaceId());
     workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
     commitTransaction();

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -595,10 +595,6 @@ public class WorkspaceAdminServiceTest {
         .setFirecloudName("fc-" + name);
   }
 
-  private DbWorkspace mustGetDbWorkspace(DbWorkspace w) {
-    return workspaceDao.findDbWorkspaceByWorkspaceId(w.getWorkspaceId());
-  }
-
   private void setupPublishWorkspaceMocks() {
     String rtAuthDomainGroupEmail = "rt@broad.org";
     when(mockWorkspaceService.getPublishedWorkspacesGroupEmail())


### PR DESCRIPTION
Convert some loops over get-user and get-workspace DB calls to "get all in this list" type calls.

Some other code cleanups. 

I'm happy to remove anything that would simplify this or is otherwise too big.

Tested locally by:
* updating user bypass times
* running the deleteUnsharedWorkspaceEnvironments cron (in debug mode, to observe the change)
* running the exportToRdr cron
* accessing workspace resources
* viewing collaborators in Workspace About
* viewing a workspace on the admin page
* sharing a workspace


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
