### PR TITLE
[risk=low][no ticket] Clean up log spam by denying access to users who aren't in Google Directory

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -5,6 +5,7 @@ import static org.pmiops.workbench.access.AccessTierService.REGISTERED_TIER_SHOR
 import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForControlledTierRenewal;
 import static org.pmiops.workbench.access.AccessUtils.getRequiredModulesForRegisteredTierRenewal;
 
+import com.google.api.services.directory.model.User;
 import com.google.api.services.oauth2.model.Userinfo;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Provider;
@@ -610,10 +611,12 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent) {
+    boolean isEnrolledIn2FA =
+        directoryService.getUser(targetUser.getUsername()).map(User::getIsEnrolledIn2Sv).orElse(false);
     return syncTwoFactorAuthStatus(
         targetUser,
         agent,
-        directoryService.getUserOrThrow(targetUser.getUsername()).getIsEnrolledIn2Sv());
+        isEnrolledIn2FA);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -612,11 +612,11 @@ public class UserServiceImpl implements UserService {
   @Override
   public DbUser syncTwoFactorAuthStatus(DbUser targetUser, Agent agent) {
     boolean isEnrolledIn2FA =
-        directoryService.getUser(targetUser.getUsername()).map(User::getIsEnrolledIn2Sv).orElse(false);
-    return syncTwoFactorAuthStatus(
-        targetUser,
-        agent,
-        isEnrolledIn2FA);
+        directoryService
+            .getUser(targetUser.getUsername())
+            .map(User::getIsEnrolledIn2Sv)
+            .orElse(false);
+    return syncTwoFactorAuthStatus(targetUser, agent, isEnrolledIn2FA);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.google;
 
 import com.google.api.services.directory.model.User;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -29,12 +28,6 @@ public interface DirectoryService {
    * org.pmiops.workbench.exceptions.NotFoundException} if not found.
    */
   User getUserOrThrow(String username);
-
-  /**
-   * Returns a mapping of researcher username (e.g. foo@researchallofus.org) to that user's 2FA
-   * enablement status in Gsuite.
-   */
-  Map<String, Boolean> getAllTwoFactorAuthStatuses();
 
   /** Looks up a user by username and returns their stored contact email address, if available. */
   Optional<String> getContactEmail(String username);

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -17,9 +17,7 @@ import com.google.api.services.directory.model.Users;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import jakarta.inject.Provider;
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -162,35 +160,6 @@ public class DirectoryServiceImpl implements DirectoryService {
   @Override
   public User getUserOrThrow(String username) {
     return getUser(username).orElseThrow(() -> new NotFoundException("user not found"));
-  }
-
-  @Override
-  public Map<String, Boolean> getAllTwoFactorAuthStatuses() {
-    final String domain = gSuiteDomain();
-    Map<String, Boolean> statuses = Maps.newHashMap();
-    Users response = null;
-    do {
-      final String pageToken =
-          Optional.ofNullable(response).map(r -> r.getNextPageToken()).orElse(null);
-      try {
-        response =
-            retryHandler.runAndThrowChecked(
-                (context) ->
-                    getGoogleDirectoryService()
-                        .users()
-                        .list()
-                        .setProjection("basic")
-                        .setDomain(domain)
-                        .setPageToken(pageToken)
-                        .execute());
-      } catch (IOException e) {
-        throw ExceptionUtils.convertGoogleIOException(e);
-      }
-      for (User u : response.getUsers()) {
-        statuses.put(u.getPrimaryEmail(), u.getIsEnrolledIn2Sv());
-      }
-    } while (!Strings.isNullOrEmpty(response.getNextPageToken()));
-    return statuses;
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/DirectoryServiceImpl.java
@@ -13,7 +13,6 @@ import com.google.api.services.directory.DirectoryScopes;
 import com.google.api.services.directory.model.User;
 import com.google.api.services.directory.model.UserEmail;
 import com.google.api.services.directory.model.UserName;
-import com.google.api.services.directory.model.Users;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
@@ -34,16 +33,12 @@ import org.pmiops.workbench.auth.ServiceAccounts;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.exceptions.ExceptionUtils;
 import org.pmiops.workbench.exceptions.NotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DirectoryServiceImpl implements DirectoryService {
-
-  private static final Logger log = LoggerFactory.getLogger(DirectoryService.class.getName());
   private static final String ALLOWED =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()";
   private static final String APPLICATION_NAME = "All of Us Researcher Workbench";
@@ -60,9 +55,6 @@ public class DirectoryServiceImpl implements DirectoryService {
   // Details: https://docs.google.com/document/d/1xgcvow0xPL6K4vxyM3PVlW-1E5Ye3X1Y5wZSD5rrPlc
   private static final String GSUITE_FIELD_ABSORB_EXTERNAL_DEPARTMENT_ID =
       "Absorb_external_department_ID";
-  private static final int MAX_USERS_LIST_PAGE_SIZE = 500;
-  private static final String EMAIL_USER_FIELD = "email";
-  private static final String USER_VIEW_TYPE = "domain_public";
 
   private static final String ADMIN_SERVICE_ACCOUNT_NAME = "gsuite-admin";
 
@@ -71,7 +63,7 @@ public class DirectoryServiceImpl implements DirectoryService {
   // unit, and that user should have full admin privileges (e.g. to create, update, delete users).
   private static final String DIRECTORY_SERVICE_USERNAME = "directory-service";
 
-  private static SecureRandom rnd = new SecureRandom();
+  private static final SecureRandom rnd = new SecureRandom();
 
   // This list must exactly match the scopes allowed via the GSuite Domain Admin page here:
   // https://admin.google.com/fake-research-aou.org/AdminHome?chromeless=1#OGX:ManageOauthClients
@@ -270,35 +262,6 @@ public class DirectoryServiceImpl implements DirectoryService {
   @Override
   public void signOut(String username) {
     retryHandler.run((context) -> getGoogleDirectoryService().users().signOut(username).execute());
-  }
-
-  private long countUsersInDomain(String gSuiteDomain) {
-    long result = 0;
-    try {
-      final Directory directoryService = getGoogleDirectoryService();
-      Optional<String> nextPageToken = Optional.empty();
-      do {
-        final Directory.Users.List listQuery =
-            directoryService
-                .users()
-                .list()
-                .setDomain(gSuiteDomain)
-                .setViewType(USER_VIEW_TYPE)
-                .setCustomFieldMask("email")
-                .setMaxResults(MAX_USERS_LIST_PAGE_SIZE)
-                .setOrderBy(EMAIL_USER_FIELD);
-        nextPageToken.ifPresent(listQuery::setPageToken);
-
-        final Users usersQueryResult = listQuery.execute();
-
-        result += usersQueryResult.getUsers().size();
-        nextPageToken = Optional.ofNullable(usersQueryResult.getNextPageToken());
-      } while (nextPageToken.isPresent());
-      return result;
-    } catch (IOException e) {
-      log.warn("Failed to retrieve GSuite User List.", e);
-      return 0;
-    }
   }
 
   private String randomString() {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -199,7 +199,7 @@ public class UserServiceTest {
     userService.syncEraCommonsStatus();
 
     DbUser retrievedUser = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(DbAccessModuleName.ERA_COMMONS, retrievedUser, null);
+    assertModuleCompletionNull(DbAccessModuleName.ERA_COMMONS, retrievedUser);
   }
 
   @Test
@@ -256,7 +256,7 @@ public class UserServiceTest {
     googleUser.setPrimaryEmail(USERNAME);
     googleUser.setIsEnrolledIn2Sv(true);
 
-    when(mockDirectoryService.getUserOrThrow(USERNAME)).thenReturn(googleUser);
+    when(mockDirectoryService.getUser(USERNAME)).thenReturn(Optional.of(googleUser));
     userService.syncTwoFactorAuthStatus();
     // twoFactorAuthCompletionTime should now be set
     DbUser user = userDao.findUserByUsername(USERNAME);
@@ -273,8 +273,14 @@ public class UserServiceTest {
     // unset 2FA in google and check that twoFactorAuthCompletionTime is set to null
     googleUser.setIsEnrolledIn2Sv(false);
     userService.syncTwoFactorAuthStatus();
-    user = userDao.findUserByUsername(USERNAME);
-    assertModuleCompletionEqual(DbAccessModuleName.TWO_FACTOR_AUTH, providedDbUser, null);
+    assertModuleCompletionNull(DbAccessModuleName.TWO_FACTOR_AUTH, providedDbUser);
+  }
+
+  @Test
+  public void testSyncTwoFactorAuthStatusNotFound() {
+    when(mockDirectoryService.getUser(USERNAME)).thenReturn(Optional.empty());
+    assertDoesNotThrow(() -> userService.syncTwoFactorAuthStatus());
+    assertModuleCompletionNull(DbAccessModuleName.TWO_FACTOR_AUTH, providedDbUser);
   }
 
   @Test
@@ -700,6 +706,10 @@ public class UserServiceTest {
   private void assertModuleCompletionEqual(
       DbAccessModuleName moduleName, DbUser user, Timestamp timestamp) {
     assertThat(getModuleCompletionTime(moduleName, user)).isEqualTo(timestamp);
+  }
+
+  private void assertModuleCompletionNull(DbAccessModuleName moduleName, DbUser user) {
+    assertThat(getModuleCompletionTime(moduleName, user)).isNull();
   }
 
   private Timestamp getModuleCompletionTime(DbAccessModuleName moduleName, DbUser user) {

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -168,11 +168,11 @@ public class UserServiceTest {
                         ChronoUnit.DAYS)))
             .setExtensionTime(null);
 
-    DbUser user = new DbUser();
-    user.setUsername(USERNAME);
-    user.setUserInitialCreditsExpiration(initialCreditsExpiration);
-    user = userDao.save(user);
-    providedDbUser = user;
+    providedDbUser =
+        userDao.save(
+            new DbUser()
+                .setUsername(USERNAME)
+                .setUserInitialCreditsExpiration(initialCreditsExpiration));
 
     // key UserService logic depends on the existence of the Registered Tier
     registeredTier = accessTierDao.save(createRegisteredTier());
@@ -180,9 +180,9 @@ public class UserServiceTest {
 
     accessModules = TestMockFactory.createAccessModules(accessModuleDao);
     Institution institution = new Institution();
-    when(mockInstitutionService.getByUser(user)).thenReturn(Optional.of(institution));
+    when(mockInstitutionService.getByUser(providedDbUser)).thenReturn(Optional.of(institution));
     when(mockInstitutionService.validateInstitutionalEmail(
-            institution, user.getContactEmail(), REGISTERED_TIER_SHORT_NAME))
+            institution, providedDbUser.getContactEmail(), REGISTERED_TIER_SHORT_NAME))
         .thenReturn(true);
   }
 


### PR DESCRIPTION
Some (test?) users cannot be found in Google Directory, which causes the nightly access sync cron to throw.  These users are clearly not compliant, so deny access instead of throwing.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
