### PR TITLE
[risk=low][RW-13727] Standardize usage of "lenient" SA clients for Leo and Rawls

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/firecloud/FireCloudServiceImpl.java
@@ -90,6 +90,7 @@ public class FireCloudServiceImpl implements FireCloudService {
       fcEndUserWorkspacesApiProvider;
   private final Provider<WorkspacesApi> endUserLenientTimeoutWorkspacesApiProvider;
   private final Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider;
+  private final Provider<WorkspacesApi> serviceAccountLenientTimeoutWorkspaceApiProvider;
 
   // old Terms of Service endpoints, before RW-11416
   @Deprecated
@@ -150,6 +151,8 @@ public class FireCloudServiceImpl implements FireCloudService {
           Provider<WorkspacesApi> endUserLenientTimeoutWorkspacesApiProvider,
       @Qualifier(RawlsConfig.SERVICE_ACCOUNT_WORKSPACE_API)
           Provider<WorkspacesApi> serviceAccountWorkspaceApiProvider,
+      @Qualifier(RawlsConfig.SERVICE_ACCOUNT_LENIENT_TIMEOUT_WORKSPACE_API)
+          Provider<WorkspacesApi> serviceAccountLenientTimeoutWorkspaceApiProvider,
       Provider<StatusApi> statusApiProvider,
       @Qualifier(FireCloudConfig.END_USER_STATIC_NOTEBOOKS_API)
           Provider<StaticNotebooksApi> endUserStaticNotebooksApiProvider,
@@ -179,6 +182,8 @@ public class FireCloudServiceImpl implements FireCloudService {
     this.fcEndUserWorkspacesApiProvider = fcEndUserWorkspacesApiProvider;
     this.endUserLenientTimeoutWorkspacesApiProvider = endUserLenientTimeoutWorkspacesApiProvider;
     this.serviceAccountWorkspaceApiProvider = serviceAccountWorkspaceApiProvider;
+    this.serviceAccountLenientTimeoutWorkspaceApiProvider =
+        serviceAccountLenientTimeoutWorkspaceApiProvider;
     this.statusApiProvider = statusApiProvider;
     this.endUserStaticNotebooksApiProvider = endUserStaticNotebooksApiProvider;
     this.requestScopedGroupCacheProvider = requestScopedGroupCacheProvider;
@@ -479,13 +484,7 @@ public class FireCloudServiceImpl implements FireCloudService {
 
   @Override
   public List<RawlsWorkspaceListResponse> listWorkspacesAsService() {
-    WorkspacesApi workspacesApi = serviceAccountWorkspaceApiProvider.get();
-
-    // this call can be slow, so let a long timeout
-    workspacesApi
-        .getApiClient()
-        .setReadTimeout(configProvider.get().firecloud.lenientTimeoutInSeconds * 1000);
-
+    WorkspacesApi workspacesApi = serviceAccountLenientTimeoutWorkspaceApiProvider.get();
     return rawlsRetryHandler.run(
         context -> workspacesApi.listWorkspaces(FIRECLOUD_WORKSPACE_REQUIRED_FIELDS));
   }

--- a/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/rawls/RawlsConfig.java
@@ -32,7 +32,11 @@ public class RawlsConfig {
   public static final String END_USER_LENIENT_TIMEOUT_API_CLIENT =
       "rawlsEndUserLenientTimeoutApiClient";
   public static final String SERVICE_ACCOUNT_API_CLIENT = "rawlsServiceAccountApiClient";
-  public static final String SERVICE_ACCOUNT_WORKSPACE_API = "rawlsWorkspaceAclsApi";
+  public static final String SERVICE_ACCOUNT_LENIENT_TIMEOUT_API_CLIENT =
+      "rawlsServiceAccountLenientTimeoutApiClient";
+  public static final String SERVICE_ACCOUNT_WORKSPACE_API = "rawlsServiceAccountWorkspacesApi";
+  public static final String SERVICE_ACCOUNT_LENIENT_TIMEOUT_WORKSPACE_API =
+      "rawlsServiceAccountLenientTimeoutWorkspacesApi";
   public static final String END_USER_WORKSPACE_API = "rawlsWorkspacesApi";
   public static final String END_USER_LENIENT_TIMEOUT_WORKSPACE_API =
       "rawlsLenientTimeoutWorkspacesApi";
@@ -72,6 +76,20 @@ public class RawlsConfig {
     return apiClient;
   }
 
+  @Bean(name = SERVICE_ACCOUNT_LENIENT_TIMEOUT_API_CLIENT)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public ApiClient allOfUsLenientTimeoutApiClient(
+      RawlsApiClientFactory factory, WorkbenchConfig config) {
+    ApiClient apiClient = factory.newRawlsApiClient();
+    try {
+      apiClient.setAccessToken(ServiceAccounts.getScopedServiceAccessToken(BILLING_SCOPES));
+      apiClient.setReadTimeout(config.firecloud.lenientTimeoutInSeconds * 1000);
+    } catch (IOException e) {
+      throw new ServerErrorException(e);
+    }
+    return apiClient;
+  }
+
   @Bean(name = END_USER_WORKSPACE_API)
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public WorkspacesApi workspacesApi(@Qualifier(END_USER_API_CLIENT) ApiClient apiClient) {
@@ -93,6 +111,15 @@ public class RawlsConfig {
   @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
   public WorkspacesApi workspacesApiAcls(
       @Qualifier(SERVICE_ACCOUNT_API_CLIENT) ApiClient apiClient) {
+    WorkspacesApi api = new WorkspacesApi();
+    api.setApiClient(apiClient);
+    return api;
+  }
+
+  @Bean(name = SERVICE_ACCOUNT_LENIENT_TIMEOUT_WORKSPACE_API)
+  @RequestScope(proxyMode = ScopedProxyMode.DEFAULT)
+  public WorkspacesApi workspacesLenientTimeoutApiAcls(
+      @Qualifier(SERVICE_ACCOUNT_LENIENT_TIMEOUT_API_CLIENT) ApiClient apiClient) {
     WorkspacesApi api = new WorkspacesApi();
     api.setApiClient(apiClient);
     return api;


### PR DESCRIPTION
Continuing the work of #9153, improve the reliability of deleteUnsharedWorkspaceEnvironments by converting more calls to Lenient Timeouts.  We're seeing a lot of timeouts of listRuntimesByProjectAsService() in particular, on Test.

Standardize the usage of these lenient timeouts by adding Lenient Timeout providers.

Tested locally by exercising each of these updated calls, and also interacting with Local UI
* FireCloudService.listWorkspacesAsService() - deleteUnsharedWorkspaceEnvironments
* LeonardoApiClientImpl.listRuntimesAsService() - deleteOldRuntimes
* LeonardoApiClientImpl.listRuntimesByProjectAsService() - deleteUnsharedWorkspaceEnvironments
* LeonardoApiClientImpl.listDisksAsService() - checkPersistentDisks
* LeonardoApiClientImpl.listDisksByProjectAsService() - deleteUnsharedWorkspaceEnvironments
* LeonardoApiClientImpl.listAppsInProjectAsService() - deleteUnsharedWorkspaceEnvironments



---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
