### PR TITLE
 [risk=low][RW-13494] Rename expiry to exhaustion where appropriate

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
@@ -72,7 +72,7 @@ public class CloudTaskInitialCreditsExhaustionController
     }
 
     logger.info(
-        "Free tier Billing Service: Handling initial credits expiry event for users: {}",
+        "handleInitialCreditsExhaustionBatch: Processing request for users: {}",
         request.getUsers().toString());
 
     Iterable<DbUser> users = userDao.findAllById(request.getUsers());
@@ -92,7 +92,7 @@ public class CloudTaskInitialCreditsExhaustionController
     alertUsersBasedOnTheThreshold(usersSet, dbCostByCreator, liveCostByCreator, newlyExpiredUsers);
 
     logger.info(
-        "Free tier Billing Service: Finished handling initial credits expiry event for users: {}",
+        "handleInitialCreditsExhaustionBatch: Finished processing request for users: {}",
         request.getUsers().toString());
 
     return ResponseEntity.noContent().build();

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionController.java
@@ -33,11 +33,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class CloudTaskInitialCreditsExpiryController
-    implements CloudTaskInitialCreditExpiryApiDelegate {
+public class CloudTaskInitialCreditsExhaustionController
+    implements CloudTaskInitialCreditExhaustionApiDelegate {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(CloudTaskInitialCreditsExpiryController.class);
+      LoggerFactory.getLogger(CloudTaskInitialCreditsExhaustionController.class);
 
   private final WorkspaceDao workspaceDao;
   private final WorkspaceService workspaceService;
@@ -46,7 +46,7 @@ public class CloudTaskInitialCreditsExpiryController
   private final LeonardoApiClient leonardoApiClient;
   private final MailService mailService;
 
-  CloudTaskInitialCreditsExpiryController(
+  CloudTaskInitialCreditsExhaustionController(
       WorkspaceDao workspaceDao,
       WorkspaceService workspaceService,
       UserDao userDao,
@@ -63,7 +63,7 @@ public class CloudTaskInitialCreditsExpiryController
 
   @SuppressWarnings("unchecked")
   @Override
-  public ResponseEntity<Void> handleInitialCreditsExpiryBatch(
+  public ResponseEntity<Void> handleInitialCreditsExhaustionBatch(
       ExpiredInitialCreditsEventRequest request) {
 
     if (request.getUsers().isEmpty()) {

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -232,7 +232,7 @@ public class TaskQueueService {
             "Authorization", "Bearer " + userAuthenticationProvider.get().getCredentials()));
   }
 
-  public void pushInitialCreditsExpiryTask(
+  public void pushInitialCreditsExhaustionTask(
       List<Long> users, Map<Long, Double> dbCostByCreator, Map<Long, Double> liveCostByCreator) {
     createAndPushTask(
         EXPIRED_FREE_CREDITS_QUEUE_NAME,

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -50,8 +50,8 @@ public class TaskQueueService {
   private static final String DELETE_WORKSPACE_ENVIRONMENTS_PATH =
       BASE_PATH + "/deleteUnsharedWorkspaceEnvironments";
 
-  private static final String INITIAL_CREDITS_EXPIRY_PATH =
-      BASE_PATH + "/handleInitialCreditsExpiry";
+  private static final String INITIAL_CREDITS_EXHAUSTION_PATH =
+      BASE_PATH + "/handleInitialCreditsExhaustion";
   private static final String AUDIT_PROJECTS_QUEUE_NAME = "auditProjectQueue";
   private static final String SYNCHRONIZE_ACCESS_QUEUE_NAME = "synchronizeAccessQueue";
   private static final String ACCESS_EXPIRATION_EMAIL_QUEUE_NAME = "accessExpirationEmailQueue";
@@ -236,7 +236,7 @@ public class TaskQueueService {
       List<Long> users, Map<Long, Double> dbCostByCreator, Map<Long, Double> liveCostByCreator) {
     createAndPushTask(
         EXPIRED_FREE_CREDITS_QUEUE_NAME,
-        INITIAL_CREDITS_EXPIRY_PATH,
+        INITIAL_CREDITS_EXHAUSTION_PATH,
         new ExpiredInitialCreditsEventRequest()
             .users(users)
             .dbCostByCreator(dbCostByCreator)

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -142,7 +142,7 @@ public class InitialCreditsService {
       return;
     }
 
-    taskQueueService.pushInitialCreditsExpiryTask(
+    taskQueueService.pushInitialCreditsExhaustionTask(
         filteredUsers.stream().map(DbUser::getUserId).toList(), dbCostByCreator, liveCostByCreator);
   }
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4371,14 +4371,14 @@ paths:
           description: Users alerted
           content: { }
       x-codegen-request-body-name: request
-  /v1/cloudTask/handleInitialCreditsExpiry:
+  /v1/cloudTask/handleInitialCreditsExhaustion:
     post:
       tags:
-        - cloudTaskInitialCreditExpiry
+        - cloudTaskInitialCreditExhaustion
         - cloudTask
       description: |
         Run the business logic to handle users who have consumed or about to consume their free credits. Including disabling their workspaces and sending them notifications.
-      operationId: handleInitialCreditsExpiryBatch
+      operationId: handleInitialCreditsExhaustionBatch
       security: [ ]
       requestBody:
         description: Users that should be alerted about their free credits use.
@@ -4389,7 +4389,7 @@ paths:
         required: true
       responses:
         200:
-          description: Handle Free Credits Expiry Task Ran Successfully
+          description: Handle Free Credits Exhaustion Task Ran Successfully
           content: { }
       x-codegen-request-body-name: request
   /v1/cloudTask/checkCreditsExpirationForUserIDs:

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
@@ -86,7 +86,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
   @Autowired InitialCreditsService initialCreditsService;
   @Autowired MailService mailService;
 
-  @Autowired CloudTaskInitialCreditsExhaustionController cloudTaskInitialCreditsExpiryController;
+  @Autowired CloudTaskInitialCreditsExhaustionController controller;
 
   private DbInstitution dbInstitution;
 
@@ -182,20 +182,20 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     // check that we have not alerted before the threshold
     ExpiredInitialCreditsEventRequest request =
         buildExpiredInitialCreditsEventRequest(List.of(user), allBQCosts, allDbCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
 
     // check that we alert for the 50% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     request.setLiveCostByCreator(allBQCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
 
     // check that we do not alert twice for the 50% threshold
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for the 75% threshold
@@ -205,14 +205,14 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     request.setLiveCostByCreator(allBQCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
 
     // check that we do not alert twice for the 75% threshold
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for expiration when we hit 100%
@@ -221,12 +221,12 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
     request.setLiveCostByCreator(allBQCosts);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
     // check that we do not alert twice for 100%
     allDbCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
   }
 
@@ -260,13 +260,13 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     ExpiredInitialCreditsEventRequest request =
         buildExpiredInitialCreditsEventRequest(List.of(user), allBQCosts, allDbCosts);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
 
     // check that we alert for the 30% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costUnderThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
@@ -274,7 +274,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     // check that we do not alert twice for the 30% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for the 65% threshold
@@ -284,7 +284,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     remaining = limit - costOverThreshold;
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
@@ -293,7 +293,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for expiration when we hit 100%
@@ -301,14 +301,14 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     final double costToTriggerExpiration = 100.01;
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
     // check that we do not alert twice for 100%
 
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
     allDbCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
   }
 
@@ -330,7 +330,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(true);
@@ -353,7 +353,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
@@ -374,7 +374,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
   }
@@ -394,7 +394,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
   }
@@ -410,7 +410,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 150.0);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -421,7 +421,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 150.0)));
 
@@ -444,7 +444,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 300.0);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -453,7 +453,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     initialCreditsService.maybeSetDollarLimitOverride(user, 200.0);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(true);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 300.0)));
     verifyNoMoreInteractions(mailService);
@@ -478,7 +478,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), sum);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -511,7 +511,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     allBQCosts.put(String.valueOf(user1.getUserId()), cost1);
     allBQCosts.put(String.valueOf(user2.getUserId()), cost2);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user1, user2),
             allBQCosts,
