### PR TITLE
[risk=low][RW-14237] Set default maxRowsPerInsert to 10000 (current max) in all environments

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_local",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -148,7 +148,7 @@
   },
   "reporting": {
     "dataset": "reporting_preprod",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_prod",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app_usage"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -146,7 +146,7 @@
   },
   "reporting": {
     "dataset": "reporting_stable",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -143,7 +143,7 @@
   },
   "reporting": {
     "dataset": "reporting_staging",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_test",
-    "maxRowsPerInsert": 500,
+    "maxRowsPerInsert": 10000,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app_usage"


### PR DESCRIPTION
Note: we restrict this to an absolute max `MAX_ROWS_PER_INSERT_ALL_REQUEST` which we are updating to 50000 soon, but it missed today's release cutoff: https://github.com/all-of-us/workbench/pull/9100

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
