### PR TITLE
[risk=low][RW-14368] Move checkPersistentDisks() to new DiskAdminService

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/DiskAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/DiskAdminController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class DiskAdminController implements DiskAdminApiDelegate {
 
+  // TODO: switch to DiskAdminService?
   private final DiskService diskService;
 
   @Autowired

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -1,49 +1,19 @@
 package org.pmiops.workbench.api;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
 import jakarta.inject.Provider;
-import jakarta.mail.MessagingException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
-import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.disks.DiskAdminService;
 import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.firecloud.FirecloudTransforms;
-import org.pmiops.workbench.initialcredits.InitialCreditsService;
-import org.pmiops.workbench.legacy_leonardo_client.ApiException;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
-import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.WorkspaceAccessLevel;
-import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
-import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
-import org.pmiops.workbench.utils.BillingUtils;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,11 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDelegate {
   private static final Logger log = Logger.getLogger(OfflineEnvironmentsController.class.getName());
 
-  // On the n'th day of inactivity on a PD, a notification is sent.
-  private static final Set<Integer> INACTIVE_DISK_NOTIFY_THRESHOLDS_DAYS = ImmutableSet.of(14);
-  // Every n'th day of inactivity on a PD (not including 0), a notification is sent.
-  private static final int INACTIVE_DISK_NOTIFY_PERIOD_DAYS = 30;
-
   // This is temporary while we wait for Leonardo autopause to rollout. Once
   // available, we should instead take a runtime status of STOPPED to trigger
   // idle deletion.
@@ -72,39 +37,27 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   private final Provider<WorkbenchConfig> configProvider;
   private final Clock clock;
 
-  private final FireCloudService fireCloudService;
-  private final InitialCreditsService initialCreditsService;
+  private final DiskAdminService diskAdminService;
   private final LeonardoApiClient leonardoApiClient;
   private final LeonardoMapper leonardoMapper;
-  private final MailService mailService;
   private final TaskQueueService taskQueueService;
-  private final UserDao userDao;
-  private final WorkspaceDao workspaceDao;
   private final WorkspaceService workspaceService;
 
   @Autowired
   OfflineEnvironmentsController(
       Clock clock,
-      FireCloudService firecloudService,
-      InitialCreditsService initialCreditsService,
+      DiskAdminService diskAdminService,
       LeonardoApiClient leonardoApiClient,
       LeonardoMapper leonardoMapper,
-      MailService mailService,
       Provider<WorkbenchConfig> configProvider,
       TaskQueueService taskQueueService,
-      UserDao userDao,
-      WorkspaceDao workspaceDao,
       WorkspaceService workspaceService) {
     this.clock = clock;
     this.configProvider = configProvider;
-    this.fireCloudService = firecloudService;
-    this.initialCreditsService = initialCreditsService;
+    this.diskAdminService = diskAdminService;
     this.leonardoApiClient = leonardoApiClient;
     this.leonardoMapper = leonardoMapper;
-    this.mailService = mailService;
     this.taskQueueService = taskQueueService;
-    this.userDao = userDao;
-    this.workspaceDao = workspaceDao;
     this.workspaceService = workspaceService;
   }
 
@@ -216,170 +169,8 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
 
   @Override
   public ResponseEntity<Void> checkPersistentDisks() {
-    // Fetch disks as the service, which gets all disks for all workspaces.
-    final List<ListPersistentDiskResponse> disks = leonardoApiClient.listDisksAsService();
-
-    log.info(String.format("Checking %d persistent disks for idleness...", disks.size()));
-
-    // Bucket disks by days since last access.
-    final Instant now = clock.instant();
-    Map<Integer, List<ListPersistentDiskResponse>> disksByDaysUnused =
-        disks.stream()
-            .filter(disk -> DiskStatus.READY.equals(disk.getStatus()))
-            .collect(
-                Collectors.groupingBy(
-                    disk -> {
-                      Instant lastAccessed = Instant.parse(disk.getAuditInfo().getDateAccessed());
-                      return (int) Duration.between(lastAccessed, now).toDays();
-                    }));
-
-    // Dispatch notifications if any disks are the right number of days old.
-    int notifySuccess = 0;
-    int notifySkip = 0;
-    int notifyFail = 0;
-    Exception lastException = null;
-    for (int daysUnused : disksByDaysUnused.keySet()) {
-      if (daysUnused <= 0) {
-        // Our periodic notifications should not trigger on day 0.
-        continue;
-      }
-
-      if (!INACTIVE_DISK_NOTIFY_THRESHOLDS_DAYS.contains(daysUnused)
-          && daysUnused % INACTIVE_DISK_NOTIFY_PERIOD_DAYS != 0) {
-        continue;
-      }
-
-      for (ListPersistentDiskResponse disk : disksByDaysUnused.get(daysUnused)) {
-        try {
-          if (notifyForUnusedDisk(disk, daysUnused)) {
-            notifySuccess++;
-          } else {
-            notifySkip++;
-          }
-        } catch (MessagingException e) {
-          log.log(
-              Level.WARNING,
-              String.format(
-                  "checkPersistentDisks: failed to send notification for disk '%s/%s'",
-                  leonardoMapper.toGoogleProject(disk.getCloudContext()), disk.getName()),
-              e);
-          lastException = e;
-          notifyFail++;
-        }
-      }
-    }
-
-    log.info(
-        String.format(
-            "checkPersistentDisks: sent %d notifications successfully (%d skipped, %d failed)",
-            notifySuccess, notifySkip, notifyFail));
-    if (lastException != null) {
-      throw new ServerErrorException(
-          String.format(
-              "checkPersistentDisks: %d/%d disk notifications failed to send, see logs for details",
-              notifyFail, notifySuccess + notifyFail + notifySkip),
-          lastException);
-    }
-
+    diskAdminService.checkPersistentDisks();
     return ResponseEntity.noContent().build();
-  }
-
-  // Returns true if an email is sent.
-  private boolean notifyForUnusedDisk(ListPersistentDiskResponse disk, int daysUnused)
-      throws MessagingException {
-    String googleProject = leonardoMapper.toGoogleProject(disk.getCloudContext());
-    final boolean attached;
-    try {
-      attached = isDiskAttached(disk, googleProject);
-    } catch (ApiException | NullPointerException ex) {
-      log.warning(
-          String.format(
-              "skipping disk '%s' error while getting disk status", disk.getName(), googleProject));
-      return false;
-    }
-
-    Optional<DbWorkspace> workspace = workspaceDao.getByGoogleProject(googleProject);
-    if (workspace.isEmpty()) {
-      log.warning(
-          String.format(
-              "skipping disk '%s' associated with unknown Google project '%s'",
-              disk.getName(), googleProject));
-      return false;
-    }
-
-    // Lookup the owners and disk creators.
-    RawlsWorkspaceACL acl =
-        fireCloudService.getWorkspaceAclAsService(
-            workspace.get().getWorkspaceNamespace(), workspace.get().getFirecloudName());
-    Map<String, RawlsWorkspaceAccessEntry> aclMap = FirecloudTransforms.extractAclResponse(acl);
-    List<String> notifyUsernames =
-        aclMap.entrySet().stream()
-            .filter(
-                entry ->
-                    WorkspaceAccessLevel.OWNER.toString().equals(entry.getValue().getAccessLevel())
-                        || entry.getKey().equals(disk.getAuditInfo().getCreator()))
-            .map(Entry::getKey)
-            .collect(Collectors.toList());
-
-    // Lookup these users in the database, so we can get their contact email, etc.
-    List<DbUser> dbUsers = userDao.findUsersByUsernameIn(notifyUsernames);
-    if (dbUsers.size() != notifyUsernames.size()) {
-      log.warning(
-          "failed to lookup one or more users in the database: "
-              + Sets.difference(
-                      dbUsers.stream().map(DbUser::getUsername).collect(Collectors.toSet()),
-                      new HashSet<>(notifyUsernames))
-                  .stream()
-                  .collect(Collectors.joining(",")));
-    }
-    if (dbUsers.isEmpty()) {
-      log.warning("found no users to notify");
-      return false;
-    }
-
-    Double initialCreditsRemaining = null;
-    if (BillingUtils.isInitialCredits(
-        workspace.get().getBillingAccountName(), configProvider.get())) {
-      initialCreditsRemaining =
-          initialCreditsService.getWorkspaceCreatorFreeCreditsRemaining(workspace.get());
-    }
-
-    mailService.alertUsersUnusedDiskWarningThreshold(
-        dbUsers, workspace.get(), disk, attached, daysUnused, initialCreditsRemaining);
-    return true;
-  }
-
-  @VisibleForTesting
-  public boolean isDiskAttached(ListPersistentDiskResponse diskResponse, String googleProject)
-      throws ApiException {
-    final String diskName = diskResponse.getName();
-
-    if (leonardoMapper.toApiListDisksResponse(diskResponse).isGceRuntime()) {
-      return leonardoApiClient.listRuntimesByProjectAsService(googleProject).stream()
-          // this filter/map follows the discriminator logic in the source Leonardo Swagger
-          // for OneOfRuntimeConfigInResponse
-          .filter(
-              resp -> {
-                var runtimeConfig =
-                    new Gson()
-                        .fromJson(
-                            new Gson().toJson(resp.getRuntimeConfig()),
-                            LeonardoRuntimeConfig.class);
-                return CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService());
-              })
-          .map(
-              resp ->
-                  new Gson()
-                      .fromJson(
-                          new Gson().toJson(resp.getRuntimeConfig()),
-                          LeonardoGceWithPdConfigInResponse.class))
-          .anyMatch(
-              gceWithPdConfig ->
-                  diskResponse.getId().equals(gceWithPdConfig.getPersistentDiskId()));
-    } else {
-      return leonardoApiClient.listAppsInProjectAsService(googleProject).stream()
-          .anyMatch(userAppEnvironment -> diskName.equals(userAppEnvironment.getDiskName()));
-    }
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/disks/DiskAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskAdminService.java
@@ -1,0 +1,251 @@
+package org.pmiops.workbench.disks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import jakarta.inject.Provider;
+import jakarta.mail.MessagingException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.firecloud.FirecloudTransforms;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
+import org.pmiops.workbench.legacy_leonardo_client.ApiException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
+import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.mail.MailService;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
+import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
+import org.pmiops.workbench.utils.BillingUtils;
+import org.pmiops.workbench.utils.mappers.LeonardoMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiskAdminService {
+  private static final Logger log = Logger.getLogger(DiskAdminService.class.getName());
+
+  // On the 14th day of inactivity on a PD, a notification is sent.
+  private static final Set<Integer> INACTIVE_DISK_NOTIFY_THRESHOLDS_DAYS = ImmutableSet.of(14);
+  // Every 30th day of inactivity on a PD (not including 0), a notification is sent.
+  private static final int INACTIVE_DISK_NOTIFY_PERIOD_DAYS = 30;
+
+  private final Clock clock;
+  private final FireCloudService fireCloudService;
+  private final InitialCreditsService initialCreditsService;
+  private final LeonardoApiClient leonardoApiClient;
+  private final LeonardoMapper leonardoMapper;
+  private final MailService mailService;
+  private final Provider<WorkbenchConfig> configProvider;
+  private final UserDao userDao;
+  private final WorkspaceDao workspaceDao;
+
+  @Autowired
+  public DiskAdminService(
+      Clock clock,
+      FireCloudService fireCloudService,
+      InitialCreditsService initialCreditsService,
+      LeonardoApiClient leonardoApiClient,
+      LeonardoMapper leonardoMapper,
+      MailService mailService,
+      Provider<WorkbenchConfig> configProvider,
+      UserDao userDao,
+      WorkspaceDao workspaceDao) {
+    this.clock = clock;
+    this.configProvider = configProvider;
+    this.fireCloudService = fireCloudService;
+    this.initialCreditsService = initialCreditsService;
+    this.leonardoApiClient = leonardoApiClient;
+    this.leonardoMapper = leonardoMapper;
+    this.mailService = mailService;
+    this.userDao = userDao;
+    this.workspaceDao = workspaceDao;
+  }
+
+  public void checkPersistentDisks() {
+    // Fetch disks as the service, which gets all disks for all workspaces.
+    final List<ListPersistentDiskResponse> disks = leonardoApiClient.listDisksAsService();
+
+    log.info(String.format("Checking %d persistent disks for idleness...", disks.size()));
+
+    // Bucket disks by days since last access.
+    final Instant now = clock.instant();
+    Map<Integer, List<ListPersistentDiskResponse>> disksByDaysUnused =
+        disks.stream()
+            .filter(disk -> DiskStatus.READY.equals(disk.getStatus()))
+            .collect(
+                Collectors.groupingBy(
+                    disk -> {
+                      Instant lastAccessed = Instant.parse(disk.getAuditInfo().getDateAccessed());
+                      return (int) Duration.between(lastAccessed, now).toDays();
+                    }));
+
+    // Dispatch notifications if any disks are the right number of days old.
+    int notifySuccess = 0;
+    int notifySkip = 0;
+    int notifyFail = 0;
+    Exception lastException = null;
+    for (int daysUnused : disksByDaysUnused.keySet()) {
+      if (daysUnused <= 0) {
+        // Our periodic notifications should not trigger on day 0.
+        continue;
+      }
+
+      if (!INACTIVE_DISK_NOTIFY_THRESHOLDS_DAYS.contains(daysUnused)
+          && daysUnused % INACTIVE_DISK_NOTIFY_PERIOD_DAYS != 0) {
+        continue;
+      }
+
+      for (ListPersistentDiskResponse disk : disksByDaysUnused.get(daysUnused)) {
+        try {
+          if (notifyForUnusedDisk(disk, daysUnused)) {
+            notifySuccess++;
+          } else {
+            notifySkip++;
+          }
+        } catch (MessagingException e) {
+          log.log(
+              Level.WARNING,
+              String.format(
+                  "checkPersistentDisks: failed to send notification for disk '%s/%s'",
+                  leonardoMapper.toGoogleProject(disk.getCloudContext()), disk.getName()),
+              e);
+          lastException = e;
+          notifyFail++;
+        }
+      }
+    }
+
+    log.info(
+        String.format(
+            "checkPersistentDisks: sent %d notifications successfully (%d skipped, %d failed)",
+            notifySuccess, notifySkip, notifyFail));
+    if (lastException != null) {
+      throw new ServerErrorException(
+          String.format(
+              "checkPersistentDisks: %d/%d disk notifications failed to send, see logs for details",
+              notifyFail, notifySuccess + notifyFail + notifySkip),
+          lastException);
+    }
+  }
+
+  // Returns true if an email is sent.
+  private boolean notifyForUnusedDisk(ListPersistentDiskResponse disk, int daysUnused)
+      throws MessagingException {
+    String googleProject = leonardoMapper.toGoogleProject(disk.getCloudContext());
+    final boolean attached;
+    try {
+      attached = isDiskAttached(disk, googleProject);
+    } catch (ApiException | NullPointerException ex) {
+      log.warning(
+          String.format(
+              "skipping disk '%s' error while getting disk status", disk.getName(), googleProject));
+      return false;
+    }
+
+    Optional<DbWorkspace> workspace = workspaceDao.getByGoogleProject(googleProject);
+    if (workspace.isEmpty()) {
+      log.warning(
+          String.format(
+              "skipping disk '%s' associated with unknown Google project '%s'",
+              disk.getName(), googleProject));
+      return false;
+    }
+
+    // Lookup the owners and disk creators.
+    RawlsWorkspaceACL acl =
+        fireCloudService.getWorkspaceAclAsService(
+            workspace.get().getWorkspaceNamespace(), workspace.get().getFirecloudName());
+    Map<String, RawlsWorkspaceAccessEntry> aclMap = FirecloudTransforms.extractAclResponse(acl);
+    List<String> notifyUsernames =
+        aclMap.entrySet().stream()
+            .filter(
+                entry ->
+                    WorkspaceAccessLevel.OWNER.toString().equals(entry.getValue().getAccessLevel())
+                        || entry.getKey().equals(disk.getAuditInfo().getCreator()))
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+
+    // Lookup these users in the database, so we can get their contact email, etc.
+    List<DbUser> dbUsers = userDao.findUsersByUsernameIn(notifyUsernames);
+    if (dbUsers.size() != notifyUsernames.size()) {
+      log.warning(
+          "failed to lookup one or more users in the database: "
+              + Sets.difference(
+                      dbUsers.stream().map(DbUser::getUsername).collect(Collectors.toSet()),
+                      new HashSet<>(notifyUsernames))
+                  .stream()
+                  .collect(Collectors.joining(",")));
+    }
+    if (dbUsers.isEmpty()) {
+      log.warning("found no users to notify");
+      return false;
+    }
+
+    Double initialCreditsRemaining = null;
+    if (BillingUtils.isInitialCredits(
+        workspace.get().getBillingAccountName(), configProvider.get())) {
+      initialCreditsRemaining =
+          initialCreditsService.getWorkspaceCreatorFreeCreditsRemaining(workspace.get());
+    }
+
+    mailService.alertUsersUnusedDiskWarningThreshold(
+        dbUsers, workspace.get(), disk, attached, daysUnused, initialCreditsRemaining);
+    return true;
+  }
+
+  @VisibleForTesting
+  public boolean isDiskAttached(ListPersistentDiskResponse diskResponse, String googleProject)
+      throws ApiException {
+    final String diskName = diskResponse.getName();
+
+    if (leonardoMapper.toApiListDisksResponse(diskResponse).isGceRuntime()) {
+      return leonardoApiClient.listRuntimesByProjectAsService(googleProject).stream()
+          // this filter/map follows the discriminator logic in the source Leonardo Swagger
+          // for OneOfRuntimeConfigInResponse
+          .filter(
+              resp -> {
+                var runtimeConfig =
+                    new Gson()
+                        .fromJson(
+                            new Gson().toJson(resp.getRuntimeConfig()),
+                            LeonardoRuntimeConfig.class);
+                return CloudServiceEnum.GCE.equals(runtimeConfig.getCloudService());
+              })
+          .map(
+              resp ->
+                  new Gson()
+                      .fromJson(
+                          new Gson().toJson(resp.getRuntimeConfig()),
+                          LeonardoGceWithPdConfigInResponse.class))
+          .anyMatch(
+              gceWithPdConfig ->
+                  diskResponse.getId().equals(gceWithPdConfig.getPersistentDiskId()));
+    } else {
+      return leonardoApiClient.listAppsInProjectAsService(googleProject).stream()
+          .anyMatch(userAppEnvironment -> diskName.equals(userAppEnvironment.getDiskName()));
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
@@ -12,17 +12,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DiskService {
-  private final LeonardoMapper leonardoMapper;
   private final LeonardoApiClient leonardoApiClient;
+  private final LeonardoMapper leonardoMapper;
   private final WorkspaceService workspaceService;
 
   @Autowired
   public DiskService(
-      LeonardoMapper leonardoMapper,
       LeonardoApiClient leonardoApiClient,
+      LeonardoMapper leonardoMapper,
       WorkspaceService workspaceService) {
-    this.leonardoMapper = leonardoMapper;
     this.leonardoApiClient = leonardoApiClient;
+    this.leonardoMapper = leonardoMapper;
     this.workspaceService = workspaceService;
   }
 

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineEnvironmentsControllerTest.java
@@ -1,71 +1,30 @@
 package org.pmiops.workbench.api;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
-import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
-import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
 
-import jakarta.mail.MessagingException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
-import org.pmiops.workbench.db.dao.AccessTierDao;
-import org.pmiops.workbench.db.dao.CdrVersionDao;
-import org.pmiops.workbench.db.dao.UserDao;
-import org.pmiops.workbench.db.dao.WorkspaceDao;
-import org.pmiops.workbench.db.model.DbCdrVersion;
-import org.pmiops.workbench.db.model.DbUser;
-import org.pmiops.workbench.db.model.DbWorkspace;
-import org.pmiops.workbench.exceptions.ServerErrorException;
-import org.pmiops.workbench.firecloud.FireCloudService;
-import org.pmiops.workbench.initialcredits.InitialCreditsService;
-import org.pmiops.workbench.legacy_leonardo_client.ApiException;
+import org.pmiops.workbench.disks.DiskAdminService;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudContext;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoCloudProvider;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
-import org.pmiops.workbench.mail.MailService;
-import org.pmiops.workbench.model.AppType;
-import org.pmiops.workbench.model.UserAppEnvironment;
-import org.pmiops.workbench.model.WorkspaceAccessLevel;
-import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
-import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
-import org.pmiops.workbench.utils.TestMockFactory;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.LeonardoMapperImpl;
 import org.pmiops.workbench.workspaces.WorkspaceService;
@@ -84,7 +43,10 @@ public class OfflineEnvironmentsControllerTest {
   private static final Duration RUNTIME_IDLE_MAX_AGE = Duration.ofDays(7);
 
   @TestConfiguration
-  @MockBean(WorkspaceService.class)
+  @MockBean({
+    DiskAdminService.class,
+    WorkspaceService.class,
+  })
   @Import({
     FakeClockConfiguration.class,
     LeonardoMapperImpl.class,
@@ -99,60 +61,22 @@ public class OfflineEnvironmentsControllerTest {
     }
   }
 
-  @MockBean private FireCloudService mockFireCloudService;
-  @MockBean private InitialCreditsService mockInitialCreditsService;
   @MockBean private LeonardoApiClient mockLeonardoApiClient;
-  @MockBean private MailService mockMailService;
 
   @Autowired private OfflineEnvironmentsController controller;
 
-  @Autowired private AccessTierDao accessTierDao;
-  @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private LeonardoMapper leonardoMapper;
-  @Autowired private UserDao userDao;
-  @Autowired private WorkspaceDao workspaceDao;
 
-  private DbUser user1;
-  private DbUser user2;
-  private DbWorkspace workspace;
   private int runtimeProjectIdIndex = 0;
-  private static WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
+  private static final WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
 
   @BeforeEach
   public void setUp() {
     config.firecloud.notebookRuntimeMaxAgeDays = (int) RUNTIME_MAX_AGE.toDays();
     config.firecloud.notebookRuntimeIdleMaxAgeDays = (int) RUNTIME_IDLE_MAX_AGE.toDays();
-    config.billing.accountId = "free-tier";
+    config.billing.accountId = "initial-credits";
 
     runtimeProjectIdIndex = 0;
-    DbCdrVersion cdrVersion = createDefaultCdrVersion();
-    accessTierDao.save(cdrVersion.getAccessTier());
-    cdrVersion = cdrVersionDao.save(cdrVersion);
-
-    user1 = new DbUser();
-    user1.setUsername("alice@fake-research-aou.org");
-    user1.setContactEmail("alice@gmail.com");
-    user1 = userDao.save(user1);
-
-    user2 = new DbUser();
-    user2.setUsername("bob@fake-research-aou.org");
-    user2.setContactEmail("bob@gmail.com");
-    user2 = userDao.save(user2);
-
-    workspace =
-        workspaceDao.save(
-            TestMockFactory.createDbWorkspaceStub(
-                    TestMockFactory.createWorkspace("ns1", "Workspace Name 1", "workspacename1"),
-                    0L)
-                .setCdrVersion(cdrVersion)
-                .setGoogleProject("proj1"));
-  }
-
-  @AfterEach
-  public void tearDown() {
-    workspaceDao.deleteAll();
-    cdrVersionDao.deleteAll();
-    userDao.deleteAll();
   }
 
   private LeonardoGetRuntimeResponse runtimeWithAge(Duration age) {
@@ -191,46 +115,6 @@ public class OfflineEnvironmentsControllerTest {
       when(mockLeonardoApiClient.getRuntimeAsService(googleProject, runtimeName))
           .thenReturn(runtime);
     }
-  }
-
-  private ListPersistentDiskResponse idleDisk(Duration idleTime) {
-    return idleDiskForProjectAndCreator(
-        workspace.getGoogleProject(), user1.getUsername(), idleTime);
-  }
-
-  private ListPersistentDiskResponse idleDiskForProjectAndCreator(
-      String googleProject, String creatorEmail, Duration idleTime) {
-    return new ListPersistentDiskResponse()
-        .diskType(DiskType.STANDARD)
-        .status(DiskStatus.READY)
-        .cloudContext(
-            new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(googleProject))
-        .name("my-disk")
-        .size(200)
-        .auditInfo(
-            new AuditInfo()
-                .creator(creatorEmail)
-                .createdDate(NOW.minus(idleTime.plus(Duration.ofDays(1L))).toString())
-                .dateAccessed(NOW.minus(idleTime).toString()));
-  }
-
-  private void stubDisks(List<ListPersistentDiskResponse> disks) {
-    when(mockLeonardoApiClient.listDisksAsService()).thenReturn(disks);
-  }
-
-  private void stubWorkspaceOwners(DbWorkspace w, List<DbUser> users) {
-    when(mockFireCloudService.getWorkspaceAclAsService(
-            w.getWorkspaceNamespace(), w.getFirecloudName()))
-        .thenReturn(
-            new RawlsWorkspaceACL()
-                .acl(
-                    users.stream()
-                        .collect(
-                            Collectors.toMap(
-                                DbUser::getUsername,
-                                u ->
-                                    new RawlsWorkspaceAccessEntry()
-                                        .accessLevel(WorkspaceAccessLevel.OWNER.toString())))));
   }
 
   @Test
@@ -297,257 +181,5 @@ public class OfflineEnvironmentsControllerTest {
     assertThat(controller.deleteOldRuntimes().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
     verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
-  }
-
-  @Test
-  public void testCheckPersistentDisksNoDisks() {
-    stubDisks(Collections.emptyList());
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verifyNoInteractions(mockMailService);
-  }
-
-  @Test
-  public void testCheckPersistentDisksNoMatchingNotifications() {
-    stubDisks(
-        List.of(
-            idleDisk(Duration.ofDays(0L)),
-            idleDisk(Duration.ofDays(1L)),
-            idleDisk(Duration.ofDays(13L)),
-            idleDisk(Duration.ofDays(31L)),
-            idleDisk(Duration.ofDays(119L))));
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verifyNoInteractions(mockMailService);
-  }
-
-  @Test
-  public void testCheckPersistentDisksSkipsNonReady() {
-    stubDisks(List.of(idleDisk(Duration.ofDays(14L)).status(DiskStatus.FAILED)));
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verifyNoInteractions(mockMailService);
-  }
-
-  @Test
-  public void testCheckPersistentDisksInitialThresholdNotification() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1));
-    stubDisks(List.of(idleDisk(Duration.ofDays(14L))));
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verify(mockMailService)
-        .alertUsersUnusedDiskWarningThreshold(
-            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(14), eq(null));
-  }
-
-  @Test
-  public void testCheckPersistentDisksPeriodicThresholdNotification() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1));
-    stubDisks(
-        List.of(
-            idleDisk(Duration.ofDays(30L)),
-            idleDisk(Duration.ofDays(60L)),
-            idleDisk(Duration.ofDays(90L))));
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verify(mockMailService, times(3))
-        .alertUsersUnusedDiskWarningThreshold(
-            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), anyInt(), any());
-  }
-
-  @Test
-  public void testCheckPersistentDisksMultipleOwners() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1, user2));
-    stubDisks(List.of(idleDisk(Duration.ofDays(30L))));
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verify(mockMailService, times(1))
-        .alertUsersUnusedDiskWarningThreshold(
-            eq(List.of(user1, user2)), eq(workspace), any(), anyBoolean(), anyInt(), any());
-  }
-
-  @Test
-  public void testCheckPersistentDisksSkipsUnknownUser() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1));
-
-    ListPersistentDiskResponse mysteryDisk = idleDisk(Duration.ofDays(14L));
-    mysteryDisk.getAuditInfo().setCreator("404@aou.org");
-    stubDisks(List.of(mysteryDisk, idleDisk(Duration.ofDays(30L))));
-
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    // Skips the unknown user, but still sends the rest.
-    verify(mockMailService)
-        .alertUsersUnusedDiskWarningThreshold(
-            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(30), any());
-  }
-
-  @Test
-  public void testCheckPersistentDisksContinuesOnMailFailure() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1));
-    stubDisks(
-        List.of(
-            idleDisk(Duration.ofDays(14L)),
-            idleDisk(Duration.ofDays(14L)),
-            idleDisk(Duration.ofDays(14L))));
-
-    doThrow(MessagingException.class)
-        // Throw on the first call only.
-        .doNothing()
-        .when(mockMailService)
-        .alertUsersUnusedDiskWarningThreshold(any(), any(), any(), anyBoolean(), anyInt(), any());
-
-    assertThrows(ServerErrorException.class, () -> controller.checkPersistentDisks());
-
-    // 3 calls, including the initial throwing call.
-    verify(mockMailService, times(3))
-        .alertUsersUnusedDiskWarningThreshold(any(), any(), any(), anyBoolean(), anyInt(), any());
-  }
-
-  @Test
-  public void testCheckPersistentDisksFreeTier() throws MessagingException {
-    stubWorkspaceOwners(workspace, List.of(user1));
-    stubDisks(List.of(idleDisk(Duration.ofDays(14L))));
-
-    workspace.setBillingAccountName(config.billing.initialCreditsBillingAccountName());
-    when(mockInitialCreditsService.getWorkspaceCreatorFreeCreditsRemaining(workspace))
-        .thenReturn(123.0);
-
-    assertThat(controller.checkPersistentDisks().getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-    verify(mockMailService)
-        .alertUsersUnusedDiskWarningThreshold(
-            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(14), eq(123.0));
-  }
-
-  @Test
-  public void testIsDiskAttached_Gce_attached() throws ApiException {
-    int diskId = 1;
-    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
-    LeonardoGceWithPdConfigInResponse runtimeConfigResponse =
-        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
-    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
-    runtimeConfigResponse.cloudService(CloudServiceEnum.GCE);
-
-    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
-        .thenReturn(
-            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse)));
-
-    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_Gce_multiple() throws ApiException {
-    int diskId = 1;
-    int otherDiskId = 2;
-    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
-
-    LeonardoGceWithPdConfigInResponse runtimeConfigResponse1 =
-        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
-    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
-    runtimeConfigResponse1.cloudService(CloudServiceEnum.GCE);
-
-    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
-        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
-    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
-    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
-
-    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
-        .thenReturn(
-            List.of(
-                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse1),
-                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
-
-    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_Gce_mismatch() throws ApiException {
-    int diskId = 1;
-    int otherDiskId = 2;
-    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
-
-    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
-        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
-    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
-    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
-
-    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
-        .thenReturn(
-            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
-
-    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_Gce_no_runtimes() throws ApiException {
-    int diskId = 1;
-    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
-
-    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
-        .thenReturn(Collections.emptyList());
-
-    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_GKE_App_attached() throws ApiException {
-    String diskName = "my-disk-name";
-    ListPersistentDiskResponse diskResponse =
-        new ListPersistentDiskResponse()
-            .name(diskName)
-            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
-
-    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
-        .thenReturn(List.of(new UserAppEnvironment().diskName(diskName)));
-
-    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_GKE_App_multiple() throws ApiException {
-    String diskName = "my-disk-name";
-    String otherDiskName = "other-disk-name";
-    ListPersistentDiskResponse diskResponse =
-        new ListPersistentDiskResponse()
-            .name(diskName)
-            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
-
-    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
-        .thenReturn(
-            List.of(
-                new UserAppEnvironment().diskName(diskName),
-                new UserAppEnvironment().diskName(otherDiskName)));
-
-    assertTrue(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_GKE_App_mismatch() throws ApiException {
-    String diskName = "my-disk-name";
-    String otherDiskName = "other-disk-name";
-    ListPersistentDiskResponse diskResponse =
-        new ListPersistentDiskResponse()
-            .name(diskName)
-            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
-
-    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
-        .thenReturn(List.of(new UserAppEnvironment().diskName(otherDiskName)));
-
-    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
-  }
-
-  @Test
-  public void testIsDiskAttached_GKE_App_no_apps() throws ApiException {
-    String diskName = "my-disk-name";
-    ListPersistentDiskResponse diskResponse =
-        new ListPersistentDiskResponse()
-            .name(diskName)
-            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
-
-    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
-        .thenReturn(Collections.emptyList());
-
-    assertFalse(controller.isDiskAttached(diskResponse, "test-project"));
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/disk/DiskAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/disk/DiskAdminServiceTest.java
@@ -1,0 +1,434 @@
+package org.pmiops.workbench.disk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.LEONARDO_LABEL_APP_TYPE;
+import static org.pmiops.workbench.leonardo.LeonardoLabelHelper.appTypeToLabelValue;
+import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
+
+import jakarta.mail.MessagingException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudContext;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.CloudProvider;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.AccessTierDao;
+import org.pmiops.workbench.db.dao.CdrVersionDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbCdrVersion;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.disks.DiskAdminService;
+import org.pmiops.workbench.exceptions.ServerErrorException;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
+import org.pmiops.workbench.legacy_leonardo_client.ApiException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGceWithPdConfigInResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeConfig.CloudServiceEnum;
+import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.mail.MailService;
+import org.pmiops.workbench.model.AppType;
+import org.pmiops.workbench.model.UserAppEnvironment;
+import org.pmiops.workbench.model.WorkspaceAccessLevel;
+import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
+import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
+import org.pmiops.workbench.utils.TestMockFactory;
+import org.pmiops.workbench.utils.mappers.LeonardoMapperImpl;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+public class DiskAdminServiceTest {
+  private static final Instant NOW = FakeClockConfiguration.NOW.toInstant();
+
+  @MockBean private FireCloudService mockFireCloudService;
+  @MockBean private LeonardoApiClient mockLeonardoApiClient;
+  @MockBean private InitialCreditsService mockInitialCreditsService;
+  @MockBean private MailService mockMailService;
+
+  @Autowired private AccessTierDao accessTierDao;
+  @Autowired private CdrVersionDao cdrVersionDao;
+  @Autowired private UserDao userDao;
+  @Autowired private WorkspaceDao workspaceDao;
+
+  @Autowired private DiskAdminService service;
+
+  private DbUser user1;
+  private DbUser user2;
+  private DbWorkspace workspace;
+  private static final WorkbenchConfig config = WorkbenchConfig.createEmptyConfig();
+
+  @TestConfiguration
+  @MockBean(WorkspaceService.class)
+  @Import({
+    FakeClockConfiguration.class,
+    DiskAdminService.class,
+    LeonardoMapperImpl.class,
+  })
+  static class Configuration {
+    @Bean
+    public WorkbenchConfig workbenchConfig() {
+      return config;
+    }
+  }
+
+  @BeforeEach
+  public void setUp() {
+    user1 = new DbUser();
+    user1.setUsername("alice@fake-research-aou.org");
+    user1.setContactEmail("alice@gmail.com");
+    user1 = userDao.save(user1);
+
+    user2 = new DbUser();
+    user2.setUsername("bob@fake-research-aou.org");
+    user2.setContactEmail("bob@gmail.com");
+    user2 = userDao.save(user2);
+
+    DbCdrVersion cdrVersion = createDefaultCdrVersion();
+    accessTierDao.save(cdrVersion.getAccessTier());
+    cdrVersion = cdrVersionDao.save(cdrVersion);
+
+    workspace =
+        workspaceDao.save(
+            TestMockFactory.createDbWorkspaceStub(
+                    TestMockFactory.createWorkspace("ns1", "Workspace Name 1", "workspacename1"),
+                    0L)
+                .setCdrVersion(cdrVersion)
+                .setGoogleProject("proj1"));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    workspaceDao.deleteAll();
+    cdrVersionDao.deleteAll();
+    userDao.deleteAll();
+  }
+
+  @Test
+  public void testCheckPersistentDisksNoDisks() {
+    stubDisks(Collections.emptyList());
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verifyNoInteractions(mockMailService);
+  }
+
+  @Test
+  public void testCheckPersistentDisksNoMatchingNotifications() {
+    stubDisks(
+        List.of(
+            idleDisk(Duration.ofDays(0L)),
+            idleDisk(Duration.ofDays(1L)),
+            idleDisk(Duration.ofDays(13L)),
+            idleDisk(Duration.ofDays(31L)),
+            idleDisk(Duration.ofDays(119L))));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verifyNoInteractions(mockMailService);
+  }
+
+  @Test
+  public void testCheckPersistentDisksSkipsNonReady() {
+    stubDisks(List.of(idleDisk(Duration.ofDays(14L)).status(DiskStatus.FAILED)));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verifyNoInteractions(mockMailService);
+  }
+
+  @Test
+  public void testCheckPersistentDisksInitialThresholdNotification() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1));
+    stubDisks(List.of(idleDisk(Duration.ofDays(14L))));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verify(mockMailService)
+        .alertUsersUnusedDiskWarningThreshold(
+            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(14), eq(null));
+  }
+
+  @Test
+  public void testCheckPersistentDisksPeriodicThresholdNotification() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1));
+    stubDisks(
+        List.of(
+            idleDisk(Duration.ofDays(30L)),
+            idleDisk(Duration.ofDays(60L)),
+            idleDisk(Duration.ofDays(90L))));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verify(mockMailService, times(3))
+        .alertUsersUnusedDiskWarningThreshold(
+            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), anyInt(), any());
+  }
+
+  @Test
+  public void testCheckPersistentDisksMultipleOwners() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1, user2));
+    stubDisks(List.of(idleDisk(Duration.ofDays(30L))));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verify(mockMailService, times(1))
+        .alertUsersUnusedDiskWarningThreshold(
+            eq(List.of(user1, user2)), eq(workspace), any(), anyBoolean(), anyInt(), any());
+  }
+
+  @Test
+  public void testCheckPersistentDisksSkipsUnknownUser() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1));
+
+    ListPersistentDiskResponse mysteryDisk = idleDisk(Duration.ofDays(14L));
+    mysteryDisk.getAuditInfo().setCreator("404@aou.org");
+    stubDisks(List.of(mysteryDisk, idleDisk(Duration.ofDays(30L))));
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    // Skips the unknown user, but still sends the rest.
+    verify(mockMailService)
+        .alertUsersUnusedDiskWarningThreshold(
+            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(30), any());
+  }
+
+  @Test
+  public void testCheckPersistentDisksContinuesOnMailFailure() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1));
+    stubDisks(
+        List.of(
+            idleDisk(Duration.ofDays(14L)),
+            idleDisk(Duration.ofDays(14L)),
+            idleDisk(Duration.ofDays(14L))));
+
+    doThrow(MessagingException.class)
+        // Throw on the first call only.
+        .doNothing()
+        .when(mockMailService)
+        .alertUsersUnusedDiskWarningThreshold(any(), any(), any(), anyBoolean(), anyInt(), any());
+
+    assertThrows(ServerErrorException.class, () -> service.checkPersistentDisks());
+
+    // 3 calls, including the initial throwing call.
+    verify(mockMailService, times(3))
+        .alertUsersUnusedDiskWarningThreshold(any(), any(), any(), anyBoolean(), anyInt(), any());
+  }
+
+  @Test
+  public void testCheckPersistentDisksFreeTier() throws MessagingException {
+    stubWorkspaceOwners(workspace, List.of(user1));
+    stubDisks(List.of(idleDisk(Duration.ofDays(14L))));
+
+    workspace.setBillingAccountName(config.billing.initialCreditsBillingAccountName());
+    when(mockInitialCreditsService.getWorkspaceCreatorFreeCreditsRemaining(workspace))
+        .thenReturn(123.0);
+
+    assertDoesNotThrow(() -> service.checkPersistentDisks());
+
+    verify(mockMailService)
+        .alertUsersUnusedDiskWarningThreshold(
+            eq(List.of(user1)), eq(workspace), any(), anyBoolean(), eq(14), eq(123.0));
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_attached() throws ApiException {
+    int diskId = 1;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isTrue();
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_multiple() throws ApiException {
+    int diskId = 1;
+    int otherDiskId = 2;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse1 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(diskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse1.cloudService(CloudServiceEnum.GCE);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(
+                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse1),
+                new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isTrue();
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_mismatch() throws ApiException {
+    int diskId = 1;
+    int otherDiskId = 2;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    LeonardoGceWithPdConfigInResponse runtimeConfigResponse2 =
+        new LeonardoGceWithPdConfigInResponse().persistentDiskId(otherDiskId);
+    // need to use a separate call because this returns a LeonardoRuntimeConfig object instead
+    runtimeConfigResponse2.cloudService(CloudServiceEnum.GCE);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(
+            List.of(new LeonardoListRuntimeResponse().runtimeConfig(runtimeConfigResponse2)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isFalse();
+  }
+
+  @Test
+  public void testIsDiskAttached_Gce_no_runtimes() throws ApiException {
+    int diskId = 1;
+    ListPersistentDiskResponse diskResponse = new ListPersistentDiskResponse().id(diskId);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(anyString()))
+        .thenReturn(Collections.emptyList());
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isFalse();
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_attached() throws ApiException {
+    String diskName = "my-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(List.of(new UserAppEnvironment().diskName(diskName)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isTrue();
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_multiple() throws ApiException {
+    String diskName = "my-disk-name";
+    String otherDiskName = "other-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(
+            List.of(
+                new UserAppEnvironment().diskName(diskName),
+                new UserAppEnvironment().diskName(otherDiskName)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isTrue();
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_mismatch() throws ApiException {
+    String diskName = "my-disk-name";
+    String otherDiskName = "other-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(List.of(new UserAppEnvironment().diskName(otherDiskName)));
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isFalse();
+  }
+
+  @Test
+  public void testIsDiskAttached_GKE_App_no_apps() throws ApiException {
+    String diskName = "my-disk-name";
+    ListPersistentDiskResponse diskResponse =
+        new ListPersistentDiskResponse()
+            .name(diskName)
+            .labels(Map.of(LEONARDO_LABEL_APP_TYPE, appTypeToLabelValue(AppType.RSTUDIO)));
+
+    when(mockLeonardoApiClient.listAppsInProjectAsService(anyString()))
+        .thenReturn(Collections.emptyList());
+
+    assertThat(service.isDiskAttached(diskResponse, "test-project")).isFalse();
+  }
+
+  private ListPersistentDiskResponse idleDisk(Duration idleTime) {
+    return idleDiskForProjectAndCreator(
+        workspace.getGoogleProject(), user1.getUsername(), idleTime);
+  }
+
+  private ListPersistentDiskResponse idleDiskForProjectAndCreator(
+      String googleProject, String creatorEmail, Duration idleTime) {
+    return new ListPersistentDiskResponse()
+        .diskType(DiskType.STANDARD)
+        .status(DiskStatus.READY)
+        .cloudContext(
+            new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(googleProject))
+        .name("my-disk")
+        .size(200)
+        .auditInfo(
+            new AuditInfo()
+                .creator(creatorEmail)
+                .createdDate(NOW.minus(idleTime.plus(Duration.ofDays(1L))).toString())
+                .dateAccessed(NOW.minus(idleTime).toString()));
+  }
+
+  private void stubDisks(List<ListPersistentDiskResponse> disks) {
+    when(mockLeonardoApiClient.listDisksAsService()).thenReturn(disks);
+  }
+
+  private void stubWorkspaceOwners(DbWorkspace w, List<DbUser> users) {
+    when(mockFireCloudService.getWorkspaceAclAsService(
+            w.getWorkspaceNamespace(), w.getFirecloudName()))
+        .thenReturn(
+            new RawlsWorkspaceACL()
+                .acl(
+                    users.stream()
+                        .collect(
+                            Collectors.toMap(
+                                DbUser::getUsername,
+                                u ->
+                                    new RawlsWorkspaceAccessEntry()
+                                        .accessLevel(WorkspaceAccessLevel.OWNER.toString())))));
+  }
+}


### PR DESCRIPTION
This does not resolve RW-14368, but will be necessary if we switch this to using TaskQueues.  Splitting out this no-change PR for easier review.

Tested locally by running Local UI and the checkPersistentDisks cron.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