@@ -537,7 +537,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 100.01);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -549,7 +549,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     allBQCosts.put(String.valueOf(user.getUserId()), newTotalCost);
 
     // we do not alert again
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 100.01)));
     verify(mailService, times(1)).alertUserInitialCreditsExhausted(eq(user));
@@ -570,7 +570,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 100.01);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -578,7 +578,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     // Simulate the user attaching their own billing account to the previously free tier workspace.
     workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 100.01)));
     verifyNoMoreInteractions(mailService);
@@ -602,7 +602,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     workspaceDao.save(userAccountWorkspace);
 
     Map<String, Double> allBQCosts = Map.of(String.valueOf(user.getUserId()), 100.01);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -628,14 +628,14 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     workspace.setLastModifiedTime(Timestamp.valueOf(LocalDateTime.now()));
     workspaceDao.save(workspace);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verifyNoInteractions(mailService);
 
     allBQCosts = Map.of(String.valueOf(user.getUserId()), 100.1);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 50.0)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -656,7 +656,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
     workspace.setLastModifiedTime(Timestamp.valueOf(LocalDateTime.now()));
     workspaceDao.save(workspace);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verifyNoInteractions(mailService);
@@ -666,7 +666,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), 100.1);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
+    controller.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 50.0)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -703,7 +703,7 @@ class CloudTaskInitialCreditsExhaustionControllerTest {
             String.valueOf(user2.getUserId()), 0d,
             String.valueOf(user3.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
+    controller.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(eq(user3), eq(0.5d), eq(151.0d), eq(149.0d));

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskInitialCreditsExhaustionControllerTest.java
@@ -73,12 +73,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 
 @DataJpaTest
-class CloudTaskInitialCreditsExpiryControllerTest {
+class CloudTaskInitialCreditsExhaustionControllerTest {
 
   private static final Instant START_INSTANT = Instant.parse("2000-01-01T00:00:00.00Z");
   private static final FakeClock CLOCK = new FakeClock(START_INSTANT);
-
-  @Autowired MailService mailService;
 
   @Autowired UserDao userDao;
   @Autowired WorkspaceDao workspaceDao;
@@ -86,8 +84,9 @@ class CloudTaskInitialCreditsExpiryControllerTest {
   @Autowired VerifiedInstitutionalAffiliationDao verifiedInstitutionalAffiliationDao;
 
   @Autowired InitialCreditsService initialCreditsService;
+  @Autowired MailService mailService;
 
-  @Autowired CloudTaskInitialCreditsExpiryController cloudTaskInitialCreditsExpiryController;
+  @Autowired CloudTaskInitialCreditsExhaustionController cloudTaskInitialCreditsExpiryController;
 
   private DbInstitution dbInstitution;
 
@@ -99,31 +98,31 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
   @TestConfiguration
   @Import({
-    CloudTaskInitialCreditsExpiryController.class,
+    CloudTaskInitialCreditsExhaustionController.class,
+    InitialCreditsService.class,
     WorkspaceServiceImpl.class,
-    InitialCreditsService.class
   })
   @MockBean({
     AccessTierService.class,
     BillingProjectAuditor.class,
+    CloudBillingClient.class,
     CohortCloningService.class,
     ConceptSetService.class,
-    CloudBillingClient.class,
     DataSetService.class,
     FeaturedWorkspaceMapper.class,
-    FirecloudMapper.class,
     FireCloudService.class,
+    FirecloudMapper.class,
     ImpersonatedWorkspaceService.class,
     InstitutionService.class,
     LeonardoApiClient.class,
     MailService.class,
     TaskQueueService.class,
     UserMapper.class,
+    UserService.class,
     UserServiceAuditor.class,
+    WorkspaceAuthService.class,
     WorkspaceInitialCreditUsageService.class,
     WorkspaceMapper.class,
-    WorkspaceAuthService.class,
-    UserService.class
   })
   static class Configuration {
     @Bean
@@ -183,20 +182,20 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     // check that we have not alerted before the threshold
     ExpiredInitialCreditsEventRequest request =
         buildExpiredInitialCreditsEventRequest(List.of(user), allBQCosts, allDbCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
 
     // check that we alert for the 50% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     request.setLiveCostByCreator(allBQCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
 
     // check that we do not alert twice for the 50% threshold
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for the 75% threshold
@@ -206,14 +205,14 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     request.setLiveCostByCreator(allBQCosts);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
 
     // check that we do not alert twice for the 75% threshold
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for expiration when we hit 100%
@@ -222,12 +221,12 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
     request.setLiveCostByCreator(allBQCosts);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
     // check that we do not alert twice for 100%
     allDbCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
   }
 
@@ -261,13 +260,13 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     ExpiredInitialCreditsEventRequest request =
         buildExpiredInitialCreditsEventRequest(List.of(user), allBQCosts, allDbCosts);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
 
     // check that we alert for the 30% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costUnderThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
@@ -275,7 +274,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     // check that we do not alert twice for the 30% threshold
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for the 65% threshold
@@ -285,7 +284,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     remaining = limit - costOverThreshold;
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(
             eq(user), eq(threshold), eq(costOverThreshold), eq(remaining));
@@ -294,7 +293,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
     allDbCosts.put(String.valueOf(user.getUserId()), costOverThreshold);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
 
     // check that we alert for expiration when we hit 100%
@@ -302,14 +301,14 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     final double costToTriggerExpiration = 100.01;
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
     // check that we do not alert twice for 100%
 
     allBQCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
     allDbCosts.put(String.valueOf(user.getUserId()), costToTriggerExpiration);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoMoreInteractions(mailService);
   }
 
@@ -331,7 +330,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(true);
@@ -354,7 +353,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
@@ -375,7 +374,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
   }
@@ -395,7 +394,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
     verifyNoInteractions(mailService);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
   }
@@ -411,7 +410,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 150.0);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -422,7 +421,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(false);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 150.0)));
 
