### PR TITLE
[risk=no][RW-13628] Create user in VWB automatically

### DIFF
--- a/api/config/cdr_config_local.json
+++ b/api/config/cdr_config_local.json
@@ -156,7 +156,7 @@
       "hasSurveyConductData": true,
       "accessTier": "registered",
       "tanagraEnabled": true,
-      "vwbTemplateId": "03e0a1e6-ddbc-499f-bdaa-6c0c91dc295a",
+      "vwbTemplateId": "7193e626-4547-40d8-ac8c-1204fc84ead1",
       "publicReleaseNumber": 4
     },
     {
@@ -180,7 +180,7 @@
       "microarrayVcfSingleSampleStoragePath": "microarray/vcf/single_sample",
       "accessTier": "controlled",
       "tanagraEnabled": true,
-      "vwbTemplateId": "03e0a1e6-ddbc-499f-bdaa-6c0c91dc295a",
+      "vwbTemplateId": "c843d45c-8030-4db8-9bf1-7a50545af6cf",
       "publicReleaseNumber": 8
     }
   ]

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -128,7 +128,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": true,
     "enableVWBEgressMonitor": true,
-    "enableVWBUserAccessManagement": false
+    "enableVWBUserAccessManagement": false,
+    "enableVWBUserCreation": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-local",
@@ -191,11 +192,11 @@
     "enableLoginIssueBanner": false
   },
   "vwb": {
-    "wsmBaseUrl": "https:\/\/terra-devel-wsm.api.verily.com",
+    "wsmBaseUrl": "https:\/\/workbench-dev.verily.com\/api\/wsm",
     "exfilManagerBaseUrl": "https:\/\/workbench-dev.verily.com\/api\/exfil",
     "vwbSamBaseUrl": "https:\/\/workbench-dev.verily.com\/api\/sam",
-    "organizationId": "79775c0a-3bf7-436a-8ab8-eab316998115",
-    "defaultPodId": "081afa2b-db53-46c2-9923-65a99da0769b",
+    "organizationId": "00a62244-0497-460f-8d55-dd1eee3ce975",
+    "defaultPodId": "b9e49b23-72e4-4b41-8c2d-cb4c9f976019",
     "exfilManagerServiceAccount": "workbench-exfil-manager@prj-d-1v-ucd.iam.gserviceaccount.com",
     "userManagerBaseUrl": "https:\/\/workbench-dev.verily.com\/api\/user"
   }

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -128,7 +128,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": false,
     "enableVWBEgressMonitor": false,
-    "enableVWBUserAccessManagement": false
+    "enableVWBUserAccessManagement": false,
+    "enableVWBUserCreation": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-preprod",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -128,7 +128,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": false,
     "enableVWBEgressMonitor": false,
-    "enableVWBUserAccessManagement": false
+    "enableVWBUserAccessManagement": false,
+    "enableVWBUserCreation": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-prod",

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -122,7 +122,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": true,
     "enableVWBEgressMonitor": false,
-    "enableVWBUserAccessManagement": false
+    "enableVWBUserAccessManagement": false,
+    "enableVWBUserCreation": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -123,7 +123,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": false,
     "enableVWBEgressMonitor": false,
-    "enableVWBUserAccessManagement": false
+    "enableVWBUserAccessManagement": false,
+    "enableVWBUserCreation": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-staging",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -128,7 +128,8 @@
     "blockComplianceTraining": false,
     "enableVWBWorkspaceCreation": false,
     "enableVWBEgressMonitor": true,
