### PR TITLE
[no ticket][risk=no] Fixing a bug where group and user order is wrong

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/VwbAccessService.java
+++ b/api/src/main/java/org/pmiops/workbench/access/VwbAccessService.java
@@ -32,7 +32,7 @@ public class VwbAccessService {
   public void addUserIntoVwbTier(String userName, String vwbGroupName) {
     if (workbenchConfigProvider.get().featureFlags.enableVWBUserAccessManagement) {
       try {
-        vwbSamClient.addUserToGroup(userName, vwbGroupName);
+        vwbSamClient.addUserToGroup(vwbGroupName, userName);
       } catch (Exception e) {
         log.log(Level.WARNING, "Failed to add user to Vwb tier group: " + e.getMessage(), e);
       }
@@ -49,7 +49,7 @@ public class VwbAccessService {
   public void removeUserFromVwbTier(String userName, String vwbGroupName) {
     if (workbenchConfigProvider.get().featureFlags.enableVWBUserAccessManagement) {
       try {
-        vwbSamClient.removeUserFromGroup(userName, vwbGroupName);
+        vwbSamClient.removeUserFromGroup(vwbGroupName, userName);
       } catch (Exception e) {
         log.log(Level.WARNING, "Failed to remove user from Vwb tier group: " + e.getMessage(), e);
       }

--- a/api/src/test/java/org/pmiops/workbench/access/VwbAccessServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/VwbAccessServiceTest.java
@@ -32,13 +32,13 @@ public class VwbAccessServiceTest {
   @Test
   public void testAddUserIntoVwbTier_featureEnabled() {
     vwbAccessService.addUserIntoVwbTier("test-user", "test-group");
-    verify(mockVwbSamClient).addUserToGroup("test-user", "test-group");
+    verify(mockVwbSamClient).addUserToGroup("test-group", "test-user");
   }
 
   @Test
   public void testAddUserIntoVwbTier_featureDisabled() {
     vwbAccessService.removeUserFromVwbTier("test-user", "test-group");
-    verify(mockVwbSamClient).removeUserFromGroup("test-user", "test-group");
+    verify(mockVwbSamClient).removeUserFromGroup("test-group", "test-user");
   }
 
   @Test


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
