### PR TITLE
[risk=low][RW-14580] eslint rule for nested components

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -79,7 +79,7 @@ module.exports = {
     // '@typescript-eslint/prefer-function-type': 'warn',
 
     'react/jsx-uses-vars': 'warn',
-    'react/no-unstable-nested-components': 'warn',  // 15 instances as of 4 Mar 2025
+    'react/no-unstable-nested-components': ['warn', { allowAsProps: true }],
     'react-hooks/rules-of-hooks': 'warn',
     // 'react-hooks/exhaustive-deps': 'warn',  // 45 instances as of 3 Jan 2022
 

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
     // '@typescript-eslint/prefer-function-type': 'warn',
 
     'react/jsx-uses-vars': 'warn',
+    'react/no-unstable-nested-components': 'warn',  // 15 instances as of 4 Mar 2025
     'react-hooks/rules-of-hooks': 'warn',
     // 'react-hooks/exhaustive-deps': 'warn',  // 45 instances as of 3 Jan 2022
 

--- a/ui/src/app/pages/access/modules-for-annual-renewal.tsx
+++ b/ui/src/app/pages/access/modules-for-annual-renewal.tsx
@@ -207,6 +207,35 @@ const ActionButton = ({
   );
 };
 
+interface TimeEstimateProps {
+  showTimeEstimate: boolean;
+  renewalTimeEstimate: number;
+}
+const TimeEstimate = ({
+  showTimeEstimate,
+  renewalTimeEstimate,
+}: TimeEstimateProps) =>
+  showTimeEstimate ? (
+    <FlexColumn style={{ alignItems: 'center' }}>
+      <Clock style={{ color: colors.disabled, width: '5em' }} />
+      {renewalTimeEstimate} min
+    </FlexColumn>
+  ) : null;
+
+interface DateProps {
+  lastConfirmedDate: string;
+  nextReviewDate: string;
+  textStyle?: CSSProperties;
+}
+const Dates = ({ lastConfirmedDate, nextReviewDate, textStyle }: DateProps) => (
+  <div style={{ ...renewalStyle.dates, ...textStyle, fontWeight: 500 }}>
+    <div>Last Updated On:</div>
+    <div>Next Review:</div>
+    <div>{lastConfirmedDate}</div>
+    <div>{nextReviewDate}</div>
+  </div>
+);
+
 interface RenewalCardBodyProps {
   moduleStatus: AccessModuleStatus;
   setLoading: (boolean) => void;
@@ -215,7 +244,6 @@ interface RenewalCardBodyProps {
   showTimeEstimate?: boolean;
   profile: Profile;
 }
-
 export const RenewalCardBody = ({
   moduleStatus,
   setLoading,
@@ -254,23 +282,6 @@ export const RenewalCardBody = ({
     !blockComplianceTraining ||
     isRenewalCompleteForModule(moduleStatus, duccSignedVersion);
 
-  const TimeEstimate = () =>
-    showTimeEstimate ? (
-      <FlexColumn style={{ alignItems: 'center' }}>
-        <Clock style={{ color: colors.disabled, width: '5em' }} />
-        {renewalTimeEstimate} min
-      </FlexColumn>
-    ) : null;
-
-  const Dates = () => (
-    <div style={{ ...renewalStyle.dates, ...textStyle, fontWeight: 500 }}>
-      <div>Last Updated On:</div>
-      <div>Next Review:</div>
-      <div>{lastConfirmedDate}</div>
-      <div>{nextReviewDate}</div>
-    </div>
-  );
-
   const module = switchCase(
     moduleStatus.moduleName,
     [
@@ -278,7 +289,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates />
+            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
             <div
               style={{ marginBottom: '0.75rem', ...textStyle, fontWeight: 500 }}
             >
@@ -297,7 +308,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate />
+            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
             <ActionButton
               {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='Review'
@@ -316,7 +327,7 @@ export const RenewalCardBody = ({
         return (
           <React.Fragment>
             <div style={{ gridArea: 'content' }}>
-              <Dates />
+              <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
               <div style={textStyle}>
                 The <AoU /> Publication and Presentation Policy requires that
                 you report any upcoming publication or presentation resulting
@@ -374,7 +385,7 @@ export const RenewalCardBody = ({
                 gridArea: 'action',
               }}
             >
-              <TimeEstimate />
+              <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
               <ActionButton
                 {...{ moduleStatus, duccSignedVersion }}
                 actionButtonText='Confirm'
@@ -397,7 +408,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates />
+            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
             <div style={textStyle}>
               You are required to complete the refreshed ethics training courses
               to understand the privacy safeguards and the compliance
@@ -422,7 +433,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate />
+            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
             <TooltipTrigger
               content={COMPLIANCE_TRAINIING_OUTAGE_MESSAGE}
               disabled={disableComplianceTrainingTooltip}
@@ -473,7 +484,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates />
+            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
             <div style={textStyle}>
               You are required to complete the refreshed ethics training courses
               to understand the privacy safeguards and the compliance
@@ -498,7 +509,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate />
+            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
             <TooltipTrigger
               content={COMPLIANCE_TRAINIING_OUTAGE_MESSAGE}
               disabled={disableComplianceTrainingTooltip}
@@ -542,7 +553,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ gridArea: 'content' }}>
-            <Dates />
+            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
             <div style={textStyle}>
               Please review and sign the data user code of conduct consenting to
               the <AoU /> data use policy.
@@ -555,7 +566,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate />
+            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
             <ActionButton
               {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='View & Sign'

--- a/ui/src/app/pages/access/modules-for-annual-renewal.tsx
+++ b/ui/src/app/pages/access/modules-for-annual-renewal.tsx
@@ -208,37 +208,43 @@ const ActionButton = ({
 };
 
 interface TimeEstimateProps {
-  showTimeEstimate: boolean;
-  renewalTimeEstimate: number;
+  moduleStatus: AccessModuleStatus;
 }
-const TimeEstimate = ({
-  showTimeEstimate,
-  renewalTimeEstimate,
-}: TimeEstimateProps) =>
-  showTimeEstimate ? (
+const TimeEstimate = ({ moduleStatus }: TimeEstimateProps) => {
+  const { moduleName } = moduleStatus;
+  const { renewalTimeEstimate } = getAccessModuleConfig(moduleName);
+
+  return (
     <FlexColumn style={{ alignItems: 'center' }}>
       <Clock style={{ color: colors.disabled, width: '5em' }} />
       {renewalTimeEstimate} min
     </FlexColumn>
-  ) : null;
+  );
+};
 
 interface DateProps {
-  lastConfirmedDate: string;
-  nextReviewDate: string;
+  moduleStatus: AccessModuleStatus;
+  duccSignedVersion: number;
   textStyle?: CSSProperties;
 }
-const Dates = ({ lastConfirmedDate, nextReviewDate, textStyle }: DateProps) => (
-  <div style={{ ...renewalStyle.dates, ...textStyle, fontWeight: 500 }}>
-    <div>Last Updated On:</div>
-    <div>Next Review:</div>
-    <div>{lastConfirmedDate}</div>
-    <div>{nextReviewDate}</div>
-  </div>
-);
+const Dates = ({ moduleStatus, duccSignedVersion, textStyle }: DateProps) => {
+  const { lastConfirmedDate, nextReviewDate } = computeRenewalDisplayDates(
+    moduleStatus,
+    duccSignedVersion
+  );
+  return (
+    <div style={{ ...renewalStyle.dates, ...textStyle, fontWeight: 500 }}>
+      <div>Last Updated On:</div>
+      <div>Next Review:</div>
+      <div>{lastConfirmedDate}</div>
+      <div>{nextReviewDate}</div>
+    </div>
+  );
+};
 
 interface RenewalCardBodyProps {
   moduleStatus: AccessModuleStatus;
-  setLoading: (boolean) => void;
+  setLoading: (loading: boolean) => void;
   textStyle?: CSSProperties;
   radioButtonStyle?: CSSProperties;
   showTimeEstimate?: boolean;
@@ -265,14 +271,6 @@ export const RenewalCardBody = ({
 
   const { duccSignedVersion } = profile;
 
-  const { renewalTimeEstimate } = getAccessModuleConfig(
-    moduleStatus.moduleName
-  );
-  const { lastConfirmedDate, nextReviewDate } = computeRenewalDisplayDates(
-    moduleStatus,
-    duccSignedVersion
-  );
-
   const { blockComplianceTraining } = serverConfigStore.get().config;
 
   const showRefreshText =
@@ -289,7 +287,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
+            <Dates {...{ moduleStatus, duccSignedVersion, textStyle }} />
             <div
               style={{ marginBottom: '0.75rem', ...textStyle, fontWeight: 500 }}
             >
@@ -308,7 +306,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
+            {showTimeEstimate && <TimeEstimate {...{ moduleStatus }} />}
             <ActionButton
               {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='Review'
@@ -327,7 +325,7 @@ export const RenewalCardBody = ({
         return (
           <React.Fragment>
             <div style={{ gridArea: 'content' }}>
-              <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
+              <Dates {...{ moduleStatus, duccSignedVersion, textStyle }} />
               <div style={textStyle}>
                 The <AoU /> Publication and Presentation Policy requires that
                 you report any upcoming publication or presentation resulting
@@ -385,7 +383,7 @@ export const RenewalCardBody = ({
                 gridArea: 'action',
               }}
             >
-              <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
+              {showTimeEstimate && <TimeEstimate {...{ moduleStatus }} />}
               <ActionButton
                 {...{ moduleStatus, duccSignedVersion }}
                 actionButtonText='Confirm'
@@ -408,7 +406,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
+            <Dates {...{ moduleStatus, duccSignedVersion, textStyle }} />
             <div style={textStyle}>
               You are required to complete the refreshed ethics training courses
               to understand the privacy safeguards and the compliance
@@ -433,7 +431,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
+            {showTimeEstimate && <TimeEstimate {...{ moduleStatus }} />}
             <TooltipTrigger
               content={COMPLIANCE_TRAINIING_OUTAGE_MESSAGE}
               disabled={disableComplianceTrainingTooltip}
@@ -484,7 +482,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ paddingRight: '1.4em', gridArea: 'content' }}>
-            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
+            <Dates {...{ moduleStatus, duccSignedVersion, textStyle }} />
             <div style={textStyle}>
               You are required to complete the refreshed ethics training courses
               to understand the privacy safeguards and the compliance
@@ -509,7 +507,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
+            {showTimeEstimate && <TimeEstimate {...{ moduleStatus }} />}
             <TooltipTrigger
               content={COMPLIANCE_TRAINIING_OUTAGE_MESSAGE}
               disabled={disableComplianceTrainingTooltip}
@@ -553,7 +551,7 @@ export const RenewalCardBody = ({
       () => (
         <React.Fragment>
           <div style={{ gridArea: 'content' }}>
-            <Dates {...{ lastConfirmedDate, nextReviewDate, textStyle }} />
+            <Dates {...{ moduleStatus, duccSignedVersion, textStyle }} />
             <div style={textStyle}>
               Please review and sign the data user code of conduct consenting to
               the <AoU /> data use policy.
@@ -566,7 +564,7 @@ export const RenewalCardBody = ({
               gridArea: 'action',
             }}
           >
-            <TimeEstimate {...{ showTimeEstimate, renewalTimeEstimate }} />
+            {showTimeEstimate && <TimeEstimate {...{ moduleStatus }} />}
             <ActionButton
               {...{ moduleStatus, duccSignedVersion }}
               actionButtonText='View & Sign'

--- a/ui/src/app/pages/admin/admin-notebook-view.tsx
+++ b/ui/src/app/pages/admin/admin-notebook-view.tsx
@@ -138,14 +138,7 @@ const AdminNotebookViewComponent = (props: Props) => {
 
   return (
     <React.Fragment>
-      <Header
-        {...{
-          workspaceDisplayName,
-          workspaceNamespace,
-          notebookNameWithSuffix,
-          accessReason,
-        }}
-      />
+      <Header {...props} {...{ workspaceDisplayName }} />
       <Main {...{ notebookHtml, errorMessage }} />
     </React.Fragment>
   );

--- a/ui/src/app/pages/admin/admin-notebook-view.tsx
+++ b/ui/src/app/pages/admin/admin-notebook-view.tsx
@@ -43,56 +43,70 @@ const styles = reactStyles({
   },
 });
 
+interface HeaderProps {
+  workspaceDisplayName: string;
+  workspaceNamespace: string;
+  notebookNameWithSuffix: string;
+  accessReason: string;
+}
+const Header = ({
+  workspaceDisplayName,
+  workspaceNamespace,
+  notebookNameWithSuffix,
+  accessReason,
+}: HeaderProps) => {
+  const workspace = workspaceDisplayName
+    ? `Workspace ${workspaceDisplayName}`
+    : 'Workspace';
+  const link = (
+    <StyledRouterLink path={`/admin/workspaces/${workspaceNamespace}`}>
+      {workspace} with namespace {workspaceNamespace}
+    </StyledRouterLink>
+  );
+  return (
+    <div style={styles.heading}>
+      Viewing {notebookNameWithSuffix} in {link} for reason:
+      <div>{accessReason}</div>
+    </div>
+  );
+};
+
+interface MainProps {
+  notebookHtml: string;
+  errorMessage: string;
+}
+const Main = ({ notebookHtml, errorMessage }: MainProps) => {
+  if (notebookHtml) {
+    return (
+      <iframe
+        id='notebook-frame'
+        style={styles.notebook}
+        srcDoc={notebookHtml}
+      />
+    );
+  } else if (errorMessage) {
+    return <div style={styles.error}>{errorMessage}</div>;
+  } else {
+    return <SpinnerOverlay />;
+  }
+};
+
 interface Props {
   workspaceNamespace: string;
   notebookNameWithSuffix: string;
   accessReason: string;
 }
-
 const AdminNotebookViewComponent = (props: Props) => {
   const { workspaceNamespace, notebookNameWithSuffix, accessReason } = props;
-  const [notebookHtml, setHtml] = useState('');
-  const [workspaceName, setWorkspaceName] = useState('');
+  const [notebookHtml, setNotebookHtml] = useState('');
+  const [workspaceDisplayName, setWorkspaceDisplayName] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-
-  const Header = () => {
-    const workspace = workspaceName
-      ? `Workspace ${workspaceName}`
-      : 'Workspace';
-    const link = (
-      <StyledRouterLink path={`/admin/workspaces/${workspaceNamespace}`}>
-        {workspace} with namespace {workspaceNamespace}
-      </StyledRouterLink>
-    );
-    return (
-      <div style={styles.heading}>
-        Viewing {notebookNameWithSuffix} in {link} for reason:
-        <div>{accessReason}</div>
-      </div>
-    );
-  };
-
-  const Main = () => {
-    if (notebookHtml) {
-      return (
-        <iframe
-          id='notebook-frame'
-          style={styles.notebook}
-          srcDoc={notebookHtml}
-        />
-      );
-    } else if (errorMessage) {
-      return <div style={styles.error}>{errorMessage}</div>;
-    } else {
-      return <SpinnerOverlay />;
-    }
-  };
 
   useEffect(() => {
     workspaceAdminApi()
       .getWorkspaceAdminView(workspaceNamespace)
       .then((workspaceAdminView) =>
-        setWorkspaceName(workspaceAdminView.workspace.name)
+        setWorkspaceDisplayName(workspaceAdminView.workspace.name)
       );
   }, []);
 
@@ -108,7 +122,7 @@ const AdminNotebookViewComponent = (props: Props) => {
       .adminReadOnlyNotebook(workspaceNamespace, notebookNameWithSuffix, {
         reason: accessReason,
       })
-      .then((response) => setHtml(response.html))
+      .then((response) => setNotebookHtml(response.html))
       .catch((e) => {
         if (e.status === 404) {
           setErrorMessage(`Notebook ${notebookNameWithSuffix} was not found`);
@@ -124,8 +138,15 @@ const AdminNotebookViewComponent = (props: Props) => {
 
   return (
     <React.Fragment>
-      <Header />
-      <Main />
+      <Header
+        {...{
+          workspaceDisplayName,
+          workspaceNamespace,
+          notebookNameWithSuffix,
+          accessReason,
+        }}
+      />
+      <Main {...{ notebookHtml, errorMessage }} />
     </React.Fragment>
   );
 };

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -59,7 +59,7 @@ const userAppToRow = (userApp: UserAppEnvironment): CloudEnvironmentRow => {
 
 interface DeleteButtonProps {
   row: CloudEnvironmentRow;
-  runtimeToDelete: string;
+  runtimeToDelete?: string;
   setRuntimeToDelete: (runtimeName: string) => void;
   setConfirmDeleteRuntime: (confirmDelete: boolean) => void;
 }
@@ -103,7 +103,7 @@ export const CloudEnvironmentsTable = ({
   runtimes,
   userApps,
 }: Props) => {
-  const [runtimeToDelete, setRuntimeToDelete] = useState<string>();
+  const [runtimeToDelete, setRuntimeToDelete] = useState<string | null>();
   const [confirmDeleteRuntime, setConfirmDeleteRuntime] = useState(false);
 
   const deleteRuntime = () => {

--- a/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
+++ b/ui/src/app/pages/admin/workspace/cloud-environments-table.tsx
@@ -57,6 +57,40 @@ const userAppToRow = (userApp: UserAppEnvironment): CloudEnvironmentRow => {
   };
 };
 
+interface DeleteButtonProps {
+  row: CloudEnvironmentRow;
+  runtimeToDelete: string;
+  setRuntimeToDelete: (runtimeName: string) => void;
+  setConfirmDeleteRuntime: (confirmDelete: boolean) => void;
+}
+const DeleteButton = ({
+  row,
+  runtimeToDelete,
+  setRuntimeToDelete,
+  setConfirmDeleteRuntime,
+}: DeleteButtonProps) => {
+  const tooltipContent =
+    row.appType === UIAppType.JUPYTER
+      ? 'The persistent disk will not be deleted.'
+      : 'Deletion is currently only available for Jupyter.  See RW-8943.';
+
+  return (
+    <TooltipTrigger content={tooltipContent}>
+      <Button
+        disabled={
+          row.appType !== UIAppType.JUPYTER || runtimeToDelete === row.name
+        }
+        onClick={() => {
+          setRuntimeToDelete(row.name);
+          setConfirmDeleteRuntime(true);
+        }}
+      >
+        Delete
+      </Button>
+    </TooltipTrigger>
+  );
+};
+
 interface Props {
   workspaceNamespace: string;
   onDelete: () => void;
@@ -85,29 +119,6 @@ export const CloudEnvironmentsTable = ({
   const cancelDeleteRuntime = () => {
     setConfirmDeleteRuntime(false);
     setRuntimeToDelete(null);
-  };
-
-  const DeleteButton = ({ row }: { row: CloudEnvironmentRow }) => {
-    const tooltipContent =
-      row.appType === UIAppType.JUPYTER
-        ? 'The persistent disk will not be deleted.'
-        : 'Deletion is currently only available for Jupyter.  See RW-8943.';
-
-    return (
-      <TooltipTrigger content={tooltipContent}>
-        <Button
-          disabled={
-            row.appType !== UIAppType.JUPYTER || runtimeToDelete === row.name
-          }
-          onClick={() => {
-            setRuntimeToDelete(row.name);
-            setConfirmDeleteRuntime(true);
-          }}
-        >
-          Delete
-        </Button>
-      </TooltipTrigger>
-    );
   };
 
   return runtimes && userApps ? (
@@ -146,7 +157,16 @@ export const CloudEnvironmentsTable = ({
         <Column field='lastAccessedTime' header='Last Accessed Time' />
         <Column field='status' header='Status' />
         <Column
-          body={(row: CloudEnvironmentRow) => <DeleteButton {...{ row }} />}
+          body={(row: CloudEnvironmentRow) => (
+            <DeleteButton
+              {...{
+                row,
+                runtimeToDelete,
+                setRuntimeToDelete,
+                setConfirmDeleteRuntime,
+              }}
+            />
+          )}
         />
       </DataTable>
     </div>

--- a/ui/src/app/pages/admin/workspace/disks-table.tsx
+++ b/ui/src/app/pages/admin/workspace/disks-table.tsx
@@ -15,7 +15,6 @@ import moment from 'moment';
 interface Props {
   sourceWorkspaceNamespace?: string;
 }
-
 export const DisksTable = ({ sourceWorkspaceNamespace }: Props) => {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -83,39 +83,15 @@ const stylesFunction = {
 const USER_DISMISSED_ALERT_VALUE = 'DISMISSED';
 
 interface NewVersionFlagProps {
-  userHasDismissedAlert: boolean;
-  setUserHasDismissedAlert: Function;
+  namespace: string;
+  terraName: string;
   setShowModal: Function;
-  localStorageKey: string;
 }
 const NewVersionFlag = ({
-  userHasDismissedAlert,
-  setUserHasDismissedAlert,
+  namespace,
+  terraName,
   setShowModal,
-  localStorageKey,
-}: NewVersionFlagProps) => (
-  <Clickable
-    data-test-id='new-version-flag'
-    propagateDataTestId={true}
-    onClick={() => {
-      localStorage.setItem(localStorageKey, USER_DISMISSED_ALERT_VALUE);
-      setUserHasDismissedAlert(true);
-      setShowModal(true);
-    }}
-  >
-    <span style={stylesFunction.cdrVersionFlagCircle(!userHasDismissedAlert)}>
-      <ClrIcon shape='flag' class='is-solid' />
-    </span>
-  </Clickable>
-);
-
-const CdrVersion = (props: {
-  workspace: Workspace;
-  cdrVersionTiersResponse: CdrVersionTiersResponse;
-}) => {
-  const { workspace, cdrVersionTiersResponse } = props;
-  const { namespace, terraName } = workspace;
-
+}: NewVersionFlagProps) => {
   const localStorageKey = `${namespace}-${terraName}-user-dismissed-cdr-version-update-alert`;
 
   const dismissedInLocalStorage = () =>
@@ -124,11 +100,36 @@ const CdrVersion = (props: {
   const [userHasDismissedAlert, setUserHasDismissedAlert] = useState(
     dismissedInLocalStorage()
   );
+  useEffect(() => setUserHasDismissedAlert(dismissedInLocalStorage()));
+
+  return (
+    <Clickable
+      data-test-id='new-version-flag'
+      propagateDataTestId={true}
+      onClick={() => {
+        localStorage.setItem(localStorageKey, USER_DISMISSED_ALERT_VALUE);
+        setUserHasDismissedAlert(true);
+        setShowModal(true);
+      }}
+    >
+      <span style={stylesFunction.cdrVersionFlagCircle(!userHasDismissedAlert)}>
+        <ClrIcon shape='flag' class='is-solid' />
+      </span>
+    </Clickable>
+  );
+};
+
+const CdrVersion = (props: {
+  workspace: Workspace;
+  cdrVersionTiersResponse: CdrVersionTiersResponse;
+}) => {
+  const { workspace, cdrVersionTiersResponse } = props;
+  const { namespace, terraName } = workspace;
+
   const [showModal, setShowModal] = useState(false);
   const [navigate] = useNavigation();
 
   // check whether the user has previously dismissed the alert in localStorage, to determine icon color
-  useEffect(() => setUserHasDismissedAlert(dismissedInLocalStorage()));
 
   return (
     <FlexRow data-test-id='cdr-version' style={{ textTransform: 'none' }}>
@@ -136,10 +137,9 @@ const CdrVersion = (props: {
       {!hasDefaultCdrVersion(workspace, cdrVersionTiersResponse) && (
         <NewVersionFlag
           {...{
-            userHasDismissedAlert,
-            setUserHasDismissedAlert,
+            namespace,
+            terraName,
             setShowModal,
-            localStorageKey,
           }}
         />
       )}

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -100,6 +100,8 @@ const NewVersionFlag = ({
   const [userHasDismissedAlert, setUserHasDismissedAlert] = useState(
     dismissedInLocalStorage()
   );
+
+  // check whether the user has previously dismissed the alert in localStorage, to determine icon color
   useEffect(() => setUserHasDismissedAlert(dismissedInLocalStorage()));
 
   return (
@@ -128,8 +130,6 @@ const CdrVersion = (props: {
 
   const [showModal, setShowModal] = useState(false);
   const [navigate] = useNavigation();
-
-  // check whether the user has previously dismissed the alert in localStorage, to determine icon color
 
   return (
     <FlexRow data-test-id='cdr-version' style={{ textTransform: 'none' }}>

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -85,7 +85,7 @@ const USER_DISMISSED_ALERT_VALUE = 'DISMISSED';
 interface NewVersionFlagProps {
   namespace: string;
   terraName: string;
-  setShowModal: Function;
+  setShowModal: (show: boolean) => void;
 }
 const NewVersionFlag = ({
   namespace,

--- a/ui/src/app/pages/workspace/workspace-nav-bar.tsx
+++ b/ui/src/app/pages/workspace/workspace-nav-bar.tsx
@@ -82,6 +82,33 @@ const stylesFunction = {
 
 const USER_DISMISSED_ALERT_VALUE = 'DISMISSED';
 
+interface NewVersionFlagProps {
+  userHasDismissedAlert: boolean;
+  setUserHasDismissedAlert: Function;
+  setShowModal: Function;
+  localStorageKey: string;
+}
+const NewVersionFlag = ({
+  userHasDismissedAlert,
+  setUserHasDismissedAlert,
+  setShowModal,
+  localStorageKey,
+}: NewVersionFlagProps) => (
+  <Clickable
+    data-test-id='new-version-flag'
+    propagateDataTestId={true}
+    onClick={() => {
+      localStorage.setItem(localStorageKey, USER_DISMISSED_ALERT_VALUE);
+      setUserHasDismissedAlert(true);
+      setShowModal(true);
+    }}
+  >
+    <span style={stylesFunction.cdrVersionFlagCircle(!userHasDismissedAlert)}>
+      <ClrIcon shape='flag' class='is-solid' />
+    </span>
+  </Clickable>
+);
+
 const CdrVersion = (props: {
   workspace: Workspace;
   cdrVersionTiersResponse: CdrVersionTiersResponse;
@@ -103,27 +130,18 @@ const CdrVersion = (props: {
   // check whether the user has previously dismissed the alert in localStorage, to determine icon color
   useEffect(() => setUserHasDismissedAlert(dismissedInLocalStorage()));
 
-  const NewVersionFlag = () => (
-    <Clickable
-      data-test-id='new-version-flag'
-      propagateDataTestId={true}
-      onClick={() => {
-        localStorage.setItem(localStorageKey, USER_DISMISSED_ALERT_VALUE);
-        setUserHasDismissedAlert(true);
-        setShowModal(true);
-      }}
-    >
-      <span style={stylesFunction.cdrVersionFlagCircle(!userHasDismissedAlert)}>
-        <ClrIcon shape='flag' class='is-solid' />
-      </span>
-    </Clickable>
-  );
-
   return (
     <FlexRow data-test-id='cdr-version' style={{ textTransform: 'none' }}>
       {getCdrVersion(workspace, cdrVersionTiersResponse).name}
       {!hasDefaultCdrVersion(workspace, cdrVersionTiersResponse) && (
-        <NewVersionFlag />
+        <NewVersionFlag
+          {...{
+            userHasDismissedAlert,
+            setUserHasDismissedAlert,
+            setShowModal,
+            localStorageKey,
+          }}
+        />
       )}
       {showModal && (
         <CdrVersionUpgradeModal


### PR DESCRIPTION
Help prevent situations like #9151 by linting.

I un-nested these components found by the linter:
* TimeEstimate (annual renewal)
* Dates (annual renewal)
* Header (admin notebook view)
* Main (admin notebook view)
* DeleteButton (cloud environments table)
* NewVersionFlag (workspace nav bar)

Tested by confirming normal behavior in Annual Renewal, Admin Notebook View, the Cloud Environments Table, and the Workspace Nav Bar (when a workspace has an old CDR Version)

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
