### PR TITLE
[risk=low][RW-14368] Better serialization for Task Queues

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -12,7 +12,7 @@ import org.pmiops.workbench.disks.DiskAdminService;
 import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoStatusUtils;
-import org.pmiops.workbench.model.TaskQueueDisk;
+import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,7 +67,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
   }
 
   @Override
-  public ResponseEntity<Void> checkPersistentDisksBatch(List<TaskQueueDisk> persistentDiskBatch) {
+  public ResponseEntity<Void> checkPersistentDisksBatch(List<Disk> persistentDiskBatch) {
     LOGGER.info(String.format("Checking %s persistent disks.", persistentDiskBatch.size()));
 
     var stopwatch = stopwatchProvider.get().start();

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -13,7 +13,7 @@ import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoGetRuntimeRespo
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
-import org.pmiops.workbench.model.TaskQueueDisk;
+import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -167,10 +167,8 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   @Override
   public ResponseEntity<Void> checkPersistentDisks() {
     // Fetch disks as the service, which gets all disks for all workspaces.
-    final List<TaskQueueDisk> disks =
-        leonardoApiClient.listDisksAsService().stream()
-            .map(leonardoMapper::toTaskQueueDisk)
-            .toList();
+    final List<Disk> disks =
+        leonardoApiClient.listDisksAsService().stream().map(leonardoMapper::toApiDisk).toList();
     log.info(String.format("Queueing %d persistent disks for idleness check.", disks.size()));
     taskQueueService.groupAndPushCheckPersistentDiskTasks(disks);
     return ResponseEntity.noContent().build();

--- a/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/RuntimeController.java
@@ -212,7 +212,7 @@ public class RuntimeController implements RuntimeApiDelegate {
                 leonardoNotebooksClient
                     .listPersistentDiskByProjectCreatedByCreator(dbWorkspace.getGoogleProject())
                     .stream()
-                    .map(leonardoMapper::toApiListDisksResponse)
+                    .map(leonardoMapper::toApiDisk)
                     .collect(Collectors.toList()));
         List<Disk> runtimeDisks =
             diskList.stream().filter(Disk::isGceRuntime).collect(Collectors.toList());

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/EnumSerializer.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/EnumSerializer.java
@@ -1,0 +1,17 @@
+package org.pmiops.workbench.cloudtasks;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+
+// serializes enum values as their values instead of their enum constants
+// needed for local execution of Task Queues
+// https://stackoverflow.com/questions/63059972/make-gson-to-use-enum-string-value-instead-of-constant-name
+public class EnumSerializer<T extends Enum<T>> implements JsonSerializer<T> {
+  @Override
+  public JsonElement serialize(T src, Type typeOfSrc, JsonSerializationContext context) {
+    return new JsonPrimitive(src.toString());
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/EnumSerializer.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/EnumSerializer.java
@@ -6,8 +6,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 
-// serializes enum values as their values instead of their enum constants
-// needed for local execution of Task Queues
+// serializes enum values as their values instead of their enum constants, needed by Task Queues
 // https://stackoverflow.com/questions/63059972/make-gson-to-use-enum-string-value-instead-of-constant-name
 public class EnumSerializer<T extends Enum<T>> implements JsonSerializer<T> {
   @Override

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -19,6 +19,8 @@ import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CreateWorkspaceTaskRequest;
 import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.model.DiskStatus;
+import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.DuplicateWorkspaceTaskRequest;
 import org.pmiops.workbench.model.ExhaustedInitialCreditsEventRequest;
 import org.pmiops.workbench.model.ProcessEgressEventRequest;
@@ -92,6 +94,18 @@ public class TaskQueueService {
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final Provider<UserAuthentication> userAuthenticationProvider;
 
+  private final Gson gson;
+
+  // by default, enums are serialized as the string representation of their enum constants
+  // (e.g. "SSD" for DiskType.SSD) but we need to use their values ("pd-ssd") instead.
+  private static Gson intializeGson() {
+    return new Gson()
+        .newBuilder()
+        .registerTypeAdapter(DiskStatus.class, new EnumSerializer<>())
+        .registerTypeAdapter(DiskType.class, new EnumSerializer<>())
+        .create();
+  }
+
   public TaskQueueService(
       WorkbenchLocationConfigService locationConfigService,
       Provider<CloudTasksClient> cloudTasksClientProvider,
@@ -101,6 +115,7 @@ public class TaskQueueService {
     this.cloudTasksClientProvider = cloudTasksClientProvider;
     this.workbenchConfigProvider = configProvider;
     this.userAuthenticationProvider = userAuthenticationProvider;
+    this.gson = intializeGson();
   }
 
   public void groupAndPushRdrWorkspaceTasks(List<Long> workspaceIds) {
@@ -266,7 +281,7 @@ public class TaskQueueService {
                 locationConfigService.getCloudTaskLocationId(),
                 pair.queueName())
             .toString();
-    String body = new Gson().toJson(jsonBody);
+    String body = gson.toJson(jsonBody);
     return cloudTasksClientProvider
         .get()
         .createTask(

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -18,10 +18,10 @@ import org.pmiops.workbench.config.WorkbenchConfig.RdrExportConfig;
 import org.pmiops.workbench.config.WorkbenchLocationConfigService;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.model.CreateWorkspaceTaskRequest;
+import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.DuplicateWorkspaceTaskRequest;
 import org.pmiops.workbench.model.ExhaustedInitialCreditsEventRequest;
 import org.pmiops.workbench.model.ProcessEgressEventRequest;
-import org.pmiops.workbench.model.TaskQueueDisk;
 import org.pmiops.workbench.model.TestUserRawlsWorkspace;
 import org.pmiops.workbench.model.TestUserWorkspace;
 import org.pmiops.workbench.model.Workspace;
@@ -228,7 +228,7 @@ public class TaskQueueService {
         INITIAL_CREDITS_EXPIRATION);
   }
 
-  public void groupAndPushCheckPersistentDiskTasks(List<TaskQueueDisk> disks) {
+  public void groupAndPushCheckPersistentDiskTasks(List<Disk> disks) {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
     createAndPushAll(
         disks, workbenchConfig.offlineBatch.disksPerCheckPersistentDiskTask, PERSISTENT_DISKS);

--- a/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
+++ b/api/src/main/java/org/pmiops/workbench/disks/DiskService.java
@@ -41,7 +41,7 @@ public class DiskService {
     String googleProject =
         workspaceService.lookupWorkspaceByNamespace(workspaceNamespace).getGoogleProject();
     return leonardoApiClient.listDisksByProjectAsService(googleProject).stream()
-        .map(leonardoMapper::toApiListDisksResponse)
+        .map(leonardoMapper::toApiDisk)
         .toList();
   }
 
@@ -51,7 +51,7 @@ public class DiskService {
 
     List<Disk> disks =
         leonardoApiClient.listPersistentDiskByProjectCreatedByCreator(googleProject).stream()
-            .map(leonardoMapper::toApiListDisksResponse)
+            .map(leonardoMapper::toApiDisk)
             .toList();
     return PersistentDiskUtils.findTheMostRecentActiveDisks(disks);
   }

--- a/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java
@@ -598,7 +598,7 @@ public class LeonardoApiClientImpl implements LeonardoApiClient {
       List<Disk> diskList =
           PersistentDiskUtils.findTheMostRecentActiveDisks(
               listPersistentDiskByProjectCreatedByCreator(dbWorkspace.getGoogleProject()).stream()
-                  .map(leonardoMapper::toApiListDisksResponse)
+                  .map(leonardoMapper::toApiDisk)
                   .filter(disk -> disk.getAppType() != null)
                   .collect(Collectors.toList()));
 

--- a/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/leonardo/PersistentDiskUtils.java
@@ -12,23 +12,22 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.pmiops.workbench.model.AppType;
 import org.pmiops.workbench.model.Disk;
-import org.pmiops.workbench.model.TQSafeDiskType;
-import org.pmiops.workbench.model.TaskQueueDisk;
+import org.pmiops.workbench.model.DiskType;
 
 public final class PersistentDiskUtils {
   private static final Logger log = Logger.getLogger(PersistentDiskUtils.class.getName());
 
   // See https://cloud.google.com/compute/pricing
-  private static final Map<TQSafeDiskType, Double> DISK_PRICE_PER_GB_MONTH =
-      Map.of(TQSafeDiskType.STANDARD, .04, TQSafeDiskType.SSD, .17);
+  private static final Map<DiskType, Double> DISK_PRICE_PER_GB_MONTH =
+      Map.of(DiskType.STANDARD, .04, DiskType.SSD, .17);
 
   private PersistentDiskUtils() {}
 
   // Keep in sync with ui/src/app/utils/machines.ts
-  public static double costPerMonth(TaskQueueDisk disk) {
+  public static double costPerMonth(Disk disk) {
     Double pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(disk.getDiskType());
     if (pricePerGbMonth == null) {
-      pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(TQSafeDiskType.STANDARD);
+      pricePerGbMonth = DISK_PRICE_PER_GB_MONTH.get(DiskType.STANDARD);
       log.warning(
           String.format(
               "unknown disk type %s for disk %s/%s, defaulting to standard",

--- a/api/src/main/java/org/pmiops/workbench/mail/MailService.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailService.java
@@ -7,8 +7,8 @@ import java.util.List;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exfiltration.EgressRemediationAction;
+import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
-import org.pmiops.workbench.model.TaskQueueDisk;
 
 public interface MailService {
 
@@ -43,7 +43,7 @@ public interface MailService {
   void alertUsersUnusedDiskWarningThreshold(
       List<DbUser> users,
       DbWorkspace diskWorkspace,
-      TaskQueueDisk disk,
+      Disk disk,
       boolean isDiskAttached,
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -51,8 +51,8 @@ import org.pmiops.workbench.mandrill.model.MandrillMessageStatus;
 import org.pmiops.workbench.mandrill.model.MandrillMessageStatuses;
 import org.pmiops.workbench.mandrill.model.RecipientAddress;
 import org.pmiops.workbench.mandrill.model.RecipientType;
+import org.pmiops.workbench.model.Disk;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
-import org.pmiops.workbench.model.TaskQueueDisk;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -336,7 +336,7 @@ public class MailServiceImpl implements MailService {
   public void alertUsersUnusedDiskWarningThreshold(
       List<DbUser> users,
       DbWorkspace diskWorkspace,
-      TaskQueueDisk disk,
+      Disk disk,
       boolean isDiskAttached,
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/LeonardoMapper.java
@@ -50,9 +50,6 @@ import org.pmiops.workbench.model.Runtime;
 import org.pmiops.workbench.model.RuntimeConfigurationType;
 import org.pmiops.workbench.model.RuntimeError;
 import org.pmiops.workbench.model.RuntimeStatus;
-import org.pmiops.workbench.model.TQSafeDiskStatus;
-import org.pmiops.workbench.model.TQSafeDiskType;
-import org.pmiops.workbench.model.TaskQueueDisk;
 import org.pmiops.workbench.model.UserAppEnvironment;
 
 @Mapper(config = MapStructConfig.class)
@@ -108,34 +105,19 @@ public interface LeonardoMapper {
   @Mapping(target = "creator", source = "auditInfo.creator")
   @Mapping(target = "createdDate", source = "auditInfo.createdDate")
   @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
-  // these 2 values are set by listDisksAfterMapper()
-  @Mapping(target = "appType", ignore = true)
-  @Mapping(target = "gceRuntime", ignore = true)
-  Disk toApiListDisksResponse(ListPersistentDiskResponse disk);
-
-  @AfterMapping
-  default void listDisksAfterMapper(
-      @MappingTarget Disk disk, ListPersistentDiskResponse listDisksResponse) {
-    LeonardoLabelHelper.maybeMapLeonardoLabelsToGkeApp(listDisksResponse.getLabels())
-        .ifPresentOrElse(disk::setAppType, () -> disk.gceRuntime(true));
-  }
-
-  @Mapping(target = "creator", source = "auditInfo.creator")
-  @Mapping(target = "createdDate", source = "auditInfo.createdDate")
-  @Mapping(target = "dateAccessed", source = "auditInfo.dateAccessed")
   @Mapping(
       target = "googleProject",
       source = "cloudContext",
       qualifiedByName = "cloudContextToGoogleProject")
   @Mapping(target = "persistentDiskId", source = "id")
-  // these 2 values are set by taskQueueListDisksAfterMapper()
+  // these 2 values are set by listDisksAfterMapper()
   @Mapping(target = "appType", ignore = true)
   @Mapping(target = "gceRuntime", ignore = true)
-  TaskQueueDisk toTaskQueueDisk(ListPersistentDiskResponse disk);
+  Disk toApiDisk(ListPersistentDiskResponse disk);
 
   @AfterMapping
-  default void taskQueueListDisksAfterMapper(
-      @MappingTarget TaskQueueDisk disk, ListPersistentDiskResponse listDisksResponse) {
+  default void listDisksAfterMapper(
+      @MappingTarget Disk disk, ListPersistentDiskResponse listDisksResponse) {
     LeonardoLabelHelper.maybeMapLeonardoLabelsToGkeApp(listDisksResponse.getLabels())
         .ifPresentOrElse(disk::setAppType, () -> disk.gceRuntime(true));
   }
@@ -261,10 +243,6 @@ public interface LeonardoMapper {
   @ValueMapping(source = "BALANCED", target = MappingConstants.NULL)
   DiskType toDiskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType diskType);
 
-  @ValueMapping(source = "BALANCED", target = MappingConstants.NULL)
-  TQSafeDiskType toTaskQueueDiskType(
-      org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType diskType);
-
   @Named("mapAppType")
   default AppType mapAppType(ListAppResponse app) {
     final Map<String, String> appLabels = LeonardoLabelHelper.toLabelMap(app.getLabels());
@@ -334,10 +312,6 @@ public interface LeonardoMapper {
 
   @ValueMapping(source = MappingConstants.NULL, target = "UNKNOWN")
   DiskStatus toApiDiskStatus(
-      org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus leonardoDiskStatus);
-
-  @ValueMapping(source = MappingConstants.NULL, target = "UNKNOWN")
-  TQSafeDiskStatus toTaskQueueDiskStatus(
       org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus leonardoDiskStatus);
 
   @Nullable

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4479,7 +4479,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/TaskQueueDisk'
+                $ref: '#/components/schemas/Disk'
         required: true
       responses:
         200:
@@ -7281,18 +7281,18 @@ components:
       enum:
       - pd-standard
       - pd-ssd
-    TQSafeDiskType:
-      type: string
-      enum:
-        - STANDARD
-        - SSD
     Disk:
       description: The configuration of a persistent disk, returned in disk responses
       required:
-      - diskType
-      - name
-      - size
-      - zone
+        - name
+        - status
+        - size
+        - diskType
+        - creator
+        - createdDate
+        - dateAccessed
+        - googleProject
+        - persistentDiskId
       type: object
       properties:
         name:
@@ -7325,49 +7325,6 @@ components:
         zone:
           type: string
           description: The GCP zone of the GCE VM. For example, us-east1-a or europe-west2-c.
-    TaskQueueDisk:
-      description: The configuration of a persistent disk, suitable for use in Task Queues.
-        The standard Disk is not possible because it contains two enums whose values differ from
-        the enum constants.  (seen by Joel Thibault, Feb 2025, have not found documentation to confirm)
-      required:
-        - name
-        - status
-        - size
-        - diskType
-        - creator
-        - createdDate
-        - dateAccessed
-        - googleProject
-        - persistentDiskId
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name of the persistent disk
-        status:
-          $ref: '#/components/schemas/TQSafeDiskStatus'
-        size:
-          type: integer
-          description: Size of persistent disk in GB
-        diskType:
-          $ref: '#/components/schemas/TQSafeDiskType'
-        appType:
-          $ref: '#/components/schemas/AppType'
-        gceRuntime:
-          type: boolean
-          description: True if disk is used by Runtime or being used by GCE runtime
-          default: false
-        creator:
-          type: string
-          description: The email for the user that created this runtime
-        createdDate:
-          type: string
-          description: timestamp for the date this runtime was created in ISO 8601
-            format
-        dateAccessed:
-          type: string
-          description: timestamp for the date this runtime was last accessed in ISO
-            8601 format. This is null if it has not been deleted yet.
         googleProject:
           type: string
           description: The Google Project the disk was created in.
@@ -8906,16 +8863,6 @@ components:
       - Deleting
       - Deleted
       - Unknown
-    TQSafeDiskStatus:
-      type: string
-      enum:
-        - CREATING
-        - RESTORING
-        - FAILED
-        - READY
-        - DELETING
-        - DELETED
-        - UNKNOWN
     RuntimeConfigurationType:
       type: string
       description: |

--- a/api/src/test/java/org/pmiops/workbench/api/DiskAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DiskAdminControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.http.ResponseEntity;
 @ExtendWith(MockitoExtension.class)
 public class DiskAdminControllerTest {
   private static final String WORKSPACE_NS = "workspace-ns";
+  private static final String GOOGLE_PROJECT = "my-project";
   private static final String LOGGED_IN_USER_EMAIL = "bob@gmail.com";
   private static final Instant NOW = Instant.now();
 
@@ -53,6 +54,7 @@ public class DiskAdminControllerTest {
             user.generatePDNameForUserApps(AppType.RSTUDIO),
             DiskStatus.DELETING,
             NOW.minusMillis(100).toString(),
+            GOOGLE_PROJECT,
             user,
             AppType.RSTUDIO);
 
@@ -61,11 +63,13 @@ public class DiskAdminControllerTest {
             user.generatePDNameForUserApps(AppType.CROMWELL),
             DiskStatus.READY,
             NOW.toString(),
+            GOOGLE_PROJECT,
             user,
             AppType.CROMWELL);
 
     Disk jupyterDisk =
-        createRuntimeDisk(user.generatePDName(), DiskStatus.READY, NOW.toString(), user);
+        createRuntimeDisk(
+            user.generatePDName(), DiskStatus.READY, NOW.toString(), GOOGLE_PROJECT, user);
 
     List<Disk> serviceResponse =
         new ArrayList<>(Arrays.asList(rStudioDisk, cromwellDisk, jupyterDisk));
@@ -93,6 +97,7 @@ public class DiskAdminControllerTest {
             user.generatePDNameForUserApps(AppType.CROMWELL),
             DiskStatus.READY,
             NOW.toString(),
+            GOOGLE_PROJECT,
             user,
             AppType.CROMWELL);
     ResponseEntity<EmptyResponse> response =

--- a/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/DisksControllerTest.java
@@ -134,6 +134,7 @@ public class DisksControllerTest {
             newestRstudioDisk.getName(),
             DiskStatus.READY,
             newestRstudioDisk.getAuditInfo().getCreatedDate(),
+            GOOGLE_PROJECT_ID,
             user,
             AppType.RSTUDIO);
 
@@ -165,6 +166,7 @@ public class DisksControllerTest {
             oldGceDisk.getName(),
             DiskStatus.READY,
             oldGceDisk.getAuditInfo().getCreatedDate(),
+            GOOGLE_PROJECT_ID,
             user);
 
     // Cromwell Disk: both are inactive, nothing to return.

--- a/api/src/test/java/org/pmiops/workbench/disk/DiskServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/disk/DiskServiceTest.java
@@ -88,9 +88,9 @@ public class DiskServiceTest {
 
     when(mockWorkspaceService.lookupWorkspaceByNamespace(anyString())).thenReturn(dbWorkspace);
     when(mockLeonardoApiClient.listDisksByProjectAsService(anyString())).thenReturn(responseList);
-    when(mockLeonardoMapper.toApiListDisksResponse(firstLPDR)).thenReturn(firstDisk);
-    when(mockLeonardoMapper.toApiListDisksResponse(secondLPDR)).thenReturn(secondDisk);
-    when(mockLeonardoMapper.toApiListDisksResponse(thirdLPDR)).thenReturn(thirdDisk);
+    when(mockLeonardoMapper.toApiDisk(firstLPDR)).thenReturn(firstDisk);
+    when(mockLeonardoMapper.toApiDisk(secondLPDR)).thenReturn(secondDisk);
+    when(mockLeonardoMapper.toApiDisk(thirdLPDR)).thenReturn(thirdDisk);
     assertThat(diskService.getAllDisksInWorkspaceNamespace(WORKSPACE_NS))
         .containsExactly(firstDisk, secondDisk, thirdDisk);
   }

--- a/api/src/test/java/org/pmiops/workbench/mail/MailServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/mail/MailServiceTest.java
@@ -35,9 +35,9 @@ import org.pmiops.workbench.mandrill.model.MandrillMessageStatus;
 import org.pmiops.workbench.mandrill.model.MandrillMessageStatuses;
 import org.pmiops.workbench.mandrill.model.RecipientAddress;
 import org.pmiops.workbench.mandrill.model.RecipientType;
+import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.SendBillingSetupEmailRequest;
-import org.pmiops.workbench.model.TQSafeDiskType;
-import org.pmiops.workbench.model.TaskQueueDisk;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -293,8 +293,8 @@ public class MailServiceTest {
     mailService.alertUsersUnusedDiskWarningThreshold(
         Collections.singletonList(user),
         new DbWorkspace().setName("my workspace").setCreator(user),
-        new TaskQueueDisk()
-            .diskType(TQSafeDiskType.SSD)
+        new Disk()
+            .diskType(DiskType.SSD)
             .gceRuntime(true)
             .size(123)
             .createdDate(
@@ -328,8 +328,8 @@ public class MailServiceTest {
     mailService.alertUsersUnusedDiskWarningThreshold(
         Collections.singletonList(user),
         new DbWorkspace().setName("my workspace").setCreator(user),
-        new TaskQueueDisk()
-            .diskType(TQSafeDiskType.SSD)
+        new Disk()
+            .diskType(DiskType.SSD)
             .gceRuntime(true)
             .size(123)
             .createdDate(

--- a/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/TestMockFactory.java
@@ -444,23 +444,31 @@ public class TestMockFactory {
         pdName, status, date, googleProjectId, user, /*appType*/ null);
   }
 
-  private static Disk createDisk(String pdName, DiskStatus status, String date, DbUser user) {
+  private static Disk createDisk(
+      String pdName, DiskStatus status, String date, String googleProject, DbUser user) {
     return new Disk()
         .name(pdName)
         .size(300)
         .diskType(DiskType.STANDARD)
         .status(status)
         .createdDate(date)
+        .googleProject(googleProject)
         .creator(user.getUsername());
   }
 
   public static Disk createAppDisk(
-      String pdName, DiskStatus status, String date, DbUser user, AppType appType) {
-    return createDisk(pdName, status, date, user).appType(appType);
+      String pdName,
+      DiskStatus status,
+      String date,
+      String googleProject,
+      DbUser user,
+      AppType appType) {
+    return createDisk(pdName, status, date, googleProject, user).appType(appType);
   }
 
-  public static Disk createRuntimeDisk(String pdName, DiskStatus status, String date, DbUser user) {
-    return createDisk(pdName, status, date, user).gceRuntime(true);
+  public static Disk createRuntimeDisk(
+      String pdName, DiskStatus status, String date, String googleProject, DbUser user) {
+    return createDisk(pdName, status, date, googleProject, user).gceRuntime(true);
   }
 
   // we make no guarantees about the order of the lists in DemographicSurveyV2

--- a/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
+++ b/api/src/test/java/org/pmiops/workbench/utils/mappers/LeonardoMapperTest.java
@@ -28,9 +28,6 @@ import org.pmiops.workbench.model.DiskType;
 import org.pmiops.workbench.model.KubernetesError;
 import org.pmiops.workbench.model.KubernetesRuntimeConfig;
 import org.pmiops.workbench.model.PersistentDiskRequest;
-import org.pmiops.workbench.model.TQSafeDiskStatus;
-import org.pmiops.workbench.model.TQSafeDiskType;
-import org.pmiops.workbench.model.TaskQueueDisk;
 import org.pmiops.workbench.model.UserAppEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -198,17 +195,17 @@ public class LeonardoMapperTest {
             .dateAccessed(leonardoAuditInfo.getDateAccessed())
             .createdDate(leonardoAuditInfo.getCreatedDate())
             .status(DiskStatus.READY);
-    assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse)).isEqualTo(disk);
+    assertThat(mapper.toApiDisk(listPersistentDiskResponse)).isEqualTo(disk);
 
     // RSTUDIO
     Map<String, String> rstudioLabel = new HashMap<>();
     rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
-    assertThat(mapper.toApiListDisksResponse(listPersistentDiskResponse.labels(rstudioLabel)))
+    assertThat(mapper.toApiDisk(listPersistentDiskResponse.labels(rstudioLabel)))
         .isEqualTo(disk.appType(AppType.RSTUDIO).gceRuntime(false));
   }
 
   @Test
-  public void testToTaskQueueDiskFromListDiskResponse() {
+  public void testToDiskFromListDiskResponse() {
     ListPersistentDiskResponse listPersistentDiskResponse =
         new ListPersistentDiskResponse()
             .diskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.SSD)
@@ -218,22 +215,22 @@ public class LeonardoMapperTest {
                 new CloudContext().cloudProvider(CloudProvider.GCP).cloudResource(GOOGLE_PROJECT))
             .id(123);
 
-    TaskQueueDisk disk =
-        new TaskQueueDisk()
-            .diskType(TQSafeDiskType.SSD)
+    Disk disk =
+        new Disk()
+            .diskType(DiskType.SSD)
             .gceRuntime(true)
             .creator(leonardoAuditInfo.getCreator())
             .dateAccessed(leonardoAuditInfo.getDateAccessed())
             .createdDate(leonardoAuditInfo.getCreatedDate())
-            .status(TQSafeDiskStatus.READY)
+            .status(DiskStatus.READY)
             .persistentDiskId(123)
             .googleProject(GOOGLE_PROJECT);
-    assertThat(mapper.toTaskQueueDisk(listPersistentDiskResponse)).isEqualTo(disk);
+    assertThat(mapper.toApiDisk(listPersistentDiskResponse)).isEqualTo(disk);
 
     // RSTUDIO
     Map<String, String> rstudioLabel = new HashMap<>();
     rstudioLabel.put(LEONARDO_LABEL_APP_TYPE, "rstudio");
-    assertThat(mapper.toTaskQueueDisk(listPersistentDiskResponse.labels(rstudioLabel)))
+    assertThat(mapper.toApiDisk(listPersistentDiskResponse.labels(rstudioLabel)))
         .isEqualTo(disk.appType(AppType.RSTUDIO).gceRuntime(false));
   }
 
@@ -249,31 +246,9 @@ public class LeonardoMapperTest {
             mapper.toDiskType(
                 org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD))
         .isEqualTo(DiskType.STANDARD);
-    ;
     assertThat(
             mapper.toDiskType(org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.SSD))
         .isEqualTo(DiskType.SSD);
-    ;
-  }
-
-  @Test
-  void test_taskQueueDiskType() {
-    assertThat(mapper.toTaskQueueDiskType(null)).isNull();
-    assertThat(
-            mapper.toTaskQueueDiskType(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.BALANCED))
-        .isNull();
-
-    assertThat(
-            mapper.toTaskQueueDiskType(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.STANDARD))
-        .isEqualTo(TQSafeDiskType.STANDARD);
-    ;
-    assertThat(
-            mapper.toTaskQueueDiskType(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskType.SSD))
-        .isEqualTo(TQSafeDiskType.SSD);
-    ;
   }
 
   @Test
@@ -304,35 +279,5 @@ public class LeonardoMapperTest {
             mapper.toApiDiskStatus(
                 org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.DELETED))
         .isEqualTo(DiskStatus.DELETED);
-  }
-
-  @Test
-  void test_taskQueueDiskStatus() {
-    assertThat(mapper.toTaskQueueDiskStatus(null)).isEqualTo(TQSafeDiskStatus.UNKNOWN);
-
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.CREATING))
-        .isEqualTo(TQSafeDiskStatus.CREATING);
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.RESTORING))
-        .isEqualTo(TQSafeDiskStatus.RESTORING);
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.FAILED))
-        .isEqualTo(TQSafeDiskStatus.FAILED);
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.READY))
-        .isEqualTo(TQSafeDiskStatus.READY);
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.DELETING))
-        .isEqualTo(TQSafeDiskStatus.DELETING);
-    assertThat(
-            mapper.toTaskQueueDiskStatus(
-                org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus.DELETED))
-        .isEqualTo(TQSafeDiskStatus.DELETED);
   }
 }

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -389,6 +389,7 @@ describe(CreateGkeAppButton.name, () => {
       size: existingDiskSize,
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
+      zone: 'us-central1-a',
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -7,7 +7,6 @@ import {
   CreateAppRequest,
   Disk,
   DisksApi,
-  DiskStatus,
 } from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -35,7 +34,7 @@ import {
   AppsApiStub,
   createListAppsCromwellResponse,
 } from 'testing/stubs/apps-api-stub';
-import { DisksApiStub } from 'testing/stubs/disks-api-stub';
+import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 import { ProfileStubVariables } from 'testing/stubs/profile-api-stub';
 import { buildWorkspaceStub } from 'testing/stubs/workspaces';
 import { ALL_GKE_APP_STATUSES, minus } from 'testing/utils';
@@ -309,16 +308,11 @@ describe(CreateGkeAppButton.name, () => {
     const diskName = 'arbitrary';
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       size: existingDiskSize,
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
       zone: 'us-central1-a',
-      status: DiskStatus.READY,
-      creator: 'me',
-      createdDate: new Date().toDateString(),
-      dateAccessed: new Date().toDateString(),
-      googleProject: 'my-project',
-      persistentDiskId: 12345,
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,
@@ -351,16 +345,11 @@ describe(CreateGkeAppButton.name, () => {
     const diskName = 'arbitrary';
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       size: existingDiskSize,
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
       zone: 'us-central1-a',
-      status: DiskStatus.READY,
-      creator: 'me',
-      createdDate: new Date().toDateString(),
-      dateAccessed: new Date().toDateString(),
-      googleProject: 'my-project',
-      persistentDiskId: 12345,
     };
     await component({
       existingDisk,
@@ -396,16 +385,10 @@ describe(CreateGkeAppButton.name, () => {
     const diskName = 'arbitrary';
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       size: existingDiskSize,
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
-      zone: 'us-central1-a',
-      status: DiskStatus.READY,
-      creator: 'me',
-      createdDate: new Date().toDateString(),
-      dateAccessed: new Date().toDateString(),
-      googleProject: 'my-project',
-      persistentDiskId: 12345,
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,

--- a/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
+++ b/ui/src/app/components/gke-app-configuration-panels/create-gke-app-button.spec.tsx
@@ -7,6 +7,7 @@ import {
   CreateAppRequest,
   Disk,
   DisksApi,
+  DiskStatus,
 } from 'generated/fetch';
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -312,6 +313,12 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
       zone: 'us-central1-a',
+      status: DiskStatus.READY,
+      creator: 'me',
+      createdDate: new Date().toDateString(),
+      dateAccessed: new Date().toDateString(),
+      googleProject: 'my-project',
+      persistentDiskId: 12345,
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,
@@ -348,6 +355,12 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
       zone: 'us-central1-a',
+      status: DiskStatus.READY,
+      creator: 'me',
+      createdDate: new Date().toDateString(),
+      dateAccessed: new Date().toDateString(),
+      googleProject: 'my-project',
+      persistentDiskId: 12345,
     };
     await component({
       existingDisk,
@@ -387,6 +400,12 @@ describe(CreateGkeAppButton.name, () => {
       name: diskName,
       diskType: defaultCromwellCreateRequest.persistentDiskRequest.diskType,
       zone: 'us-central1-a',
+      status: DiskStatus.READY,
+      creator: 'me',
+      createdDate: new Date().toDateString(),
+      dateAccessed: new Date().toDateString(),
+      googleProject: 'my-project',
+      persistentDiskId: 12345,
     };
     const createAppRequest: CreateAppRequest = {
       ...defaultCromwellCreateRequest,

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -6,6 +6,7 @@ import { parseInt } from 'lodash';
 import {
   Disk,
   DisksApi,
+  DiskStatus,
   DiskType,
   GpuConfig,
   Runtime,
@@ -670,15 +671,19 @@ describe('RuntimeConfigurationPanel', () => {
     runtimeDiskStore.set(runtimeDiskStoreStub);
   };
 
-  const existingDisk = (): Disk => {
-    return {
-      size: 1000,
-      diskType: DiskType.STANDARD,
-      name: 'my-existing-disk',
-      gceRuntime: true,
-      zone: 'us-central1-a',
-    };
-  };
+  const existingDisk = (): Disk => ({
+    size: 1000,
+    diskType: DiskType.STANDARD,
+    name: 'my-existing-disk',
+    gceRuntime: true,
+    zone: 'us-central1-a',
+    status: DiskStatus.READY,
+    creator: 'me',
+    createdDate: new Date().toDateString(),
+    dateAccessed: new Date().toDateString(),
+    googleProject: 'my-project',
+    persistentDiskId: 12345,
+  });
 
   const detachableDiskRuntime = (): Runtime => {
     const { size, diskType, name } = existingDisk();

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -672,17 +672,12 @@ describe('RuntimeConfigurationPanel', () => {
   };
 
   const existingDisk = (): Disk => ({
+    ...stubDisk(),
     size: 1000,
     diskType: DiskType.STANDARD,
     name: 'my-existing-disk',
     gceRuntime: true,
     zone: 'us-central1-a',
-    status: DiskStatus.READY,
-    creator: 'me',
-    createdDate: new Date().toDateString(),
-    dateAccessed: new Date().toDateString(),
-    googleProject: 'my-project',
-    persistentDiskId: 12345,
   });
 
   const detachableDiskRuntime = (): Runtime => {

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -6,7 +6,6 @@ import { parseInt } from 'lodash';
 import {
   Disk,
   DisksApi,
-  DiskStatus,
   DiskType,
   GpuConfig,
   Runtime,

--- a/ui/src/app/utils/analysis-config.spec.tsx
+++ b/ui/src/app/utils/analysis-config.spec.tsx
@@ -114,6 +114,7 @@ const defaultAnalysisConfig: AnalysisConfig = {
     detachable: true,
   },
   detachedDisk: {
+    ...stubDisk(),
     size: defaultDiskSize,
     name: defaultDiskName,
     diskType: defaultDiskType,
@@ -440,6 +441,7 @@ describe(toAnalysisConfig.name, () => {
     };
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       diskType: persistentDisk.diskType,
       size: persistentDisk.size - 1, // equal or smaller will match
       name: 'my favorite disk',
@@ -478,6 +480,7 @@ describe(toAnalysisConfig.name, () => {
     };
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       diskType: persistentDisk.diskType,
       size: persistentDisk.size + 1, // too big, will not match
       name: 'my favorite disk',
@@ -516,6 +519,7 @@ describe(toAnalysisConfig.name, () => {
     };
 
     const existingDisk: Disk = {
+      ...stubDisk(),
       diskType: DiskType.STANDARD, // does not match persistentDisk.diskType
       size: persistentDisk.size,
       name: 'my favorite disk',
@@ -703,6 +707,7 @@ describe(withAnalysisConfigDefaults.name, () => {
       };
       const size = 789;
       const inputDisk: Disk = {
+        ...stubDisk(),
         size,
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         name: 'whatever',
@@ -720,6 +725,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskConfig: { ...defaultAnalysisConfig.diskConfig, size: undefined },
       };
       const inputDisk: Disk = {
+        ...stubDisk(),
         size: undefined,
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         name: 'whatever',
@@ -740,6 +746,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         },
       };
       const inputDisk: Disk = {
+        ...stubDisk(),
         size: 1000,
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         name: 'whatever',
@@ -760,6 +767,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         },
       };
       const inputDisk: Disk = {
+        ...stubDisk(),
         size: 1000,
         diskType: undefined,
         name: 'whatever',
@@ -882,6 +890,7 @@ describe(withAnalysisConfigDefaults.name, () => {
       };
       const size = 789;
       const inputDisk: Disk = {
+        ...stubDisk(),
         size,
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         name: 'whatever',
@@ -901,6 +910,7 @@ describe(withAnalysisConfigDefaults.name, () => {
         diskConfig: { ...defaultAnalysisConfig.diskConfig, size: undefined },
       };
       const inputDisk: Disk = {
+        ...stubDisk(),
         size: undefined,
         diskType: defaultAnalysisConfig.detachedDisk.diskType,
         name: 'whatever',

--- a/ui/src/app/utils/runtime-hooks.spec.tsx
+++ b/ui/src/app/utils/runtime-hooks.spec.tsx
@@ -15,7 +15,7 @@ import {
   runtimeApi,
 } from 'app/services/swagger-fetch-clients';
 
-import { DisksApiStub } from 'testing/stubs/disks-api-stub';
+import { DisksApiStub, stubDisk } from 'testing/stubs/disks-api-stub';
 import {
   defaultDataProcRuntime,
   defaultGceRuntime,
@@ -221,6 +221,7 @@ describe(useCustomRuntime.name, () => {
       runtimeLoaded: true,
     });
     const existingDisk = {
+      ...stubDisk(),
       size: 1000,
       diskType: DiskType.STANDARD,
       name: 'my-existing-disk',

--- a/ui/src/testing/stubs/disks-api-stub.ts
+++ b/ui/src/testing/stubs/disks-api-stub.ts
@@ -14,6 +14,12 @@ export const stubDisk = (): Disk => ({
   gceRuntime: true,
   name: 'stub-disk',
   zone: 'us-central1-a',
+  status: DiskStatus.READY,
+  creator: 'me',
+  createdDate: new Date().toDateString(),
+  dateAccessed: new Date().toDateString(),
+  googleProject: 'my-project',
+  persistentDiskId: 12345,
 });
 
 export const mockJupyterDisk = (): Disk => ({
@@ -25,7 +31,10 @@ export const mockJupyterDisk = (): Disk => ({
   appType: null,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  dateAccessed: '2023-05-22T18:55:10.108838Z',
   zone: 'us-central1-a',
+  googleProject: 'my-project',
+  persistentDiskId: 12345,
 });
 
 export const mockCromwellDisk = (): Disk => ({
@@ -37,7 +46,10 @@ export const mockCromwellDisk = (): Disk => ({
   appType: AppType.CROMWELL,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  dateAccessed: '2023-05-22T18:55:10.108838Z',
   zone: 'us-central1-a',
+  googleProject: 'my-project',
+  persistentDiskId: 12345,
 });
 
 export const mockRStudioDisk = (): Disk => ({
@@ -49,7 +61,10 @@ export const mockRStudioDisk = (): Disk => ({
   appType: AppType.RSTUDIO,
   creator: '"evrii@fake-research-aou.org"',
   createdDate: '2023-05-22T18:55:10.108838Z',
+  dateAccessed: '2023-05-22T18:55:10.108838Z',
   zone: 'us-central1-a',
+  googleProject: 'my-project',
+  persistentDiskId: 12345,
 });
 
 export class DisksApiStub extends DisksApi {


### PR DESCRIPTION
Cleanup of #9124
* remove TaskQueueDisk and replace with the standard Disk
* remove the TQSafe enums
* serialize enums by using their **values** when passing to TaskQueues, to match value-based deserialization
  * for an example, see the `fromValues()` method in any swagger-generated enum, such as DiskType

Tested locally by running crons and interacting with disks and runtimes in the local UI


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
