### PR TITLE
[risk=low][RW-14791] Reduce checkInitialCreditsExpiration query to ID only and log timing

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -69,12 +69,12 @@ public class OfflineUserController implements OfflineUserApiDelegate {
             userIds.size(), formatDurationPretty(elapsed)));
 
     stopwatch.reset().start();
-    List<String> queueIds = taskQueueService.groupAndPushCheckInitialCreditExpirationTasks(userIds);
+    List<String> taskIds = taskQueueService.groupAndPushCheckInitialCreditExpirationTasks(userIds);
     elapsed = stopwatch.stop().elapsed();
     logger.info(
         String.format(
             "checkInitialCreditsExpiration: Grouped and pushed %d user IDs into %d tasks in %s",
-            userIds.size(), queueIds.size(), formatDurationPretty(elapsed)));
+            userIds.size(), taskIds.size(), formatDurationPretty(elapsed)));
 
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineUserController.java
@@ -1,8 +1,15 @@
 package org.pmiops.workbench.api;
 
+import static org.pmiops.workbench.utils.LogFormatters.formatDurationPretty;
+
+import com.google.common.base.Stopwatch;
+import jakarta.inject.Provider;
+import java.time.Duration;
+import java.util.List;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.db.dao.UserService;
-import org.pmiops.workbench.db.model.DbUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,13 +17,20 @@ import org.springframework.web.bind.annotation.RestController;
 /** Handles offline / cron-based API requests related to user management. */
 @RestController
 public class OfflineUserController implements OfflineUserApiDelegate {
-  private final UserService userService;
+  private final Logger logger = LoggerFactory.getLogger(OfflineUserController.class);
+
+  private final Provider<Stopwatch> stopwatchProvider;
   private final TaskQueueService taskQueueService;
+  private final UserService userService;
 
   @Autowired
-  public OfflineUserController(UserService userService, TaskQueueService taskQueueService) {
-    this.userService = userService;
+  public OfflineUserController(
+      Provider<Stopwatch> stopwatchProvider,
+      TaskQueueService taskQueueService,
+      UserService userService) {
+    this.stopwatchProvider = stopwatchProvider;
     this.taskQueueService = taskQueueService;
+    this.userService = userService;
   }
 
   /**
@@ -43,9 +57,25 @@ public class OfflineUserController implements OfflineUserApiDelegate {
     return ResponseEntity.noContent().build();
   }
 
+  @Override
   public ResponseEntity<Void> checkInitialCreditsExpiration() {
-    taskQueueService.groupAndPushCheckInitialCreditExpirationTasks(
-        userService.getAllUsersWithActiveInitialCredits().stream().map(DbUser::getUserId).toList());
+    // temp performance logging
+    Stopwatch stopwatch = stopwatchProvider.get().start();
+    List<Long> userIds = userService.getAllUserIdsWithActiveInitialCredits();
+    Duration elapsed = stopwatch.stop().elapsed();
+    logger.info(
+        String.format(
+            "checkInitialCreditsExpiration: Retrieved %d user IDs from DB in %s",
+            userIds.size(), formatDurationPretty(elapsed)));
+
+    stopwatch.reset().start();
+    List<String> queueIds = taskQueueService.groupAndPushCheckInitialCreditExpirationTasks(userIds);
+    elapsed = stopwatch.stop().elapsed();
+    logger.info(
+        String.format(
+            "checkInitialCreditsExpiration: Grouped and pushed %d user IDs into %d tasks in %s",
+            userIds.size(), queueIds.size(), formatDurationPretty(elapsed)));
+
     return ResponseEntity.noContent().build();
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -230,9 +230,9 @@ public class TaskQueueService {
             .liveCostByCreator(liveCostByCreator));
   }
 
-  public void groupAndPushCheckInitialCreditExpirationTasks(List<Long> userIds) {
+  public List<String> groupAndPushCheckInitialCreditExpirationTasks(List<Long> userIds) {
     WorkbenchConfig workbenchConfig = workbenchConfigProvider.get();
-    createAndPushAll(
+    return createAndPushAll(
         userIds,
         workbenchConfig.offlineBatch.usersPerCheckInitialCreditsExpirationTask,
         INITIAL_CREDITS_EXPIRATION);

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -42,8 +42,10 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
   List<DbUser> findUsers();
 
   @Query(
-      "SELECT user FROM DbUser user JOIN FETCH user.userInitialCreditsExpiration uice WHERE uice.expirationCleanupTime IS NULL")
-  List<DbUser> findUsersWithActiveInitialCredits();
+      "SELECT user.userId FROM DbUser user "
+          + "JOIN DbUserInitialCreditsExpiration exp ON exp.user.userId = user.userId "
+          + "WHERE exp.expirationCleanupTime IS NULL")
+  List<Long> findUserIdsWithActiveInitialCredits();
 
   /** Returns the user with their authorities loaded. */
   @Query("SELECT user FROM DbUser user LEFT JOIN FETCH user.authorities WHERE user.userId = :id")
@@ -51,7 +53,9 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
   /** Returns the user with the page visits and authorities loaded. */
   @Query(
-      "SELECT user FROM DbUser user LEFT JOIN FETCH user.authorities LEFT JOIN FETCH user.pageVisits WHERE user.userId = :id")
+      "SELECT user FROM DbUser user "
+          + "LEFT JOIN FETCH user.authorities LEFT JOIN FETCH user.pageVisits "
+          + "WHERE user.userId = :id")
   DbUser findUserWithAuthoritiesAndPageVisits(@Param("id") long id);
 
   // Find users matching the requested access tier and a (name or username) search term.

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -91,7 +91,7 @@ public interface UserService {
 
   List<Long> getAllUserIdsWithCurrentTierAccess();
 
-  List<DbUser> getAllUsersWithActiveInitialCredits();
+  List<Long> getAllUserIdsWithActiveInitialCredits();
 
   /**
    * Find users whose name or username match the supplied search terms and who have the appropriate

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -503,8 +503,8 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public List<DbUser> getAllUsersWithActiveInitialCredits() {
-    return userDao.findUsersWithActiveInitialCredits();
+  public List<Long> getAllUserIdsWithActiveInitialCredits() {
+    return userDao.findUserIdsWithActiveInitialCredits();
   }
 
   /**

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -71,9 +71,9 @@ public class OfflineUserControllerTest {
     List<DbUser> users = createUsers();
     List<Long> userIds = users.stream().map(DbUser::getUserId).toList();
     when(mockUserService.getAllUserIds()).thenReturn(userIds);
+    when(mockUserService.getAllUserIdsWithActiveInitialCredits()).thenReturn(userIds);
     when(mockUserService.getAllUserIdsWithCurrentTierAccess()).thenReturn(userIds);
     when(mockUserService.getAllUsers()).thenReturn(users);
-    when(mockUserService.getAllUsersWithActiveInitialCredits()).thenReturn(users);
     when(mockCloudTasksClient.createTask(anyString(), any(Task.class)))
         .thenReturn(Task.newBuilder().setName("name").build());
 

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineUserControllerTest.java
@@ -11,6 +11,7 @@ import static org.pmiops.workbench.cloudtasks.TaskQueueService.AUDIT_PROJECTS;
 
 import com.google.cloud.tasks.v2.CloudTasksClient;
 import com.google.cloud.tasks.v2.Task;
+import com.google.common.base.Stopwatch;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
@@ -52,8 +53,9 @@ public class OfflineUserControllerTest {
   @Import({
     FakeClockConfiguration.class,
     OfflineUserController.class,
+    Stopwatch.class,
     TaskQueueService.class,
-    WorkbenchLocationConfigService.class
+    WorkbenchLocationConfigService.class,
   })
   @MockBean({CloudTasksClient.class, UserService.class})
   static class Configuration {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -625,7 +625,7 @@ public class UserServiceTest {
   }
 
   @Test
-  public void testGetAllUsersWithActiveInitialCredits() {
+  public void testGetAllUserIdsWithActiveInitialCredits() {
     Timestamp today = Timestamp.from(START_INSTANT);
     Timestamp yesterday = Timestamp.from(START_INSTANT.minus(1, ChronoUnit.DAYS));
     Timestamp tomorrow = Timestamp.from(START_INSTANT.plus(1, ChronoUnit.DAYS));
@@ -645,10 +645,11 @@ public class UserServiceTest {
         createUserWithSpecifiedInitialCreditsExpiration(
             "expiredandcleaned@researchallofus.org", yesterday, today, today);
 
-    List<DbUser> activeUsers = userService.getAllUsersWithActiveInitialCredits();
-    assertThat(activeUsers).containsAtLeast(notExpiredUser, expiredButNotCleanedUser);
-    assertThat(activeUsers).doesNotContain(noCreditsUser);
-    assertThat(activeUsers).doesNotContain(expiredAndCleanedUser);
+    List<Long> activeUsers = userService.getAllUserIdsWithActiveInitialCredits();
+    assertThat(activeUsers)
+        .containsAtLeast(notExpiredUser.getUserId(), expiredButNotCleanedUser.getUserId());
+    assertThat(activeUsers).doesNotContain(noCreditsUser.getUserId());
+    assertThat(activeUsers).doesNotContain(expiredAndCleanedUser.getUserId());
   }
 
   @Test


### PR DESCRIPTION
The checkInitialCreditsExpiration cron is consistently timing out in Prod, even though all it's doing is retrieving a list of users and launching Task Queues to do the actual work.

Add logging timing to help figure out what's going on, and also reduce the DB query to retrieve only what we need - the user IDs.

Tested locally.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
