### PR TITLE
[risk=low][RW-13727] Use lenient client for delete-unshared

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -177,9 +177,10 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
   @Override
   public ResponseEntity<Void> deleteUnsharedWorkspaceEnvironments() {
     List<String> activeNamespaces =
-        workspaceService.getWorkspacesAsService().stream()
+        workspaceService.listWorkspacesAsService().stream()
             .map(ws -> ws.getWorkspace().getNamespace())
             .toList();
+
     log.info(
         String.format(
             "Queuing %d active workspaces in batches for deletion of unshared resources",

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -475,7 +475,7 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   @Override
   public ResponseEntity<WorkspaceResponseListResponse> getWorkspaces() {
     return ResponseEntity.ok(
-        new WorkspaceResponseListResponse().items(workspaceService.getWorkspaces()));
+        new WorkspaceResponseListResponse().items(workspaceService.listWorkspaces()));
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceServiceImpl.java
@@ -61,7 +61,7 @@ public class FeaturedWorkspaceServiceImpl implements FeaturedWorkspaceService {
             .toList();
 
     Map<String, RawlsWorkspaceListResponse> fcWorkspacesByUuid =
-        fireCloudService.getWorkspaces().stream()
+        fireCloudService.listWorkspaces().stream()
             .collect(
                 Collectors.toMap(
                     fcWorkspace -> fcWorkspace.getWorkspace().getWorkspaceId(),

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudService.java
@@ -112,9 +112,9 @@ public interface FireCloudService {
 
   Optional<RawlsWorkspaceResponse> getWorkspace(DbWorkspace dbWorkspace);
 
-  List<RawlsWorkspaceListResponse> getWorkspaces();
+  List<RawlsWorkspaceListResponse> listWorkspaces();
 
-  List<RawlsWorkspaceListResponse> getWorkspacesAsService();
+  List<RawlsWorkspaceListResponse> listWorkspacesAsService();
 
   void deleteWorkspace(String workspaceNamespace, String firecloudName);
 

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -710,7 +710,7 @@ public class InitialCreditsService {
 
   private List<Workspace> getWorkspacesForUser(DbUser user) {
     return workspaceMapper
-        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.getWorkspacesAsService(), this)
+        .toApiWorkspaceResponseList(workspaceDao, fireCloudService.listWorkspacesAsService(), this)
         .stream()
         .map(WorkspaceResponse::getWorkspace)
         .filter(ws -> ws.getCreatorUser().getUserName().equals(user.getUsername()))

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -90,13 +90,13 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
-  public List<WorkspaceResponse> getWorkspaces() {
+  public List<WorkspaceResponse> listWorkspaces() {
     return Collections.emptyList();
   }
 
   @Override
-  public List<WorkspaceResponse> getWorkspacesAsService() {
-    logger.warn("getWorkspacesAsService not implemented in VWB");
+  public List<WorkspaceResponse> listWorkspacesAsService() {
+    logger.warn("listWorkspacesAsService not implemented in VWB");
     return Collections.emptyList();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -34,9 +34,9 @@ public interface WorkspaceService {
 
   boolean notebookTransferComplete(String workspaceNamespace, String workspaceTerraName);
 
-  List<WorkspaceResponse> getWorkspaces();
+  List<WorkspaceResponse> listWorkspaces();
 
-  List<WorkspaceResponse> getWorkspacesAsService();
+  List<WorkspaceResponse> listWorkspacesAsService();
 
   /**
    * Get all Featured workspaces from the DB.

--- a/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/NotebooksControllerTest.java
@@ -669,8 +669,8 @@ public class NotebooksControllerTest {
     RawlsWorkspaceListResponse fcListResponse = new RawlsWorkspaceListResponse();
     fcListResponse.setWorkspace(fcWorkspace);
     fcListResponse.setAccessLevel(firecloudMapper.apiToFcWorkspaceAccessLevel(access));
-    List<RawlsWorkspaceListResponse> workspaceResponses = mockFireCloudService.getWorkspaces();
+    List<RawlsWorkspaceListResponse> workspaceResponses = mockFireCloudService.listWorkspaces();
     workspaceResponses.add(fcListResponse);
-    doReturn(workspaceResponses).when(mockFireCloudService).getWorkspaces();
+    doReturn(workspaceResponses).when(mockFireCloudService).listWorkspaces();
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -511,9 +511,9 @@ public class WorkspacesControllerTest {
     doReturn(fcGetResponse)
         .when(fireCloudService)
         .getWorkspace(fcWorkspace.getNamespace(), fcWorkspace.getName());
-    List<RawlsWorkspaceListResponse> workspaceResponses = fireCloudService.getWorkspaces();
+    List<RawlsWorkspaceListResponse> workspaceResponses = fireCloudService.listWorkspaces();
     workspaceResponses.add(fcResponse);
-    doReturn(workspaceResponses).when(fireCloudService).getWorkspaces();
+    doReturn(workspaceResponses).when(fireCloudService).listWorkspaces();
   }
 
   /**
@@ -627,7 +627,7 @@ public class WorkspacesControllerTest {
         TestMockFactory.createTerraWorkspace(
             workspace.getNamespace(), workspace.getTerraName(), null));
     fcResponse.setAccessLevel(RawlsWorkspaceAccessLevel.OWNER);
-    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).getWorkspaces();
+    doReturn(Collections.singletonList(fcResponse)).when(fireCloudService).listWorkspaces();
 
     assertThat(workspacesController.getWorkspaces().getBody().getItems().size()).isEqualTo(1);
     assertThat(
@@ -2793,7 +2793,7 @@ public class WorkspacesControllerTest {
 
   @Test
   public void testEmptyFireCloudWorkspaces() {
-    when(fireCloudService.getWorkspaces()).thenReturn(new ArrayList<>());
+    when(fireCloudService.listWorkspaces()).thenReturn(new ArrayList<>());
     try {
       ResponseEntity<WorkspaceResponseListResponse> response = workspacesController.getWorkspaces();
       assertThat(response.getBody().getItems()).isEmpty();

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -113,7 +113,7 @@ public class FeaturedWorkspaceTest {
             .workspace(new RawlsWorkspaceDetails().workspaceId(firecloudUuid))
             .accessLevel(RawlsWorkspaceAccessLevel.OWNER));
 
-    when(mockFireCloudService.getWorkspaces()).thenReturn(rawlsWorkspaces);
+    when(mockFireCloudService.listWorkspaces()).thenReturn(rawlsWorkspaces);
   }
 
   @Test
@@ -170,7 +170,7 @@ public class FeaturedWorkspaceTest {
     // override the mock so that FC getWorkspaces() does not return the workspace
     // which simulates inaccessibility to my user
 
-    when(mockFireCloudService.getWorkspaces()).thenReturn(Collections.emptyList());
+    when(mockFireCloudService.listWorkspaces()).thenReturn(Collections.emptyList());
 
     List<WorkspaceResponse> workspaceResponsesList =
         assertDoesNotThrow(
@@ -194,7 +194,7 @@ public class FeaturedWorkspaceTest {
             .map(ws -> ws.accessLevel(RawlsWorkspaceAccessLevel.NO_ACCESS))
             .toList();
 
-    when(mockFireCloudService.getWorkspaces()).thenReturn(workspaceWithoutAccess);
+    when(mockFireCloudService.listWorkspaces()).thenReturn(workspaceWithoutAccess);
 
     List<WorkspaceResponse> workspaceResponsesList =
         assertDoesNotThrow(

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -204,7 +204,7 @@ public class WorkspaceServiceTest {
         RawlsWorkspaceAccessLevel.OWNER,
         WorkspaceActiveStatus.ACTIVE);
 
-    doReturn(firecloudWorkspaceResponses).when(mockFireCloudService).getWorkspaces();
+    doReturn(firecloudWorkspaceResponses).when(mockFireCloudService).listWorkspaces();
 
     currentUser = new DbUser();
     currentUser.setUsername(DEFAULT_USERNAME);
@@ -334,19 +334,19 @@ public class WorkspaceServiceTest {
             workspaceNamespace,
             accessLevel);
     firecloudWorkspaceResponses.add(mockWorkspaceListResponse);
-    when(mockFireCloudService.getWorkspaces()).thenReturn(firecloudWorkspaceResponses);
+    when(mockFireCloudService.listWorkspaces()).thenReturn(firecloudWorkspaceResponses);
 
     return dbWorkspace;
   }
 
   @Test
-  public void getWorkspaces() {
-    assertThat(workspaceService.getWorkspaces()).hasSize(5);
+  public void listWorkspaces() {
+    assertThat(workspaceService.listWorkspaces()).hasSize(5);
   }
 
   @Test
-  public void getWorkspaces_skipDeleted() {
-    int currentWorkspacesSize = workspaceService.getWorkspaces().size();
+  public void listWorkspaces_skipDeleted() {
+    int currentWorkspacesSize = workspaceService.listWorkspaces().size();
 
     addMockedWorkspace(
         workspaceIdIncrementer.getAndIncrement(),
@@ -354,12 +354,12 @@ public class WorkspaceServiceTest {
         DEFAULT_WORKSPACE_NAMESPACE,
         RawlsWorkspaceAccessLevel.OWNER,
         WorkspaceActiveStatus.DELETED);
-    assertThat(workspaceService.getWorkspaces().size()).isEqualTo(currentWorkspacesSize);
+    assertThat(workspaceService.listWorkspaces().size()).isEqualTo(currentWorkspacesSize);
   }
 
   @Test
-  public void getWorkspaces_skipPublished() {
-    int currentWorkspacesSize = workspaceService.getWorkspaces().size();
+  public void listWorkspaces_skipPublished() {
+    int currentWorkspacesSize = workspaceService.listWorkspaces().size();
     addMockedPublishedWorkspace(
         workspaceIdIncrementer.getAndIncrement(),
         "published_reader",
@@ -368,12 +368,12 @@ public class WorkspaceServiceTest {
         WorkspaceActiveStatus.ACTIVE,
         RawlsWorkspaceAccessLevel.READER);
 
-    assertThat(workspaceService.getWorkspaces().size()).isEqualTo(currentWorkspacesSize);
+    assertThat(workspaceService.listWorkspaces().size()).isEqualTo(currentWorkspacesSize);
   }
 
   @Test
-  public void getWorkspaces_published_butOwner() {
-    int currentWorkspacesSize = workspaceService.getWorkspaces().size();
+  public void listWorkspaces_published_butOwner() {
+    int currentWorkspacesSize = workspaceService.listWorkspaces().size();
     addMockedPublishedWorkspace(
         workspaceIdIncrementer.getAndIncrement(),
         "published_reader",
@@ -382,7 +382,7 @@ public class WorkspaceServiceTest {
         WorkspaceActiveStatus.ACTIVE,
         RawlsWorkspaceAccessLevel.OWNER);
 
-    assertThat(workspaceService.getWorkspaces().size()).isEqualTo(currentWorkspacesSize + 1);
+    assertThat(workspaceService.listWorkspaces().size()).isEqualTo(currentWorkspacesSize + 1);
   }
 
   @Test


### PR DESCRIPTION
The deleteUnsharedWorkspaceEnvironments cron job is timing out on both Prod and Test, because calls to Terra List Workspaces often exceed the timeout of 40s.  Because this is a cron job (and not interactive use) we can instead use the more lenient timeout.

Also rename "get workspaces" to the more idiomatic "list workspaces" where used, and add timing logs for future debugging

 ---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
