### PR TITLE
[risk=low][RW-14538] Don't fail the entire checkPersistentDisksBatch when one email fails to send

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -341,7 +341,6 @@ public class MailServiceImpl implements MailService {
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)
       throws MessagingException {
-
     final String htmlMessage =
         buildHtml(
             UNUSED_DISK_RESOURCE,

--- a/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/mail/MailServiceImpl.java
@@ -341,6 +341,7 @@ public class MailServiceImpl implements MailService {
       int daysUnused,
       @Nullable Double workspaceInitialCreditsRemaining)
       throws MessagingException {
+
     final String htmlMessage =
         buildHtml(
             UNUSED_DISK_RESOURCE,

--- a/api/src/test/java/org/pmiops/workbench/disk/DiskAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/disk/DiskAdminServiceTest.java
@@ -2,7 +2,6 @@ package org.pmiops.workbench.disk;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -34,7 +33,6 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.disks.DiskAdminService;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.legacy_leonardo_client.ApiException;
@@ -223,8 +221,7 @@ public class DiskAdminServiceTest {
         .when(mockMailService)
         .alertUsersUnusedDiskWarningThreshold(any(), any(), any(), anyBoolean(), anyInt(), any());
 
-    assertThrows(
-        ServerErrorException.class,
+    assertDoesNotThrow(
         () ->
             service.checkPersistentDisks(
                 List.of(


### PR DESCRIPTION
Mail errors are very common for this task - over 10 per day.  Because we mark the whole batch as failed, it retries the whole batch again.  Typically it fails for this one user again, so retries again.  For the successful users (the vast majority) they will see an email for every retry.

Let's not do this.  We don't need to mark the batch as failed, and therefore there will be no need for retrying.

An alternate approach is to update the retry configuration: #9143.  I think both changes are worthwhile.


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
