### PR TITLE
[risk=low][no ticket] Stop displaying "NaN GB" for genomics extraction

### DIFF
--- a/ui/src/app/components/genomics-extraction-table.tsx
+++ b/ui/src/app/components/genomics-extraction-table.tsx
@@ -149,18 +149,17 @@ const mapJobToTableRow = (
     dateStarted: job.submissionDate,
     dateStartedDisplay: formatDatetime(job.submissionDate),
     duration: durationMoment?.asSeconds(),
-    durationDisplay: !!durationMoment ? (
+    durationDisplay: durationMoment ? (
       formatDuration(durationMoment)
     ) : (
       <MissingCell />
     ),
     size: job.vcfSizeMb,
-    sizeDisplay:
-      job.vcfSizeMb === null ? (
-        <MissingCell />
-      ) : (
-        (job.vcfSizeMb / 1000).toFixed(1) + 'GB'
-      ),
+    sizeDisplay: job.vcfSizeMb ? (
+      (job.vcfSizeMb / 1000).toFixed(1) + 'GB'
+    ) : (
+      <MissingCell />
+    ),
     menuJsx: <GenomicsExtractionMenu {...{ job, workspace, onMutate }} />,
   };
 };


### PR DESCRIPTION
When a genomics extraction is in progress, we displayed some nonsensical text:

<img width="753" alt="Screenshot 2025-02-06 at 2 10 55 PM" src="https://github.com/user-attachments/assets/02117bec-c700-4340-b317-d74e14e66f7c" />


Now we don't:

<img width="698" alt="Screenshot 2025-02-06 at 2 10 14 PM" src="https://github.com/user-attachments/assets/edabb80a-e23d-41fd-891c-4782e29365de" />


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
