### PR TITLE
[risk=low][RW-14617] Apply recommendations to improve Genomic Extraction reliability

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -77,6 +77,8 @@ public class GenomicExtractionService {
 
   private static final int EARLIEST_SUPPORTED_LEGACY_METHOD_VERSION = 3;
 
+  private static final BigDecimal MEMORY_RETRY_MULTIPLIER = BigDecimal.valueOf(1.5);
+
   private final FireCloudService fireCloudService;
   private final GenomicDatasetService genomicDatasetService;
   private final JiraService jiraService;
@@ -510,7 +512,7 @@ public class GenomicExtractionService {
                     .methodConfigurationName(methodConfig.getName())
                     .deleteIntermediateOutputFiles(true)
                     .useCallCache(true)
-                    .memoryRetryMultiplier(BigDecimal.valueOf(1.5)),
+                    .memoryRetryMultiplier(MEMORY_RETRY_MULTIPLIER),
                 cohortExtractionConfig.operationalTerraWorkspaceNamespace,
                 cohortExtractionConfig.operationalTerraWorkspaceName);
 

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import jakarta.inject.Provider;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -505,10 +506,11 @@ public class GenomicExtractionService {
             .get()
             .createSubmission(
                 new FirecloudSubmissionRequest()
-                    .deleteIntermediateOutputFiles(true)
                     .methodConfigurationNamespace(methodConfig.getNamespace())
                     .methodConfigurationName(methodConfig.getName())
-                    .useCallCache(false),
+                    .deleteIntermediateOutputFiles(true)
+                    .useCallCache(true)
+                    .memoryRetryMultiplier(BigDecimal.valueOf(1.5)),
                 cohortExtractionConfig.operationalTerraWorkspaceNamespace,
                 cohortExtractionConfig.operationalTerraWorkspaceName);
 

--- a/api/src/main/resources/firecloud.yaml
+++ b/api/src/main/resources/firecloud.yaml
@@ -2570,6 +2570,27 @@ components:
           enum:
             - NoNewCalls
             - ContinueWhilePossible
+        memoryRetryMultiplier:
+          type: number
+          description: If a task fails due to running out of memory and the stderr of the task
+            contains one of error keys that is set in Cromwell config along with maxRetries in its
+            runtime attributes, then it will be retried with its memory multiplied by this amount.
+            See Cromwell docs for more information.
+        ignoreEmptyOutputs:
+          type: boolean
+          description: Whether or not to create output columns if they would be empty and optional.
+            Defaults to false (columns are created).
+        monitoringScript:
+          type: string
+          description: Location of user-defined monitoring script that runs inside the task container
+        monitoringImage:
+          type: string
+          description: User-defined monitoring container that runs as a sibling to the task container.
+            Alternative to monitoringScript.
+        monitoringImageScript:
+          type: string
+          description: When using monitoringImage, a user-defined script that runs inside the
+            monitoring container
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionResponse:


### PR DESCRIPTION
Genomics workflows often have data-dependent resource constraints.  In certain circumstances, our Genomics Extraction workflow may run out of memory in one or more shards (very small sub-tasks).  Today, this means that the overall workflow fails, but this is often recoverable if the shard task were given more memory.  Cromwell has configuration settings for this common scenario, and Terra gives us access to these settings.

Apply two settings which are recommended by the Variants team for everyday use of this pipeline, [Enable Call Caching](https://cromwell.readthedocs.io/en/develop/cromwell_features/CallCaching/) and [Retry with More Memory](https://cromwell.readthedocs.io/en/develop/cromwell_features/RetryWithMoreMemory/#retry-with-more-memory) (1.5x). 

I can't test directly that this will solve the users' problems in RW-14617 or RW-14632, but I was able to run an extraction successfully with these settings.

See the right column of a [workflow submission](https://bvdp-saturn-dev.appspot.com/#workspaces/aou-wgs-cohort-extraction/aouwgscohortextraction/submission_history/6b2010a6-5c97-4c96-8c4e-bb7541845f72) before this change

<img width="1320" alt="Before" src="https://github.com/user-attachments/assets/8a806bf4-6794-4df0-966b-dc10ce9f35b5" />

and a [submission](https://bvdp-saturn-dev.appspot.com/#workspaces/aou-wgs-cohort-extraction/aouwgscohortextraction/submission_history/4e8bdfe8-e3fe-4a31-9d79-72cf9561023f) after

<img width="1321" alt="After" src="https://github.com/user-attachments/assets/c9c70047-ffca-4cfb-8b36-1bfaa26e673f" />

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