@@ -445,7 +444,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 300.0);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -454,7 +453,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     initialCreditsService.maybeSetDollarLimitOverride(user, 200.0);
     assertThat(workspace.isInitialCreditsExhausted()).isEqualTo(true);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 300.0)));
     verifyNoMoreInteractions(mailService);
@@ -479,12 +478,12 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), sum);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
 
-    // confirm DB updates after handleInitialCreditsExpiryBatch()
+    // confirm DB updates after handleInitialCreditsExhaustionBatch()
 
     for (DbWorkspace ws : Arrays.asList(ws1, ws2)) {
       // retrieve from DB again to reflect update after cron
@@ -512,7 +511,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     allBQCosts.put(String.valueOf(user1.getUserId()), cost1);
     allBQCosts.put(String.valueOf(user2.getUserId()), cost2);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user1, user2),
             allBQCosts,
@@ -538,7 +537,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 100.01);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -550,7 +549,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     allBQCosts.put(String.valueOf(user.getUserId()), newTotalCost);
 
     // we do not alert again
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 100.01)));
     verify(mailService, times(1)).alertUserInitialCreditsExhausted(eq(user));
@@ -571,7 +570,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     Map<String, Double> allBQCosts = Maps.newHashMap();
     allBQCosts.put(String.valueOf(user.getUserId()), 100.01);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -579,7 +578,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     // Simulate the user attaching their own billing account to the previously free tier workspace.
     workspaceDao.save(workspace.setBillingAccountName(fullBillingAccountName("byo-account")));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 100.01)));
     verifyNoMoreInteractions(mailService);
