### PR TITLE
[risk=low][RW-13727] Only retrieve the namespaces - don't need the whole DbWorkspace

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -116,6 +116,13 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
       @Param("initialCreditAccountNames") List<String> initialCreditAccountNames,
       @Param("creators") Set<DbUser> creators);
 
+  @Query(
+      "SELECT w.workspaceNamespace "
+          + "FROM DbWorkspace w "
+          + "WHERE w.firecloudUuid in (:firecloudUuids) "
+          + "AND w.activeStatus = 0") // active
+  List<String> findNamespacesByActiveStatusAndFirecloudUuidIn(Collection<String> firecloudUuids);
+
   interface WorkspaceCostView {
     Long getWorkspaceId();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -214,14 +214,15 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             .toList();
 
     stopwatch.reset().start();
-    List<DbWorkspace> rwbWorkspaces = workspaceDao.findActiveByFirecloudUuidIn(terraWorkspaceIds);
+    List<String> rwbNamespaces =
+        workspaceDao.findNamespacesByActiveStatusAndFirecloudUuidIn(terraWorkspaceIds);
     elapsed = stopwatch.stop().elapsed();
     log.info(
         String.format(
             "getActiveWorkspaceNamespacesAsService: Retrieved %d RWB workspaces from DB in %s",
-            rwbWorkspaces.size(), formatDurationPretty(elapsed)));
+            rwbNamespaces.size(), formatDurationPretty(elapsed)));
 
-    return rwbWorkspaces.stream().map(DbWorkspace::getWorkspaceNamespace).toList();
+    return rwbNamespaces;
   }
 
   @Override

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -304,19 +304,20 @@ public class WorkspaceDaoTest {
                 .setFirecloudUuid("456")
                 .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE));
 
-    DbWorkspace unmatchedUuid =
-        workspaceDao.save(
-            new DbWorkspace()
-                .setWorkspaceNamespace("nope")
-                .setFirecloudUuid("789")
-                .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE));
+    // these two won't match
 
     DbWorkspace deleted =
         workspaceDao.save(
             new DbWorkspace()
-                .setWorkspaceNamespace("oh no")
-                .setFirecloudUuid("000")
+                .setWorkspaceNamespace("gone")
+                .setFirecloudUuid("bye")
                 .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED));
+
+    workspaceDao.save(
+        new DbWorkspace()
+            .setWorkspaceNamespace("don't want it")
+            .setFirecloudUuid("not searching for this one")
+            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE));
 
     List<String> requestedUuids =
         List.of(ws1.getFirecloudUuid(), ws2.getFirecloudUuid(), deleted.getFirecloudUuid());


### PR DESCRIPTION
According to the logs of the first successful deleteUnsharedWorkspaceEnvironments run on Prod, we're pushing awfully close against the 10-min deadline:
```
Retrieved 19045 RWB workspaces from DB in 7m 45s 750ms
```

Update the DB query to retrieve only what we need - the namespaces.  Running this branch on Local (with only 11 DB rows returned) shows a significant speedup from main (3 runs each): [58ms, 56ms, 46ms] vs. [234ms, 133ms, 115ms]

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
