### PR TITLE
[risk=low][RW-14690] Audit current tier members only for project membership

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -627,7 +627,9 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-test'
     testImplementation 'org.springframework.boot:spring-boot-test-autoconfigure'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation ('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'com.vaadin.external.google', module: 'android-json'
+    }
 }
 
 tasks.compileJava {

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -29,7 +29,8 @@ public class OfflineUserController implements OfflineUserApiDelegate {
    */
   @Override
   public ResponseEntity<Void> bulkAuditProjectAccess() {
-    taskQueueService.groupAndPushAuditProjectsTasks(userService.getAllUserIds());
+    taskQueueService.groupAndPushAuditProjectsTasks(
+        userService.getAllUserIdsWithCurrentTierAccess());
     return ResponseEntity.noContent().build();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -70,7 +70,7 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   Set<DbUser> findUsersByUsernameInAndDisabledFalse(List<String> usernames);
 
   @Query(
-      "SELECT dbUser.userId FROM DbUser dbUser "
+      "SELECT DISTINCT dbUser.userId FROM DbUser dbUser "
           + "JOIN DbUserAccessTier uat ON uat.user.userId = dbUser.userId "
           + "WHERE uat.tierAccessStatus = 1 ") // TierAccessStatus.ENABLED
   List<Long> findUserIdsWithCurrentTierAccess();

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -41,9 +41,6 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   @Query("SELECT user FROM DbUser user")
   List<DbUser> findUsers();
 
-  @Query("SELECT user FROM DbUser user WHERE user.disabled = FALSE")
-  List<DbUser> findUsersExcludingDisabled();
-
   @Query(
       "SELECT user FROM DbUser user JOIN FETCH user.userInitialCreditsExpiration uice WHERE uice.expirationCleanupTime IS NULL")
   List<DbUser> findUsersWithActiveInitialCredits();
@@ -71,6 +68,12 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
       @Param("term") String term, Sort sort, @Param("shortName") String accessTierShortName);
 
   Set<DbUser> findUsersByUsernameInAndDisabledFalse(List<String> usernames);
+
+  @Query(
+      "SELECT dbUser.userId FROM DbUser dbUser "
+          + "JOIN DbUserAccessTier uat ON uat.user.userId = dbUser.userId "
+          + "WHERE uat.tierAccessStatus = 1 ") // TierAccessStatus.ENABLED
+  List<Long> findUserIdsWithCurrentTierAccess();
 
   @Query(
       "SELECT u FROM DbUser u "

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -89,9 +89,9 @@ public interface UserService {
 
   List<DbUser> getAllUsers();
 
-  List<DbUser> getAllUsersWithActiveInitialCredits();
-
   List<Long> getAllUserIdsWithCurrentTierAccess();
+
+  List<DbUser> getAllUsersWithActiveInitialCredits();
 
   /**
    * Find users whose name or username match the supplied search terms and who have the appropriate

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -89,9 +89,9 @@ public interface UserService {
 
   List<DbUser> getAllUsers();
 
-  List<DbUser> getAllUsersExcludingDisabled();
-
   List<DbUser> getAllUsersWithActiveInitialCredits();
+
+  List<Long> getAllUserIdsWithCurrentTierAccess();
 
   /**
    * Find users whose name or username match the supplied search terms and who have the appropriate

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -498,13 +498,13 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public List<DbUser> getAllUsersExcludingDisabled() {
-    return userDao.findUsersExcludingDisabled();
+  public List<DbUser> getAllUsersWithActiveInitialCredits() {
+    return userDao.findUsersWithActiveInitialCredits();
   }
 
   @Override
-  public List<DbUser> getAllUsersWithActiveInitialCredits() {
-    return userDao.findUsersWithActiveInitialCredits();
+  public List<Long> getAllUserIdsWithCurrentTierAccess() {
+    return userDao.findUserIdsWithCurrentTierAccess();
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -498,13 +498,13 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public List<DbUser> getAllUsersWithActiveInitialCredits() {
-    return userDao.findUsersWithActiveInitialCredits();
+  public List<Long> getAllUserIdsWithCurrentTierAccess() {
+    return userDao.findUserIdsWithCurrentTierAccess();
   }
 
   @Override
-  public List<Long> getAllUserIdsWithCurrentTierAccess() {
-    return userDao.findUserIdsWithCurrentTierAccess();
+  public List<DbUser> getAllUsersWithActiveInitialCredits() {
+    return userDao.findUsersWithActiveInitialCredits();
   }
 
   /**

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -18,7 +18,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
@@ -70,8 +69,7 @@ public class OfflineUserControllerTest {
   public void setUp() {
     incrementedUserId = 1L;
     List<DbUser> users = createUsers();
-    List<Long> userIds = users.stream().map(DbUser::getUserId).collect(Collectors.toList());
-    when(mockUserService.getAllUsersExcludingDisabled()).thenReturn(users);
+    List<Long> userIds = users.stream().map(DbUser::getUserId).toList();
     when(mockUserService.getAllUsers()).thenReturn(users);
     when(mockUserService.getAllUsersWithActiveInitialCredits()).thenReturn(users);
     when(mockUserService.getAllUserIds()).thenReturn(userIds);

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -70,9 +70,10 @@ public class OfflineUserControllerTest {
     incrementedUserId = 1L;
     List<DbUser> users = createUsers();
     List<Long> userIds = users.stream().map(DbUser::getUserId).toList();
+    when(mockUserService.getAllUserIds()).thenReturn(userIds);
+    when(mockUserService.getAllUserIdsWithCurrentTierAccess()).thenReturn(userIds);
     when(mockUserService.getAllUsers()).thenReturn(users);
     when(mockUserService.getAllUsersWithActiveInitialCredits()).thenReturn(users);
-    when(mockUserService.getAllUserIds()).thenReturn(userIds);
     when(mockCloudTasksClient.createTask(anyString(), any(Task.class)))
         .thenReturn(Task.newBuilder().setName("name").build());
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -657,7 +657,8 @@ public class UserServiceTest {
     DbUser exRtUser = userDao.save(new DbUser().setUserId(2).setUsername("ex-rt"));
     DbUser ctUser = userDao.save(new DbUser().setUserId(3).setUsername("ct"));
     DbUser exCtUser = userDao.save(new DbUser().setUserId(4).setUsername("ex-ct"));
-    DbUser noTierUser = userDao.save(new DbUser().setUserId(5).setUsername("none"));
+    // user with no tier access
+    userDao.save(new DbUser().setUserId(5).setUsername("none"));
 
     // add "rt" and "ex-rt" to the Registered Tier, but then remove ex-rt
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHORT_NAME;
+import static org.pmiops.workbench.utils.TestMockFactory.createControlledTier;
 import static org.pmiops.workbench.utils.TestMockFactory.createRegisteredTier;
 
 import com.google.api.services.directory.model.User;
@@ -29,6 +30,7 @@ import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.FakeJpaDateTimeConfiguration;
 import org.pmiops.workbench.access.AccessModuleService;
 import org.pmiops.workbench.access.AccessModuleServiceImpl;
+import org.pmiops.workbench.access.AccessTierService;
 import org.pmiops.workbench.access.AccessTierServiceImpl;
 import org.pmiops.workbench.access.UserAccessModuleMapperImpl;
 import org.pmiops.workbench.access.VwbAccessService;
@@ -38,6 +40,7 @@ import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.model.DbAccessModule;
 import org.pmiops.workbench.db.model.DbAccessModule.DbAccessModuleName;
+import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserCodeOfConductAgreement;
 import org.pmiops.workbench.db.model.DbUserInitialCreditsExpiration;
@@ -80,9 +83,13 @@ public class UserServiceTest {
   // An arbitrary timestamp to use as the anchor time for access module test cases.
   private static final Instant START_INSTANT = FakeClockConfiguration.NOW.toInstant();
   private static final int CLOCK_INCREMENT_MILLIS = 1000;
+
   private static DbUser providedDbUser;
   private static WorkbenchConfig providedWorkbenchConfig;
   private static List<DbAccessModule> accessModules;
+  private static DbAccessTier registeredTier;
+  private static DbAccessTier controlledTier;
+
   @MockBean private DirectoryService mockDirectoryService;
   @MockBean private FireCloudService mockFireCloudService;
   @MockBean private InstitutionService mockInstitutionService;
@@ -90,7 +97,9 @@ public class UserServiceTest {
 
   @Autowired private AccessModuleDao accessModuleDao;
   @Autowired private AccessTierDao accessTierDao;
+  @Autowired private AccessTierService accessTierService;
   @Autowired private FakeClock fakeClock;
+  @Autowired private InstitutionDao institutionDao;
   @Autowired private UserAccessModuleDao userAccessModuleDao;
   @Autowired private UserDao userDao;
   @Autowired private UserService userService;
@@ -98,7 +107,6 @@ public class UserServiceTest {
 
   // use a SpyBean when we need the full service for some tests and mocks for others
   @SpyBean private AccessModuleService accessModuleService;
-  @Autowired private InstitutionDao institutionDao;
 
   @Import({
     FakeClockConfiguration.class,
@@ -167,7 +175,8 @@ public class UserServiceTest {
     providedDbUser = user;
 
     // key UserService logic depends on the existence of the Registered Tier
-    accessTierDao.save(createRegisteredTier());
+    registeredTier = accessTierDao.save(createRegisteredTier());
+    controlledTier = accessTierDao.save(createControlledTier());
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();
@@ -644,11 +653,25 @@ public class UserServiceTest {
 
   @Test
   public void testGetAllUserIdsWithCurrentTierAccess() {
-
     DbUser rtUser = userDao.save(new DbUser().setUserId(1).setUsername("rt"));
-    DbUser ctUser = userDao.save(new DbUser().setUserId(2).setUsername("ct"));
-    DbUser noTierUser = userDao.save(new DbUser().setUserId(2).setUsername("none"));
+    DbUser exRtUser = userDao.save(new DbUser().setUserId(2).setUsername("ex-rt"));
+    DbUser ctUser = userDao.save(new DbUser().setUserId(3).setUsername("ct"));
+    DbUser exCtUser = userDao.save(new DbUser().setUserId(4).setUsername("ex-ct"));
+    DbUser noTierUser = userDao.save(new DbUser().setUserId(5).setUsername("none"));
 
+    // add "rt" and "ex-rt" to the Registered Tier, but then remove ex-rt
+
+    accessTierService.addUserToTier(rtUser, registeredTier);
+    accessTierService.addUserToTier(exRtUser, registeredTier);
+    accessTierService.removeUserFromTier(exRtUser, registeredTier);
+
+    // add "ct" and "ex-ct" to the Controlled Tier, but then remove ex-ct
+
+    accessTierService.addUserToTier(ctUser, controlledTier);
+    accessTierService.addUserToTier(exCtUser, controlledTier);
+    accessTierService.removeUserFromTier(exCtUser, controlledTier);
+
+    // former tier members are excluded
     assertThat(userService.getAllUserIdsWithCurrentTierAccess())
         .containsExactly(rtUser.getUserId(), ctUser.getUserId());
   }

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -622,9 +622,10 @@ public class UserServiceTest {
     Timestamp tomorrow = Timestamp.from(START_INSTANT.plus(1, ChronoUnit.DAYS));
 
     DbUser noCreditsUser =
-        PresetData.createDbUser()
-            .setUsername("nocredits@researchallofus.org")
-            .setUserInitialCreditsExpiration(null);
+        userDao.save(
+            PresetData.createDbUser()
+                .setUsername("nocredits@researchallofus.org")
+                .setUserInitialCreditsExpiration(null));
     DbUser notExpiredUser =
         createUserWithSpecifiedInitialCreditsExpiration(
             "notexpired@researchallofus.org", today, tomorrow, null);
@@ -639,6 +640,17 @@ public class UserServiceTest {
     assertThat(activeUsers).containsAtLeast(notExpiredUser, expiredButNotCleanedUser);
     assertThat(activeUsers).doesNotContain(noCreditsUser);
     assertThat(activeUsers).doesNotContain(expiredAndCleanedUser);
+  }
+
+  @Test
+  public void testGetAllUserIdsWithCurrentTierAccess() {
+
+    DbUser rtUser = userDao.save(new DbUser().setUserId(1).setUsername("rt"));
+    DbUser ctUser = userDao.save(new DbUser().setUserId(2).setUsername("ct"));
+    DbUser noTierUser = userDao.save(new DbUser().setUserId(2).setUsername("none"));
+
+    assertThat(userService.getAllUserIdsWithCurrentTierAccess())
+        .containsExactly(rtUser.getUserId(), ctUser.getUserId());
   }
 
   private DbUser createUserWithSpecifiedInitialCreditsExpiration(


### PR DESCRIPTION
The auditProjectQueue often fails at the user impersonation step, so we are unable to query for project membership for certain users.  Limit the scope of these checks to users who currently have access to CDR resources, to cut down on noise.

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
