### PR TITLE
[risk=low][RW-14237] Enable configuring reporting batch sizes per-table

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_local",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -153,7 +153,11 @@
   "reporting": {
     "dataset": "reporting_local",
     "maxRowsPerInsert": 1000,
-    "exportTerraDataWarehouse": false
+    "exportTerraDataWarehouse": false,
+    "batchSizeOverrides": {
+      "cohort": 10000,
+      "user": 500
+    }
   },
   "ras": {
     "host": "https:\/\/stsstg.nih.gov",

--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_local",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": false,
     "batchSizeOverrides": {
       "cohort": 10000,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -148,7 +148,7 @@
   },
   "reporting": {
     "dataset": "reporting_preprod",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -148,7 +148,7 @@
   },
   "reporting": {
     "dataset": "reporting_preprod",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -154,7 +154,7 @@
     "dataset": "reporting_prod",
     "maxRowsPerInsert": 500,
     "batchSizeOverrides": {
-      "dataset_domain_value": 5000
+      "dataset_domain_value": 50000
     },
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app",

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -152,7 +152,10 @@
   },
   "reporting": {
     "dataset": "reporting_prod",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
+    "batchSizeOverrides": {
+      "dataset_domain_value": 5000
+    },
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app_usage"

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_prod",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-prod-analytics-dev.warehouse.leonardo_app_usage"

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -146,7 +146,7 @@
   },
   "reporting": {
     "dataset": "reporting_stable",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -146,7 +146,7 @@
   },
   "reporting": {
     "dataset": "reporting_stable",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -143,7 +143,7 @@
   },
   "reporting": {
     "dataset": "reporting_staging",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -143,7 +143,7 @@
   },
   "reporting": {
     "dataset": "reporting_staging",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": false
   },
   "ras": {

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_test",
-    "maxRowsPerInsert": 10000,
+    "maxRowsPerInsert": 1000,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app_usage"

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -152,7 +152,7 @@
   },
   "reporting": {
     "dataset": "reporting_test",
-    "maxRowsPerInsert": 1000,
+    "maxRowsPerInsert": 500,
     "exportTerraDataWarehouse": true,
     "terraWarehouseLeoAppTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app",
     "terraWarehouseLeoAppUsageTableId": "broad-dsde-dev-analytics-dev.warehouse.leonardo_app_usage"

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -376,26 +376,6 @@ public class WorkbenchConfig {
     public boolean useTestCaptcha;
   }
 
-  //
-  //  // temporary (?) kluge while we work on a better solution for reporting
-  //  // need to keep this up to date with the RWB table names in ReportingTableService
-  //  // (this is either the "matchingTableName" or the table denoted specifically as RWB when it
-  //  // differs from BQ)
-  //  // sizes limited to less than
-  // InsertAllRequestPayloadTransformer.MAX_ROWS_PER_INSERT_ALL_REQUEST
-  //  public static class BatchSizeOverrides {
-  //    public Integer cohort;
-  //    public Integer data_set_values;
-  //    public Integer data_set;
-  //    public Integer institution;
-  //    public Integer new_user_satisfaction_survey;
-  //    public Integer user_general_discovery_source;
-  //    public Integer user_partner_discovery_source;
-  //    public Integer user;
-  //    public Integer workspace_free_tier_usage;
-  //    public Integer workspace;
-  //  }
-
   public static class ReportingConfig {
     public String dataset;
     // Max rows per batch queried in MySQL, and also the upload batch size for BigQuery. Max

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -4,6 +4,7 @@ import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig.CDRv8PlusConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig.LegacyWorkflowConfig;
 
@@ -375,23 +376,25 @@ public class WorkbenchConfig {
     public boolean useTestCaptcha;
   }
 
-  // temporary (?) kluge while we work on a better solution for reporting
-  // need to keep this up to date with the RWB table names in ReportingTableService
-  // (this is either the "matchingTableName" or the table denoted specifically as RWB when it
-  // differs from BQ)
-  // sizes limited to less than InsertAllRequestPayloadTransformer.MAX_ROWS_PER_INSERT_ALL_REQUEST
-  public static class BatchSizeOverrides {
-    public Integer cohort;
-    public Integer data_set_values;
-    public Integer data_set;
-    public Integer institution;
-    public Integer new_user_satisfaction_survey;
-    public Integer user_general_discovery_source;
-    public Integer user_partner_discovery_source;
-    public Integer user;
-    public Integer workspace_free_tier_usage;
-    public Integer workspace;
-  }
+  //
+  //  // temporary (?) kluge while we work on a better solution for reporting
+  //  // need to keep this up to date with the RWB table names in ReportingTableService
+  //  // (this is either the "matchingTableName" or the table denoted specifically as RWB when it
+  //  // differs from BQ)
+  //  // sizes limited to less than
+  // InsertAllRequestPayloadTransformer.MAX_ROWS_PER_INSERT_ALL_REQUEST
+  //  public static class BatchSizeOverrides {
+  //    public Integer cohort;
+  //    public Integer data_set_values;
+  //    public Integer data_set;
+  //    public Integer institution;
+  //    public Integer new_user_satisfaction_survey;
+  //    public Integer user_general_discovery_source;
+  //    public Integer user_partner_discovery_source;
+  //    public Integer user;
+  //    public Integer workspace_free_tier_usage;
+  //    public Integer workspace;
+  //  }
 
   public static class ReportingConfig {
     public String dataset;
@@ -409,7 +412,8 @@ public class WorkbenchConfig {
     public String terraWarehouseLeoAppUsageTableId;
 
     // OPTIONAL: overrides for batch sizes for specific tables
-    public BatchSizeOverrides batchSizeOverrides;
+    // uses the BQ table name when it differs from the RWB table name (or none exists)
+    public Map<String, Integer> batchSizeOverrides;
   }
 
   /** RAS(Researcher Auth Service) configurations. */

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -375,6 +375,24 @@ public class WorkbenchConfig {
     public boolean useTestCaptcha;
   }
 
+  // temporary (?) kluge while we work on a better solution for reporting
+  // need to keep this up to date with the RWB table names in ReportingTableService
+  // (this is either the "matchingTableName" or the table denoted specifically as RWB when it
+  // differs from BQ)
+  // sizes limited to less than InsertAllRequestPayloadTransformer.MAX_ROWS_PER_INSERT_ALL_REQUEST
+  public static class BatchSizeOverrides {
+    public Integer cohort;
+    public Integer data_set_values;
+    public Integer data_set;
+    public Integer institution;
+    public Integer new_user_satisfaction_survey;
+    public Integer user_general_discovery_source;
+    public Integer user_partner_discovery_source;
+    public Integer user;
+    public Integer workspace_free_tier_usage;
+    public Integer workspace;
+  }
+
   public static class ReportingConfig {
     public String dataset;
     // Max rows per batch queried in MySQL, and also the upload batch size for BigQuery. Max
@@ -389,6 +407,9 @@ public class WorkbenchConfig {
     public String terraWarehouseLeoAppTableId;
     // Terra Data Warehouse leonardo_app_usage BQ table id.
     public String terraWarehouseLeoAppUsageTableId;
+
+    // OPTIONAL: overrides for batch sizes for specific tables
+    public BatchSizeOverrides batchSizeOverrides;
   }
 
   /** RAS(Researcher Auth Service) configurations. */

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryService.java
@@ -8,8 +8,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingDataset;
-import org.pmiops.workbench.model.ReportingDatasetCohort;
-import org.pmiops.workbench.model.ReportingDatasetConceptSet;
 import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
 import org.pmiops.workbench.model.ReportingLeonardoAppUsage;
@@ -23,10 +21,6 @@ import org.pmiops.workbench.model.ReportingWorkspaceFreeTierUsage;
 /** Expose handy, performant queries that don't require Dao, Entity, or Projection classes. */
 public interface ReportingQueryService {
   List<ReportingDataset> getDatasetBatch(long limit, long offset);
-
-  List<ReportingDatasetCohort> getDatasetCohortBatch(long limit, long offset);
-
-  List<ReportingDatasetConceptSet> getDatasetConceptSetBatch(long limit, long offset);
 
   List<ReportingDatasetDomainIdValue> getDatasetDomainIdValueBatch(long limit, long offset);
 

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -37,8 +37,6 @@ import org.pmiops.workbench.model.InstitutionMembershipRequirement;
 import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
 import org.pmiops.workbench.model.ReportingCohort;
 import org.pmiops.workbench.model.ReportingDataset;
-import org.pmiops.workbench.model.ReportingDatasetCohort;
-import org.pmiops.workbench.model.ReportingDatasetConceptSet;
 import org.pmiops.workbench.model.ReportingDatasetDomainIdValue;
 import org.pmiops.workbench.model.ReportingInstitution;
 import org.pmiops.workbench.model.ReportingLeonardoAppUsage;
@@ -55,7 +53,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ReportingQueryServiceImpl implements ReportingQueryService {
-  private static final long MAX_ROWS_PER_INSERT_ALL_REQUEST = 10_000;
   private final JdbcTemplate jdbcTemplate;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final BigQueryService bigQueryService;
@@ -222,36 +219,6 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .lastModifiedTime(offsetDateTimeUtc(rs.getTimestamp("last_modified_time")))
                 .name(rs.getString("name"))
                 .workspaceId(rs.getLong("workspace_id")));
-  }
-
-  @Override
-  public List<ReportingDatasetCohort> getDatasetCohortBatch(long limit, long offset) {
-    return jdbcTemplate.query(
-        String.format(
-            "SELECT data_set_id, cohort_id\n"
-                + "FROM data_set_cohort\n"
-                + "  LIMIT %d\n"
-                + "  OFFSET %d",
-            limit, offset),
-        (rs, unused) ->
-            new ReportingDatasetCohort()
-                .cohortId(rs.getLong("cohort_id"))
-                .datasetId(rs.getLong("data_set_id")));
-  }
-
-  @Override
-  public List<ReportingDatasetConceptSet> getDatasetConceptSetBatch(long limit, long offset) {
-    return jdbcTemplate.query(
-        String.format(
-            "SELECT data_set_id, concept_set_id\n"
-                + "FROM data_set_concept_set\n"
-                + "  LIMIT %d\n"
-                + "  OFFSET %d",
-            limit, offset),
-        (rs, unused) ->
-            new ReportingDatasetConceptSet()
-                .datasetId(rs.getLong("data_set_id"))
-                .conceptSetId(rs.getLong("concept_set_id")));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableParams.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableParams.java
@@ -8,7 +8,7 @@ import org.pmiops.workbench.reporting.insertion.InsertAllRequestPayloadTransform
 
 public record ReportingTableParams<T extends ReportingBase>(
     String bqTableName,
-    long batchSize,
+    int batchSize,
     InsertAllRequestPayloadTransformer<T> bqInsertionBuilder,
     BiFunction<Long, Long, List<T>> rwbBatchQueryFn,
     IntSupplier rwbTableCountFn) {}

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
@@ -90,11 +90,11 @@ public class ReportingTableService {
         workspaceFreeTierUsage());
   }
 
-  private int batchSize(String rwbTableName) {
+  private int batchSize(String bqTableName) {
     ReportingConfig config = workbenchConfigProvider.get().reporting;
     int wantedSize =
         Optional.ofNullable(config.batchSizeOverrides)
-            .flatMap(overrides -> Optional.ofNullable(overrides.get(rwbTableName)))
+            .flatMap(overrides -> Optional.ofNullable(overrides.get(bqTableName)))
             .orElse(config.maxRowsPerInsert);
 
     // don't exceed the max rows allowed by the BQ API


### PR DESCRIPTION
#9101 was not successful.  For some tables (at least cohort on Prod) that batch size is actually too big, and causes the insertion to fail because it exceeds the max size of 10 MB.

This is hopefully a way to enable a short-term solution by fine-tuning the right batch sizes for each table in each environment.  Once this is deployed, we can update these values by config changes instead of releases.

Unfortunately this is probably not a long-term solution, as the tables will continue growing.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