@@ -603,7 +602,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     workspaceDao.save(userAccountWorkspace);
 
     Map<String, Double> allBQCosts = Map.of(String.valueOf(user.getUserId()), 100.01);
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -629,14 +628,14 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     workspace.setLastModifiedTime(Timestamp.valueOf(LocalDateTime.now()));
     workspaceDao.save(workspace);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verifyNoInteractions(mailService);
 
     allBQCosts = Map.of(String.valueOf(user.getUserId()), 100.1);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 50.0)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -657,7 +656,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
     workspace.setLastModifiedTime(Timestamp.valueOf(LocalDateTime.now()));
     workspaceDao.save(workspace);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 0d)));
     verifyNoInteractions(mailService);
@@ -667,7 +666,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
 
     allBQCosts.put(String.valueOf(user.getUserId()), 100.1);
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(
         buildExpiredInitialCreditsEventRequest(
             List.of(user), allBQCosts, Map.of(String.valueOf(user.getUserId()), 50.0)));
     verify(mailService).alertUserInitialCreditsExhausted(eq(user));
@@ -704,7 +703,7 @@ class CloudTaskInitialCreditsExpiryControllerTest {
             String.valueOf(user2.getUserId()), 0d,
             String.valueOf(user3.getUserId()), 0d));
 
