### PR TITLE
[RW-11310][risk=no] Update to nodejs22

### DIFF
--- a/api/docs/developer-system-requirements.md
+++ b/api/docs/developer-system-requirements.md
@@ -29,7 +29,7 @@ We currently only support MacOS and Linux for development and testing.
 For local development, also install:
 
   * [yarn](https://yarnpkg.com/lang/en/docs/install/#mac-stable)
-  * [Node.js](https://nodejs.org/en/) >= 18.  Currently known to work up to 20.9.0
+  * [Node.js](https://nodejs.org/en/) >= 22.
   * `envsubst` which is part of [gettext](https://www.gnu.org/software/gettext/)
     * Mac: `brew install gettext`
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --global yarn n
-# Upgrade to Node 18, above installs 12.
-RUN n 18
+# Upgrade to Node 22, above installs 12.
+RUN n 22
 
 # keep in sync with api/gradle.build and ci/Dockerfile.circle_build
 ENV CLOUD_SDK_VERSION 503.0.0

--- a/ui/app.yaml
+++ b/ui/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 default_expiration: "2m"
 
 handlers:


### PR DESCRIPTION
Deploy a Node 22 artifact for the UI.

Tested by running:

```
deploy/project.rb deploy \
--project all-of-us-workbench-test \
--account circle-deploy-account@all-of-us-workbench-test.iam.gserviceaccount.com \
--no-promote --git-version eric/RW-11310 --app-version erictest
```

and observing that a Node 22 image is deployed.
![image](https://github.com/user-attachments/assets/0278b8fd-5c80-4055-bdfd-4b0392d977a6)

Clicking this link shows the expected UI.
![image](https://github.com/user-attachments/assets/41a687c7-2d32-4cdf-8068-21c3ced5019a)

The CI image seems to already be using Node 22:

```
erollins@wm091-509 ci % docker build --platform linux/x86_64 . -f Dockerfile.circle_build -t us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-4.5.6
[+] Building 0.0s (11/11) FINISHED                                                                                                                                                                                                                              docker:colima
 => [internal] load build definition from Dockerfile.circle_build                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 2.74kB                                                                                                                                                                                                                                   0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)                                                                                                                                                        0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 54)                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/cimg/openjdk:17.0-browsers                                                                                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                          0.0s
 => [1/7] FROM docker.io/cimg/openjdk:17.0-browsers                                                                                                                                                                                                                      0.0s
 => CACHED [2/7] RUN cd &&   wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-503.0.0-linux-x86_64.tar.gz -O gcloud.tgz &&   tar -xf gcloud.tgz &&   ./google-cloud-sdk/install.sh  --quiet &&   ~/google-cloud-sdk/bin/gcloud componen  0.0s
 => CACHED [3/7] RUN sudo apt-get update && sudo apt-get install --no-install-recommends -yq   default-mysql-client   gettext   python3-pip   ruby   wait-for-it   && sudo apt-get clean   && sudo rm -rf /var/lib/apt/lists/*                                           0.0s
 => CACHED [4/7] RUN sudo pip install --upgrade pip pylint                                                                                                                                                                                                               0.0s
 => CACHED [5/7] RUN curl -o /tmp/cloud_sql_proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.2/cloud-sql-proxy.linux.amd64   && sudo mv /tmp/cloud_sql_proxy /usr/local/bin && sudo chmod +x /usr/local/bin/cloud_sql_proxy               0.0s
 => CACHED [6/7] RUN wget "https://services.gradle.org/distributions/gradle-7.6.4-bin.zip" -O /tmp/gradle.zip   && sudo unzip /tmp/gradle.zip -d /opt/gradle                                                                                                             0.0s
 => CACHED [7/7] RUN sudo gem install jira-ruby                                                                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                                                                                                  0.0s
 => => writing image sha256:5c2a91e3013df83972c6dbd1eb936202d04a914a75ea11ac2a49d1d4cafaf565                                                                                                                                                                             0.0s
 => => naming to us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-4.5.6                                                                                                                                                                                               0.0s

 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 54)
erollins@wm091-509 ci % docker run --platform linux/x86_64 -it us.gcr.io/broad-dsp-gcr-public/workbench:buildimage-4.5.6 /bin/bash
_XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created.
circleci@f0049698aeb5:~/project$ node --version
v22.13.1
```


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
