### PR TITLE
[risk=low][RW-14654] Add timing logs for checkInitialCreditsUsage

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineBillingController.java
@@ -60,6 +60,13 @@ public class OfflineBillingController implements OfflineBillingApiDelegate {
     stopwatch.reset().start();
     // Clear table googleproject_cost and then insert all entries from BQ
     googleProjectPerCostDao.deleteAll();
+    elapsed = stopwatch.stop().elapsed();
+    log.info(
+        String.format(
+            "checkInitialCreditsUsage: cleared googleproject_cost table in %s",
+            formatDurationPretty(elapsed)));
+
+    stopwatch.reset().start();
     googleProjectPerCostDao.batchInsertProjectPerCost(workspaceCosts);
     elapsed = stopwatch.stop().elapsed();
     log.info(

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineBillingControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineBillingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Stopwatch;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,19 +23,18 @@ import org.springframework.context.annotation.Import;
 @DataJpaTest
 public class OfflineBillingControllerTest {
 
-  @Autowired private InitialCreditsBatchUpdateService mockFreeTierBillingUpdateService;
   @Autowired private OfflineBillingController offlineBillingController;
-  @Autowired private TaskQueueService mockTaskQueueService;
-  @Autowired private UserService mockUserService;
-  @Autowired private GoogleProjectPerCostDao mockGoogleProjectPerCostDao;
+
+  @MockBean private GoogleProjectPerCostDao mockGoogleProjectPerCostDao;
+  @MockBean private InitialCreditsBatchUpdateService mockInitialCreditsBatchUpdateService;
+  @MockBean private TaskQueueService mockTaskQueueService;
+  @MockBean private UserService mockUserService;
 
   @TestConfiguration
-  @Import({FakeClockConfiguration.class, OfflineBillingController.class})
-  @MockBean({
-    InitialCreditsBatchUpdateService.class,
-    TaskQueueService.class,
-    UserService.class,
-    GoogleProjectPerCostDao.class
+  @Import({
+    FakeClockConfiguration.class,
+    OfflineBillingController.class,
+    Stopwatch.class,
   })
   static class Configuration {}
 
@@ -64,7 +64,7 @@ public class OfflineBillingControllerTest {
     freeTierForAllWorkspace.put("2", 0.4);
     freeTierForAllWorkspace.put("3", 1d);
     freeTierForAllWorkspace.put("4", 0.34);
-    when(mockFreeTierBillingUpdateService.getFreeTierWorkspaceCostsFromBQ())
+    when(mockInitialCreditsBatchUpdateService.getFreeTierWorkspaceCostsFromBQ())
         .thenReturn(freeTierForAllWorkspace);
   }
 }


### PR DESCRIPTION
This shows that it's the RWB clearing and insertion taking up the majority of the time, at least on Local:
```
[Thu Mar 13 11:36:24 EDT 2025] INFO: org.pmiops.workbench.api.OfflineBillingController checkInitialCreditsUsage - Checking initial credits usage for all workspaces
[Thu Mar 13 11:36:27 EDT 2025] INFO: org.pmiops.workbench.api.OfflineBillingController checkInitialCreditsUsage - checkInitialCreditsUsage: Retrieved 41286 workspace cost entries from BigQuery in 3s 175ms
[Thu Mar 13 11:36:49 EDT 2025] INFO: org.pmiops.workbench.api.OfflineBillingController checkInitialCreditsUsage - checkInitialCreditsUsage: cleared googleproject_cost table in 22s 411ms
[Thu Mar 13 11:37:10 EDT 2025] INFO: org.pmiops.workbench.api.OfflineBillingController checkInitialCreditsUsage - checkInitialCreditsUsage: Inserted all workspace costs to googleproject_cost table in 20s 996ms
```
It would be interesting to see this breakdown in other environments, where the runtime can sometimes exceed 500s, worryingly close to the 600s limit.


---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