-    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExpiryBatch(request);
+    cloudTaskInitialCreditsExpiryController.handleInitialCreditsExhaustionBatch(request);
 
     verify(mailService)
         .alertUserInitialCreditsDollarThreshold(eq(user3), eq(0.5d), eq(151.0d), eq(149.0d));

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -194,7 +194,7 @@ public class InitialCreditsServiceTest {
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, costOverThreshold);
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costUnderThreshold))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costOverThreshold))));
@@ -205,7 +205,7 @@ public class InitialCreditsServiceTest {
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, costOverThreshold);
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 50.5d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costOverThreshold))));
@@ -218,7 +218,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costOverThreshold))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costToTriggerExpiration))));
@@ -252,7 +252,7 @@ public class InitialCreditsServiceTest {
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, costOverThreshold);
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costUnderThreshold))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costOverThreshold))));
@@ -262,7 +262,7 @@ public class InitialCreditsServiceTest {
     allBQCosts.put(SINGLE_WORKSPACE_TEST_PROJECT, costOverThreshold);
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(
                 new MapMatcher(Map.of(user.getUserId(), 30.1))), // The previous costOverThreshold
@@ -274,7 +274,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costOverThreshold))),
             argThat(new MapMatcher(Map.of(user.getUserId(), costToTriggerExpiration))));
@@ -295,7 +295,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01))));
@@ -319,7 +319,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01))));
@@ -422,7 +422,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 150.0))));
@@ -459,7 +459,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 300.0))));
@@ -501,7 +501,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), cost1 + cost2))));
@@ -539,7 +539,7 @@ public class InitialCreditsServiceTest {
     initialCreditsService.checkFreeTierBillingUsageForUsers(
         Sets.newHashSet(user1, user2), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user1.getUserId(), user2.getUserId()))),
             argThat(new MapMatcher(Map.of(user1.getUserId(), 0.0d, user2.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user1.getUserId(), cost1, user2.getUserId(), cost2))));
@@ -569,7 +569,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01))));
@@ -586,7 +586,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService, times(1))
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 123.45))));
@@ -614,7 +614,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01))));
@@ -768,7 +768,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 0.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.01d))));
@@ -803,7 +803,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 50.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 100.1))));
@@ -838,7 +838,7 @@ public class InitialCreditsServiceTest {
 
     initialCreditsService.checkFreeTierBillingUsageForUsers(Sets.newHashSet(user), allBQCosts);
     verify(taskQueueService)
-        .pushInitialCreditsExpiryTask(
+        .pushInitialCreditsExhaustionTask(
             argThat(new UserListMatcher(List.of(user.getUserId()))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 50.0d))),
             argThat(new MapMatcher(Map.of(user.getUserId(), 150.1d))));


### PR DESCRIPTION
We now have similar concepts of "exhausted initial credits" meaning the user exceeded the dollar amount and "expired initial credits" meaning that the time period when a user was eligible to use those credits has ended.

Prior to this, we sometimes used the word "expiry" to mean what we currently call "exhaustion" and this has become confusing.  Let's rename this.

We have other PRs #8994 and #9092 which rename larger portions of code, but they have been getting out of date quickly due to work in this area.  This PR is aiming for a quick review and merge before we change too much again.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
