### PR TITLE
[risk=low][RW-13727] Improve performance of deleteUnsharedWorkspaceEnvironments

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineEnvironmentsController.java
@@ -176,15 +176,13 @@ public class OfflineEnvironmentsController implements OfflineEnvironmentsApiDele
 
   @Override
   public ResponseEntity<Void> deleteUnsharedWorkspaceEnvironments() {
-    List<String> activeNamespaces =
-        workspaceService.listWorkspacesAsService().stream()
-            .map(ws -> ws.getWorkspace().getNamespace())
-            .toList();
+    List<String> activeNamespaces = workspaceService.getActiveWorkspaceNamespacesAsService();
 
     log.info(
         String.format(
             "Queuing %d active workspaces in batches for deletion of unshared resources",
             activeNamespaces.size()));
+
     taskQueueService.groupAndPushDeleteWorkspaceEnvironmentTasks(activeNamespaces);
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -120,8 +120,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   // https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#
   public static final List<String> FIRECLOUD_WORKSPACE_REQUIRED_FIELDS =
       List.of(
-          "workspace.workspaceId",
           "accessLevel",
+          "workspace.workspaceId",
           "workspace.name",
           "workspace.namespace",
           "workspace.googleProject",

--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -120,8 +120,8 @@ public class FireCloudServiceImpl implements FireCloudService {
   // https://docs.google.com/document/d/1YS95Q7ViRztaCSfPK-NS6tzFPrVpp5KUo0FaWGx7VHw/edit#
   public static final List<String> FIRECLOUD_WORKSPACE_REQUIRED_FIELDS =
       List.of(
-          "accessLevel",
           "workspace.workspaceId",
+          "accessLevel",
           "workspace.name",
           "workspace.namespace",
           "workspace.googleProject",

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -95,8 +95,8 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
-  public List<WorkspaceResponse> listWorkspacesAsService() {
-    logger.warn("listWorkspacesAsService not implemented in VWB");
+  public List<String> getActiveWorkspaceNamespacesAsService() {
+    logger.warn("getActiveWorkspaceNamespacesAsService not implemented in VWB");
     return Collections.emptyList();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -36,7 +36,7 @@ public interface WorkspaceService {
 
   List<WorkspaceResponse> listWorkspaces();
 
-  List<WorkspaceResponse> listWorkspacesAsService();
+  List<String> getActiveWorkspaceNamespacesAsService();
 
   /**
    * Get all Featured workspaces from the DB.

--- a/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/featuredworkspace/FeaturedWorkspaceTest.java
@@ -167,7 +167,7 @@ public class FeaturedWorkspaceTest {
   public void testGetByFeaturedCategory_inaccessible() {
     mockFeaturedWorkspaces("Tutorial_namespace", DbFeaturedCategory.TUTORIAL_WORKSPACES, "one");
 
-    // override the mock so that FC getWorkspaces() does not return the workspace
+    // override the mock so that FC listWorkspaces() does not return the workspace
     // which simulates inaccessibility to my user
 
     when(mockFireCloudService.listWorkspaces()).thenReturn(Collections.emptyList());
@@ -186,7 +186,7 @@ public class FeaturedWorkspaceTest {
     String namespace = "Tutorial_namespace";
     mockFeaturedWorkspaces(namespace, DbFeaturedCategory.TUTORIAL_WORKSPACES, "one");
 
-    // override the mock so that FC getWorkspaces() returns the workspace with NO_ACCESS
+    // override the mock so that FC listWorkspaces() returns the workspace with NO_ACCESS
     // which simulates that my user is not in the workspace's tier auth domain
 
     var workspaceWithoutAccess =


### PR DESCRIPTION
There are 3 steps in the pre-queuing phase of the deleteUnsharedWorkspaceEnvironments cron which can take a meaningful amount of time:
1. Terra List Workspaces
2. Query the RWB DB for which of these workspaces are active 
3. Combine the Terra Workspace with the RWB DbWorkspace to create a Workspace entity

Step 3 isn't necessary (we only need the Workspace Namespace) so I remove it here.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
