### PR TITLE
[no ticket][risk=no] Change session storage to local storage to prevent duplicate privacy warning

### DIFF
--- a/ui/src/app/pages/privacy-warning.tsx
+++ b/ui/src/app/pages/privacy-warning.tsx
@@ -9,7 +9,7 @@ import { AoU } from 'app/components/text-wrappers';
 import colors from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 import { signOut } from 'app/utils/authentication';
-import { PRIVACY_WARNING_SESSION_KEY } from 'app/utils/constants';
+import { PRIVACY_WARNING_KEY } from 'app/utils/constants';
 const styles = reactStyles({
   bodyText: {
     color: colors.primary,
@@ -54,8 +54,8 @@ export const PrivacyWarning = ({ onAcknowledge }: PrivacyWarningProps) => {
           aria-label='Acknowledge'
           style={{ margin: '0rem' }}
           onClick={() => {
-            sessionStorage.setItem(
-              PRIVACY_WARNING_SESSION_KEY,
+            localStorage.setItem(
+              PRIVACY_WARNING_KEY,
               new Date().toDateString()
             );
             onAcknowledge();

--- a/ui/src/app/pages/signed-in/signed-in.tsx
+++ b/ui/src/app/pages/signed-in/signed-in.tsx
@@ -20,7 +20,7 @@ import { hasRegisteredTierAccess } from 'app/utils/access-tiers';
 import { setInstitutionCategoryState } from 'app/utils/analytics';
 import {
   DEMOGRAPHIC_SURVEY_SESSION_KEY,
-  PRIVACY_WARNING_SESSION_KEY,
+  PRIVACY_WARNING_KEY,
 } from 'app/utils/constants';
 import { shouldShowDemographicSurvey } from 'app/utils/profile-utils';
 import {
@@ -72,7 +72,7 @@ export const SignedInImpl = (spinnerProps: WithSpinnerOverlayProps) => {
 
   const [hideFooter, setHideFooter] = useState(false);
   const [hasAcknowledgedPrivacyWarning, setHasAcknowledgedPrivacyWarning] =
-    useState(!!sessionStorage.getItem(PRIVACY_WARNING_SESSION_KEY));
+    useState(!!localStorage.getItem(PRIVACY_WARNING_KEY));
 
   const { config } = useStore(serverConfigStore);
   const { tiers } = useStore(cdrVersionStore);

--- a/ui/src/app/utils/authentication.tsx
+++ b/ui/src/app/utils/authentication.tsx
@@ -14,7 +14,7 @@ import { User, WebStorageStateStore } from 'oidc-client-ts';
 
 import {
   DEMOGRAPHIC_SURVEY_SESSION_KEY,
-  PRIVACY_WARNING_SESSION_KEY,
+  PRIVACY_WARNING_KEY,
 } from './constants';
 
 const GOOGLE_BILLING_SCOPE = 'https://www.googleapis.com/auth/cloud-billing';
@@ -117,7 +117,7 @@ export const signOut = async (continuePath: string = '/login') => {
   await authStore.get().auth.removeUser();
 
   sessionStorage.removeItem(DEMOGRAPHIC_SURVEY_SESSION_KEY);
-  sessionStorage.removeItem(PRIVACY_WARNING_SESSION_KEY);
+  localStorage.removeItem(PRIVACY_WARNING_KEY);
 
   if (signOutApiCallSucceeded) {
     window.location.replace(continuePath);

--- a/ui/src/app/utils/constants.tsx
+++ b/ui/src/app/utils/constants.tsx
@@ -2,7 +2,7 @@ export const DEMOGRAPHIC_SURVEY_V2_PATH = '/demographic-survey';
 
 export const DEMOGRAPHIC_SURVEY_SESSION_KEY =
   'demographic-survey-banner-dismissed';
-export const PRIVACY_WARNING_SESSION_KEY = 'privacy-warning-acknowledged';
+export const PRIVACY_WARNING_KEY = 'privacy-warning-acknowledged';
 
 // Demographic survey Questions Key
 export const ETHNIC_CATEGORIES = 'ethnicCategories';


### PR DESCRIPTION
Fix duplicate privacy warning.

You can test by opening one tab, acknowledging the privacy warning, and then opening RWB in a different tab.


https://github.com/user-attachments/assets/a25e4564-11b7-49a2-acbf-4c7314d837b7



<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