-    "enableVWBUserAccessManagement": true
+    "enableVWBUserAccessManagement": true,
+    "enableVWBUserCreation": false
   },
   "actionAudit": {
     "logName": "workbench-action-audit-test",

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -331,6 +331,9 @@ public class WorkbenchConfig {
     public boolean enableVWBEgressMonitor;
     // If true, AoU will call SAM and VWB to add/remove user from VWB tier group.
     public boolean enableVWBUserAccessManagement;
+    // If true, AoU will create the VWB user when the user first signs in, similar to Terra
+    // experience
+    public boolean enableVWBUserCreation;
   }
 
   public static class ActionAuditConfig {

--- a/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
@@ -1,0 +1,37 @@
+package org.pmiops.workbench.user;
+
+import jakarta.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.vwb.user.model.OrganizationMember;
+import org.pmiops.workbench.vwb.usermanager.VwbUserManagerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VwbUserService {
+
+  private static final Logger logger = LoggerFactory.getLogger(VwbUserService.class);
+
+  private final VwbUserManagerClient vwbUserManagerClient;
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
+  public VwbUserService(
+      VwbUserManagerClient vwbUserManagerClient,
+      Provider<WorkbenchConfig> workbenchConfigProvider) {
+    this.vwbUserManagerClient = vwbUserManagerClient;
+    this.workbenchConfigProvider = workbenchConfigProvider;
+  }
+
+  public void createUser(String email) {
+    if (!workbenchConfigProvider.get().featureFlags.enableVWBUserCreation) {
+      return;
+    }
+    OrganizationMember organizationMember = vwbUserManagerClient.getOrganizationMember(email);
+    if (organizationMember.getUserDescription() != null) {
+      logger.info("User already exists in VWB with email {}", email);
+      return;
+    }
+    vwbUserManagerClient.createUser(email);
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/UserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/UserManagerClient.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.vwb.usermanager;
 
 import jakarta.inject.Provider;
+import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.vwb.user.api.OrganizationV2Api;
 import org.pmiops.workbench.vwb.user.api.UserV2Api;
 import org.pmiops.workbench.vwb.user.model.OrganizationMember;
@@ -21,14 +22,18 @@ public class UserManagerClient {
 
   private final UserManagerRetryHandler userManagerRetryHandler;
 
+  private final Provider<WorkbenchConfig> workbenchConfigProvider;
+
   public UserManagerClient(
       @Qualifier(UserManagerConfig.VWB_SERVICE_ACCOUNT_USER_API)
           Provider<UserV2Api> userV2ApiProvider,
       Provider<OrganizationV2Api> organizationV2ApiProvider,
-      UserManagerRetryHandler userManagerRetryHandler) {
+      UserManagerRetryHandler userManagerRetryHandler,
+      Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.userV2ApiProvider = userV2ApiProvider;
     this.organizationV2ApiProvider = organizationV2ApiProvider;
     this.userManagerRetryHandler = userManagerRetryHandler;
+    this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
   public OrganizationMember getOrganizationMember(String organizationId, String userName) {

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -4,46 +4,51 @@ import jakarta.inject.Provider;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.vwb.user.api.OrganizationV2Api;
 import org.pmiops.workbench.vwb.user.api.UserV2Api;
-import org.pmiops.workbench.vwb.user.model.OrganizationMember;
-import org.pmiops.workbench.vwb.user.model.UserCreateRequest;
+import org.pmiops.workbench.vwb.user.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserManagerClient {
+public class VwbUserManagerClient {
 
-  private static final Logger logger = LoggerFactory.getLogger(UserManagerClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(VwbUserManagerClient.class);
 
   private final Provider<UserV2Api> userV2ApiProvider;
 
   private final Provider<OrganizationV2Api> organizationV2ApiProvider;
 
-  private final UserManagerRetryHandler userManagerRetryHandler;
+  private final VwbUserManagerRetryHandler vwbUserManagerRetryHandler;
 
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
 
-  public UserManagerClient(
-      @Qualifier(UserManagerConfig.VWB_SERVICE_ACCOUNT_USER_API)
+  public VwbUserManagerClient(
+      @Qualifier(VwbUserManagerConfig.VWB_SERVICE_ACCOUNT_USER_API)
           Provider<UserV2Api> userV2ApiProvider,
       Provider<OrganizationV2Api> organizationV2ApiProvider,
-      UserManagerRetryHandler userManagerRetryHandler,
+      VwbUserManagerRetryHandler vwbUserManagerRetryHandler,
       Provider<WorkbenchConfig> workbenchConfigProvider) {
     this.userV2ApiProvider = userV2ApiProvider;
     this.organizationV2ApiProvider = organizationV2ApiProvider;
-    this.userManagerRetryHandler = userManagerRetryHandler;
+    this.vwbUserManagerRetryHandler = vwbUserManagerRetryHandler;
     this.workbenchConfigProvider = workbenchConfigProvider;
   }
 
-  public OrganizationMember getOrganizationMember(String organizationId, String userName) {
-    return userManagerRetryHandler.run(
+  public OrganizationMember getOrganizationMember(String userName) {
+    String organizationId = workbenchConfigProvider.get().vwb.organizationId;
+    return vwbUserManagerRetryHandler.run(
         context ->
             organizationV2ApiProvider.get().getOrganizationMemberV2(organizationId, userName));
   }
 
-  public void createUser(UserCreateRequest email, String organizationId) {
-    userManagerRetryHandler.run(
-        context -> userV2ApiProvider.get().createUserV2(email, organizationId));
+  public void createUser(String email) {
+    String organizationId = workbenchConfigProvider.get().vwb.organizationId;
+    logger.info("Creating user in VWB with email {}", email);
+    vwbUserManagerRetryHandler.run(
+        context ->
+            userV2ApiProvider
+                .get()
+                .createUserV2(new UserCreateRequest().email(email), organizationId));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
@@ -10,6 +10,7 @@ import org.pmiops.workbench.rawls.RawlsApiClientFactory;
 import org.pmiops.workbench.vwb.user.ApiClient;
 import org.pmiops.workbench.vwb.user.api.OrganizationV2Api;
 import org.pmiops.workbench.vwb.user.api.UserV2Api;
+import org.pmiops.workbench.vwb.user.api.WorkbenchGroupApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,13 +18,14 @@ import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
-public class UserManagerConfig {
+public class VwbUserManagerConfig {
 
   public static final String VWB_SERVICE_ACCOUNT_USER_API_CLIENT =
       "VWB_SERVICE_ACCOUNT_USER_API_CLIENT";
   public static final String VWB_SERVICE_ACCOUNT_USER_API = "VWB_SERVICE_ACCOUNT_USER_API";
   public static final String VWB_SERVICE_ACCOUNT_ORGANIZATION_API =
       "VWB_SERVICE_ACCOUNT_ORGANIZATION_API";
+  private static final String VWB_SERVICE_ACCOUNT_GROUP_API = "VWB_SERVICE_ACCOUNT_GROUP_API";
 
   public static final List<String> SCOPES =
       ImmutableList.<String>builder().addAll(RawlsApiClientFactory.SCOPES).build();
@@ -62,5 +64,12 @@ public class UserManagerConfig {
   public UserV2Api serviceAccountUserV2Api(
       @Qualifier(VWB_SERVICE_ACCOUNT_USER_API_CLIENT) ApiClient apiClient) {
     return new UserV2Api(apiClient);
+  }
+
+  @Bean(name = VWB_SERVICE_ACCOUNT_GROUP_API)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public WorkbenchGroupApi groupApi(
+      @Qualifier(VWB_SERVICE_ACCOUNT_USER_API_CLIENT) ApiClient apiClient) {
+    return new WorkbenchGroupApi(apiClient);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
@@ -10,7 +10,6 @@ import org.pmiops.workbench.rawls.RawlsApiClientFactory;
 import org.pmiops.workbench.vwb.user.ApiClient;
 import org.pmiops.workbench.vwb.user.api.OrganizationV2Api;
 import org.pmiops.workbench.vwb.user.api.UserV2Api;
-import org.pmiops.workbench.vwb.user.api.WorkbenchGroupApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +24,6 @@ public class VwbUserManagerConfig {
   public static final String VWB_SERVICE_ACCOUNT_USER_API = "VWB_SERVICE_ACCOUNT_USER_API";
   public static final String VWB_SERVICE_ACCOUNT_ORGANIZATION_API =
       "VWB_SERVICE_ACCOUNT_ORGANIZATION_API";
-  private static final String VWB_SERVICE_ACCOUNT_GROUP_API = "VWB_SERVICE_ACCOUNT_GROUP_API";
 
   public static final List<String> SCOPES =
       ImmutableList.<String>builder().addAll(RawlsApiClientFactory.SCOPES).build();
@@ -64,12 +62,5 @@ public class VwbUserManagerConfig {
   public UserV2Api serviceAccountUserV2Api(
       @Qualifier(VWB_SERVICE_ACCOUNT_USER_API_CLIENT) ApiClient apiClient) {
     return new UserV2Api(apiClient);
-  }
-
-  @Bean(name = VWB_SERVICE_ACCOUNT_GROUP_API)
-  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
-  public WorkbenchGroupApi groupApi(
-      @Qualifier(VWB_SERVICE_ACCOUNT_USER_API_CLIENT) ApiClient apiClient) {
-    return new WorkbenchGroupApi(apiClient);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
@@ -35,6 +35,9 @@ public class VwbUserManagerConfig {
   private ApiClient newApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.vwb.userManagerBaseUrl);
+    apiClient.setReadTimeout(30000);
+    apiClient.setConnectTimeout(30000);
+    apiClient.setWriteTimeout(30000);
     return apiClient;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerConfig.java
@@ -27,6 +27,7 @@ public class VwbUserManagerConfig {
 
   public static final List<String> SCOPES =
       ImmutableList.<String>builder().addAll(RawlsApiClientFactory.SCOPES).build();
+  public static final int TIMEOUT = 30 * 1000;
 
   /**
    * Creates a User Manager API client, unauthenticated. Most clients should use an authenticated,
@@ -35,9 +36,9 @@ public class VwbUserManagerConfig {
   private ApiClient newApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.vwb.userManagerBaseUrl);
-    apiClient.setReadTimeout(30000);
-    apiClient.setConnectTimeout(30000);
-    apiClient.setWriteTimeout(30000);
+    apiClient.setReadTimeout(TIMEOUT);
+    apiClient.setConnectTimeout(TIMEOUT);
+    apiClient.setWriteTimeout(TIMEOUT);
     return apiClient;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerRetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerRetryHandler.java
@@ -14,9 +14,9 @@ import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.stereotype.Service;
 
 @Service
-public class UserManagerRetryHandler extends TerraServiceRetryHandler<ApiException> {
+public class VwbUserManagerRetryHandler extends TerraServiceRetryHandler<ApiException> {
 
-  private static final Logger logger = Logger.getLogger(UserManagerRetryHandler.class.getName());
+  private static final Logger logger = Logger.getLogger(VwbUserManagerRetryHandler.class.getName());
 
   private static class UserManagerRetryPolicy extends ResponseCodeRetryPolicy {
 
@@ -50,7 +50,7 @@ public class UserManagerRetryHandler extends TerraServiceRetryHandler<ApiExcepti
     }
   }
 
-  public UserManagerRetryHandler(
+  public VwbUserManagerRetryHandler(
       BackOffPolicy backOffPolicy, Provider<TermsOfServiceApi> termsOfServiceApiProvider) {
     super(
         backOffPolicy,

--- a/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmConfig.java
@@ -61,6 +61,9 @@ public class WsmConfig {
   private ApiClient newApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.vwb.wsmBaseUrl);
+    apiClient.setReadTimeout(60 * 1000);
+    apiClient.setConnectTimeout(60 * 1000);
+    apiClient.setWriteTimeout(60 * 1000);
     return apiClient;
   }
 

--- a/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmConfig.java
@@ -25,6 +25,7 @@ public class WsmConfig {
   public static final String WSM_SERVICE_ACCOUNT_API_CLIENT = "WSM_SERVICE_ACCOUNT_API_CLIENT";
   public static final String WSM_SERVICE_ACCOUNT_WORKSPACE_API =
       "WSM_SERVICE_ACCOUNT_WORKSPACE_API";
+  public static final int TIMEOUT = 60 * 1000;
 
   @Bean
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -61,9 +62,9 @@ public class WsmConfig {
   private ApiClient newApiClient(WorkbenchConfig workbenchConfig) {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(workbenchConfig.vwb.wsmBaseUrl);
-    apiClient.setReadTimeout(60 * 1000);
-    apiClient.setConnectTimeout(60 * 1000);
-    apiClient.setWriteTimeout(60 * 1000);
+    apiClient.setReadTimeout(TIMEOUT);
+    apiClient.setConnectTimeout(TIMEOUT);
+    apiClient.setWriteTimeout(TIMEOUT);
     return apiClient;
   }
 

--- a/api/src/main/resources/vwb-user-manager.yaml
+++ b/api/src/main/resources/vwb-user-manager.yaml
@@ -2164,14 +2164,12 @@ components:
         createdDate:
           description: Timestamp of creation
           type: string
-          format: date-time
         lastUpdatedBy:
           description: User email of last update
           type: string
         lastUpdatedDate:
           description: Timestamp of last update
           type: string
-          format: date-time
 
     UserFacingId:
       type: string

--- a/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/ProfileControllerTest.java
@@ -115,6 +115,7 @@ import org.pmiops.workbench.survey.NewUserSatisfactionSurveyService;
 import org.pmiops.workbench.test.FakeClock;
 import org.pmiops.workbench.test.FakeLongRandom;
 import org.pmiops.workbench.testconfig.UserServiceTestConfiguration;
+import org.pmiops.workbench.user.VwbUserService;
 import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.AuditLogEntryMapperImpl;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
@@ -155,6 +156,7 @@ public class ProfileControllerTest extends BaseControllerTest {
   @Autowired private UserDao userDao;
   @Autowired private UserTermsOfServiceDao userTermsOfServiceDao;
   @Autowired private FakeClock fakeClock;
+  @Autowired private VwbUserService vwbUserService;
 
   private static final long NONCE_LONG = 12345;
   private static final String CAPTCHA_TOKEN = "captchaToken";
@@ -219,7 +221,8 @@ public class ProfileControllerTest extends BaseControllerTest {
     NewUserSatisfactionSurveyService.class,
     TaskQueueService.class,
     LeonardoApiClient.class,
-    VwbAccessService.class
+    VwbAccessService.class,
+    VwbUserService.class
   })
   static class Configuration {
     @Bean

--- a/ui/src/environments/environment.local.ts
+++ b/ui/src/environments/environment.local.ts
@@ -21,5 +21,5 @@ export const environment: Environment = {
   inactivityTimeoutSecondsCt: 99999999999,
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: true,
-  vwbUiUrl: 'https://terra-devel-ui-terra.api.verily.com',
+  vwbUiUrl: 'https://workbench-dev.verily.com',
 };

--- a/ui/src/environments/test-env-base.ts
+++ b/ui/src/environments/test-env-base.ts
@@ -23,5 +23,5 @@ export const testEnvironmentBase: EnvironmentBase = {
   inactivityTimeoutSecondsCt: 24 * 60 * 60, // 24 hours
   allowTestAccessTokenOverride: true,
   tanagraLocalAuth: false,
-  vwbUiUrl: 'https://terra-devel-ui-terra.api.verily.com',
+  vwbUiUrl: 'https://workbench-dev.verily.com',
 };


### PR DESCRIPTION

This PR will create the user in VWB when the user first signs in in AoU. The user won't be able to create workspaces yet until we implement pod/user. This will be the next PR.
Craeting the user in VWB is behind a feature flag.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
