### PR TITLE
[RW-14861][risk=no] Only show configuration panel after attempting to load existing disk

### DIFF
--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -899,6 +899,7 @@ describe('RuntimeConfigurationPanel', () => {
     runtimeDiskStore.set({
       workspaceNamespace: workspace.namespace,
       gcePersistentDisk: null,
+      gcePersistentDiskLoaded: true,
     });
 
     // Add this in your beforeEach block where you set up other mocks
@@ -964,7 +965,7 @@ describe('RuntimeConfigurationPanel', () => {
         gcePersistentDisk: runtimeDiskStore.get().gcePersistentDisk,
         isLoaded: true,
       }));
-    
+
     // Use rerender instead of creating a new component
     rerender(
       <MemoryRouter>

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -656,6 +656,7 @@ describe('RuntimeConfigurationPanel', () => {
   const runtimeDiskStoreStub = {
     workspaceNamespace: workspaceStubs[0].namespace,
     gcePersistentDisk: null,
+    gcePersistentDiskLoaded: true,
   };
   runtimeDiskStore.set(runtimeDiskStoreStub);
 
@@ -900,6 +901,17 @@ describe('RuntimeConfigurationPanel', () => {
       gcePersistentDisk: null,
     });
 
+    // Add this in your beforeEach block where you set up other mocks
+    jest
+      .spyOn(runtimeHooks, 'useRuntimeAndDiskStores')
+      .mockImplementation(() => ({
+        runtimeLoaded: true,
+        gcePersistentDiskLoaded: true,
+        runtime: runtimeStore.get().runtime,
+        gcePersistentDisk: runtimeDiskStore.get().gcePersistentDisk,
+        isLoaded: true,
+      }));
+
     mockSetRuntimeRequest = jest.fn();
   });
 
@@ -923,10 +935,18 @@ describe('RuntimeConfigurationPanel', () => {
   };
 
   it('should show loading spinner while loading', async () => {
-    // simulate not done loading
-    runtimeStore.set({ ...runtimeStore.get(), runtimeLoaded: false });
+    // Override the mock to simulate loading state
+    jest
+      .spyOn(runtimeHooks, 'useRuntimeAndDiskStores')
+      .mockImplementation(() => ({
+        runtimeLoaded: false,
+        gcePersistentDiskLoaded: false,
+        runtime: null,
+        gcePersistentDisk: null,
+        isLoaded: false,
+      }));
 
-    const { container } = component();
+    const { container, rerender } = component();
     expect(container).toBeInTheDocument();
 
     await waitFor(() =>
@@ -934,7 +954,23 @@ describe('RuntimeConfigurationPanel', () => {
       expect(screen.queryByLabelText('Please Wait')).toBeInTheDocument()
     );
 
-    runtimeStore.set({ ...runtimeStore.get(), runtimeLoaded: true });
+    // Now mock it as loaded
+    jest
+      .spyOn(runtimeHooks, 'useRuntimeAndDiskStores')
+      .mockImplementation(() => ({
+        runtimeLoaded: true,
+        gcePersistentDiskLoaded: true,
+        runtime: runtimeStore.get().runtime,
+        gcePersistentDisk: runtimeDiskStore.get().gcePersistentDisk,
+        isLoaded: true,
+      }));
+    
+    // Use rerender instead of creating a new component
+    rerender(
+      <MemoryRouter>
+        <RuntimeConfigurationPanel {...defaultProps} />
+      </MemoryRouter>
+    );
 
     await waitFor(() =>
       expect(screen.queryByLabelText('Please Wait')).not.toBeInTheDocument()

--- a/ui/src/app/components/runtime-configuration-panel.spec.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.spec.tsx
@@ -902,7 +902,6 @@ describe('RuntimeConfigurationPanel', () => {
       gcePersistentDiskLoaded: true,
     });
 
-    // Add this in your beforeEach block where you set up other mocks
     jest
       .spyOn(runtimeHooks, 'useRuntimeAndDiskStores')
       .mockImplementation(() => ({

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -53,7 +53,6 @@ import {
 import {
   ProfileStore,
   runtimeDiskStore,
-  runtimeStore,
   serverConfigStore,
   useStore,
 } from 'app/utils/stores';

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -258,7 +258,7 @@ export const getErrorsAndWarnings = ({
   };
 };
 
-export const RuntimeConfigurationPanelContent = fp.flow(
+const RuntimeConfigurationPanelContent = fp.flow(
   withCdrVersions(),
   withCurrentWorkspace()
 )(

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -253,13 +253,7 @@ export const getErrorsAndWarnings = ({
   };
 };
 
-export interface RuntimeConfigurationPanelProps {
-  onClose?: () => void;
-  initialPanelContent?: PanelContent;
-  creatorInitialCreditsRemaining?: number;
-  profileState: ProfileStore;
-}
-export const RuntimeConfigurationPanel = fp.flow(
+export const RuntimeConfigurationPanelContents = fp.flow(
   withCdrVersions(),
   withCurrentWorkspace()
 )(
@@ -275,7 +269,8 @@ export const RuntimeConfigurationPanel = fp.flow(
     WithCdrVersions &
     WithCurrentWorkspace) => {
     const { runtimeLoaded } = useStore(runtimeStore);
-    const { gcePersistentDisk } = useStore(runtimeDiskStore);
+    const { gcePersistentDisk, gcePersistentDiskLoaded } =
+      useStore(runtimeDiskStore);
     const [runtimeStatus, setRuntimeStatusRequest] = useRuntimeStatus(
       namespace,
       googleProject
@@ -291,7 +286,7 @@ export const RuntimeConfigurationPanel = fp.flow(
     });
 
     // Prioritize the "pendingRuntime", if any. When an update is pending, we want
-    // to render the target runtime details, which  may not match the current runtime.
+    // to render the target runtime details, which may not match the current runtime.
     const existingAnalysisConfig = toAnalysisConfig(
       pendingRuntime || currentRuntime || ({} as Partial<Runtime>),
       gcePersistentDisk
@@ -389,7 +384,7 @@ export const RuntimeConfigurationPanel = fp.flow(
       }
     }
 
-    if (!runtimeLoaded) {
+    if (!runtimeLoaded || !gcePersistentDiskLoaded) {
       return <Spinner style={{ width: '100%', marginTop: '7.5rem' }} />;
     }
 
@@ -586,3 +581,28 @@ export const RuntimeConfigurationPanel = fp.flow(
     );
   }
 );
+
+export interface RuntimeConfigurationPanelProps {
+  onClose?: () => void;
+  initialPanelContent?: PanelContent;
+  creatorInitialCreditsRemaining?: number;
+  profileState: ProfileStore;
+}
+
+export const RuntimeConfigurationPanel = ({
+  profileState,
+  onClose = () => {},
+  initialPanelContent,
+  creatorInitialCreditsRemaining,
+}: RuntimeConfigurationPanelProps) => {
+  return (
+    <RuntimeConfigurationPanelContents
+      {...{
+        onClose,
+        profileState,
+        creatorInitialCreditsRemaining,
+        initialPanelContent,
+      }}
+    />
+  );
+};

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -257,6 +257,13 @@ export const getErrorsAndWarnings = ({
   };
 };
 
+export interface RuntimeConfigurationPanelProps {
+  onClose?: () => void;
+  initialPanelContent?: PanelContent;
+  creatorInitialCreditsRemaining?: number;
+  profileState: ProfileStore;
+}
+
 const RuntimeConfigurationPanelContent = fp.flow(
   withCdrVersions(),
   withCurrentWorkspace()
@@ -579,13 +586,6 @@ const RuntimeConfigurationPanelContent = fp.flow(
     );
   }
 );
-
-export interface RuntimeConfigurationPanelProps {
-  onClose?: () => void;
-  initialPanelContent?: PanelContent;
-  creatorInitialCreditsRemaining?: number;
-  profileState: ProfileStore;
-}
 
 export const RuntimeConfigurationPanel = ({
   profileState,

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -258,7 +258,7 @@ export const getErrorsAndWarnings = ({
   };
 };
 
-export const RuntimeConfigurationPanelContents = fp.flow(
+export const RuntimeConfigurationPanelContent = fp.flow(
   withCdrVersions(),
   withCurrentWorkspace()
 )(
@@ -603,7 +603,7 @@ export const RuntimeConfigurationPanel = ({
   }
 
   return (
-    <RuntimeConfigurationPanelContents
+    <RuntimeConfigurationPanelContent
       {...{
         onClose,
         profileState,

--- a/ui/src/app/components/runtime-configuration-panel.tsx
+++ b/ui/src/app/components/runtime-configuration-panel.tsx
@@ -595,6 +595,7 @@ export const RuntimeConfigurationPanel = ({
 }: RuntimeConfigurationPanelProps) => {
   const workspace = useCurrentWorkspace();
   const { namespace } = workspace;
+  // This initializes the runtime and disk stores, and isLoaded represents the runtime and disk being loaded.
   const { isLoaded } = useRuntimeAndDiskStores(namespace);
 
   if (!isLoaded) {

--- a/ui/src/app/pages/workspace/workspace-wrapper.tsx
+++ b/ui/src/app/pages/workspace/workspace-wrapper.tsx
@@ -148,6 +148,7 @@ const updateRuntimeStores = async ({
   runtimeDiskStore.set({
     workspaceNamespace,
     gcePersistentDisk: undefined,
+    gcePersistentDiskLoaded: false,
   });
   runtimeStore.set({
     workspaceNamespace,

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -250,6 +250,27 @@ export const connectReplaySubject = <T extends {}>(
 export const withCurrentWorkspace = () => {
   return connectBehaviorSubject(currentWorkspaceStore, 'workspace');
 };
+
+/**
+ * Hook that provides access to the current workspace data
+ * @returns The current workspace data from the currentWorkspaceStore
+ */
+export const useCurrentWorkspace = (): WorkspaceData => {
+  const [workspace, setWorkspace] = useState<WorkspaceData>(currentWorkspaceStore.getValue());
+  
+  useEffect(() => {
+    const subscription = currentWorkspaceStore.subscribe(value => {
+      setWorkspace(value);
+    });
+    
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+  
+  return workspace;
+};
+
 export interface WithCurrentWorkspace {
   workspace: WorkspaceData;
 }

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -256,18 +256,20 @@ export const withCurrentWorkspace = () => {
  * @returns The current workspace data from the currentWorkspaceStore
  */
 export const useCurrentWorkspace = (): WorkspaceData => {
-  const [workspace, setWorkspace] = useState<WorkspaceData>(currentWorkspaceStore.getValue());
-  
+  const [workspace, setWorkspace] = useState<WorkspaceData>(
+    currentWorkspaceStore.getValue()
+  );
+
   useEffect(() => {
-    const subscription = currentWorkspaceStore.subscribe(value => {
+    const subscription = currentWorkspaceStore.subscribe((value) => {
       setWorkspace(value);
     });
-    
+
     return () => {
       subscription.unsubscribe();
     };
   }, []);
-  
+
   return workspace;
 };
 

--- a/ui/src/app/utils/index.tsx
+++ b/ui/src/app/utils/index.tsx
@@ -251,6 +251,10 @@ export const withCurrentWorkspace = () => {
   return connectBehaviorSubject(currentWorkspaceStore, 'workspace');
 };
 
+export interface WithCurrentWorkspace {
+  workspace: WorkspaceData;
+}
+
 /**
  * Hook that provides access to the current workspace data
  * @returns The current workspace data from the currentWorkspaceStore
@@ -272,10 +276,6 @@ export const useCurrentWorkspace = (): WorkspaceData => {
 
   return workspace;
 };
-
-export interface WithCurrentWorkspace {
-  workspace: WorkspaceData;
-}
 
 // HOC that provides a 'cohort' prop with current Cohort
 export const withCurrentCohort = () => {

--- a/ui/src/app/utils/runtime-hooks.spec.tsx
+++ b/ui/src/app/utils/runtime-hooks.spec.tsx
@@ -75,7 +75,11 @@ describe(useCustomRuntime.name, () => {
 
   const setCurrentDisk = (d: Disk) => {
     disksApiStub.disk = d;
-    runtimeDiskStore.set({ ...runtimeDiskStore.get(), gcePersistentDisk: d });
+    runtimeDiskStore.set({
+      ...runtimeDiskStore.get(),
+      gcePersistentDisk: d,
+      gcePersistentDiskLoaded: true,
+    });
   };
 
   it('should update runtime when request includes updated runtime', async () => {

--- a/ui/src/app/utils/runtime-hooks.spec.tsx
+++ b/ui/src/app/utils/runtime-hooks.spec.tsx
@@ -28,10 +28,9 @@ import { mockUseStore } from 'testing/utils';
 
 import { LeoRuntimeInitializer } from './leo-runtime-initializer';
 import { DATAPROC_MIN_DISK_SIZE_GB } from './machines';
-import { useCustomRuntime, useRuntimeAndDiskStores } from './runtime-hooks';
+import { useCustomRuntime } from './runtime-hooks';
 import * as runtimeHooks from './runtime-hooks';
 import { runtimeDiskStore, runtimeStore } from './stores';
-import * as useStoreModule from './stores';
 
 describe(useCustomRuntime.name, () => {
   let disksApiStub: DisksApiStub;

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -446,7 +446,7 @@ export const withRuntimeStore = () => (WrappedComponent) => {
 /**
  * Hook that initializes the runtime and disk stores and returns their loading states.
  * Use this to show loading indicators while runtime and disk data are being fetched.
- * 
+ *
  * @param workspaceNamespace - The namespace of the workspace
  * @returns Object containing loading states for runtime and disk
  */
@@ -454,11 +454,12 @@ export const useRuntimeAndDiskStores = (workspaceNamespace: string) => {
   // Initialize runtime and disk stores
   useRuntime(workspaceNamespace);
   useDisk(workspaceNamespace);
-  
+
   // Get current loading states
   const { runtimeLoaded, runtime } = useStore(runtimeStore);
-  const { gcePersistentDiskLoaded, gcePersistentDisk } = useStore(runtimeDiskStore);
-  
+  const { gcePersistentDiskLoaded, gcePersistentDisk } =
+    useStore(runtimeDiskStore);
+
   return {
     runtimeLoaded,
     gcePersistentDiskLoaded,
@@ -466,6 +467,6 @@ export const useRuntimeAndDiskStores = (workspaceNamespace: string) => {
     runtime,
     gcePersistentDisk,
     // Helper to check if everything is loaded
-    isLoaded: runtimeLoaded && gcePersistentDiskLoaded
+    isLoaded: runtimeLoaded && gcePersistentDiskLoaded,
   };
 };

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -442,3 +442,30 @@ export const withRuntimeStore = () => (WrappedComponent) => {
     return <WrappedComponent {...props} runtimeStore={value} />;
   };
 };
+
+/**
+ * Hook that initializes the runtime and disk stores and returns their loading states.
+ * Use this to show loading indicators while runtime and disk data are being fetched.
+ * 
+ * @param workspaceNamespace - The namespace of the workspace
+ * @returns Object containing loading states for runtime and disk
+ */
+export const useRuntimeAndDiskStores = (workspaceNamespace: string) => {
+  // Initialize runtime and disk stores
+  useRuntime(workspaceNamespace);
+  useDisk(workspaceNamespace);
+  
+  // Get current loading states
+  const { runtimeLoaded, runtime } = useStore(runtimeStore);
+  const { gcePersistentDiskLoaded, gcePersistentDisk } = useStore(runtimeDiskStore);
+  
+  return {
+    runtimeLoaded,
+    gcePersistentDiskLoaded,
+    // Also return the actual data for convenience
+    runtime,
+    gcePersistentDisk,
+    // Helper to check if everything is loaded
+    isLoaded: runtimeLoaded && gcePersistentDiskLoaded
+  };
+};

--- a/ui/src/app/utils/runtime-hooks.tsx
+++ b/ui/src/app/utils/runtime-hooks.tsx
@@ -119,6 +119,7 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
         runtimeDiskStore.set({
           workspaceNamespace: null,
           gcePersistentDisk: null,
+          gcePersistentDiskLoaded: false,
         }),
       async () => {
         let gcePersistentDisk: Disk = null;
@@ -139,6 +140,7 @@ export const useDisk = (currentWorkspaceNamespace: string) => {
           runtimeDiskStore.set({
             workspaceNamespace: currentWorkspaceNamespace,
             gcePersistentDisk,
+            gcePersistentDiskLoaded: true,
           });
         }
       }

--- a/ui/src/app/utils/runtime-utils.spec.tsx
+++ b/ui/src/app/utils/runtime-utils.spec.tsx
@@ -59,6 +59,7 @@ describe('runtime-utils', () => {
     runtimeDiskStore.set({
       workspaceNamespace,
       gcePersistentDisk: undefined,
+      gcePersistentDiskLoaded: true,
     });
     jest.useFakeTimers();
   });

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -203,11 +203,13 @@ export const runtimeStore = atom<RuntimeStore>({
 export interface RuntimeDiskStore {
   workspaceNamespace: string | null | undefined;
   gcePersistentDisk: Disk | null | undefined;
+  gcePersistentDiskLoaded: boolean;
 }
 
 export const runtimeDiskStore = atom<RuntimeDiskStore>({
   workspaceNamespace: undefined,
   gcePersistentDisk: undefined,
+  gcePersistentDiskLoaded: false,
 });
 
 export interface StackdriverErrorReporterStore {

--- a/ui/src/testing/utils.ts
+++ b/ui/src/testing/utils.ts
@@ -5,6 +5,9 @@ import {
   TerraJobStatus,
 } from 'generated/fetch';
 
+// For testing stores
+import * as useStoreModule from 'app/utils/stores';
+
 export function minus<T>(a1: T[], a2: T[]): T[] {
   return a1.filter((e) => !a2.includes(e));
 }
@@ -22,3 +25,30 @@ export const ALL_RUNTIME_STATUSES = Object.keys(RuntimeStatus)
   .concat([null, undefined]);
 
 export const ALL_GKE_APP_TYPES = Object.keys(AppType).map((k) => AppType[k]);
+
+/**
+ * Mock the useStore hook for testing with a mapping of stores to their mocked return values.
+ * This simplifies tests that need to mock multiple stores.
+ * 
+ * @param storeMappings - A Map mapping store objects to their mocked state values
+ * @returns The original spy on useStore to allow for cleanup
+ * 
+ * Example usage:
+ * ```
+ * const useStoreSpy = mockUseStore(new Map([
+ *   [runtimeStore, { runtime: mockRuntime, runtimeLoaded: true }],
+ *   [runtimeDiskStore, { gcePersistentDisk: mockDisk, gcePersistentDiskLoaded: true }]
+ * ]));
+ * 
+ * // After the test
+ * useStoreSpy.mockRestore();
+ * ```
+ */
+export function mockUseStore(storeMappings: Map<any, any>) {
+  return jest.spyOn(useStoreModule, 'useStore').mockImplementation((store) => {
+    if (storeMappings.has(store)) {
+      return storeMappings.get(store);
+    }
+    return null;
+  });
+}

--- a/ui/src/testing/utils.ts
+++ b/ui/src/testing/utils.ts
@@ -29,17 +29,17 @@ export const ALL_GKE_APP_TYPES = Object.keys(AppType).map((k) => AppType[k]);
 /**
  * Mock the useStore hook for testing with a mapping of stores to their mocked return values.
  * This simplifies tests that need to mock multiple stores.
- * 
+ *
  * @param storeMappings - A Map mapping store objects to their mocked state values
  * @returns The original spy on useStore to allow for cleanup
- * 
+ *
  * Example usage:
  * ```
  * const useStoreSpy = mockUseStore(new Map([
  *   [runtimeStore, { runtime: mockRuntime, runtimeLoaded: true }],
  *   [runtimeDiskStore, { gcePersistentDisk: mockDisk, gcePersistentDiskLoaded: true }]
  * ]));
- * 
+ *
  * // After the test
  * useStoreSpy.mockRestore();
  * ```


### PR DESCRIPTION
Before this fix, if you deleted a runtime and not its disk, the first time you load the configuration panel after deleting, you would see the size of the default disk in the description section. After re-opening the panel, you would see values reflecting the existing persistent disk.

Previous behavior:

https://github.com/user-attachments/assets/58568c04-6e4d-4733-81f7-c21ad29dff19

Updated Behavior:

https://github.com/user-attachments/assets/dd6b8319-f097-44af-b2d5-52277161fe4d


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
