### PR TITLE
[risk=low][RW-14538] Don't retry Task Queues jobs which send emails

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
+++ b/api/src/main/java/org/pmiops/workbench/compliancetraining/ComplianceTrainingService.java
@@ -5,5 +5,5 @@ import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.exceptions.NotFoundException;
 
 public interface ComplianceTrainingService {
-  public DbUser syncComplianceTrainingStatus() throws NotFoundException, ApiException;
+  DbUser syncComplianceTrainingStatus() throws NotFoundException, ApiException;
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -450,8 +450,8 @@ paths:
       tags:
       - profile
       summary: Sync compliance training status
-      description: Retrieves moodleId(either from DB or call from Moodle API) and
-        gets Training status on the basis of that
+      description: Retrieves the Absorb training status for the user and updates access module
+        completion times and access tier membership when appropriate
       operationId: syncComplianceTrainingStatus
       responses:
         200:

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -149,10 +149,6 @@ queue:
   rate: 1/s
   max_concurrent_requests: 10
 
-  retry_parameters:
-    task_retry_limit: 1
-    task_age_limit: 5m
-
 - name: checkPersistentDiskQueue
   target: api
 
@@ -160,7 +156,3 @@ queue:
   bucket_size: 10
   rate: 1/s
   max_concurrent_requests: 10
-
-  retry_parameters:
-    task_retry_limit: 1
-    task_age_limit: 5m


### PR DESCRIPTION
Users are reporting getting flooded with "Unused disk" emails after transitioning that cron job to Task Queues.  Logs show that many more batches of these jobs (about 3x on 2/26, about 1.5x on 2/27) are executing than expected, along with frequent failures.  I see that a retry policy is specified for this queue, so I expect that this is the problem.

Also update accessExpirationEmailQueue which I expect to suffer from the same problem.

I ran local crons and local UI without issue, but this doesn't exercise the change here.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
