### PR TITLE
[DT-989][risk=no] Limit non-ops users to one account per institutional email

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserDao.java
@@ -33,6 +33,19 @@ public interface UserDao extends CrudRepository<DbUser, Long> {
 
   DbUser findUserByUserId(long userId);
 
+  List<DbUser> findUsersByContactEmail(String contactEmail);
+
+  @Query(
+      value =
+          "select u.* "
+              + "from user u "
+              + "join user_verified_institutional_affiliation uvia on (u.user_id = uvia.user_id) "
+              + "join institution i on (uvia.institution_id = i.institution_id) "
+              + "where i.short_name = 'AouOps' "
+              + "and u.contact_email = :contactEmail",
+      nativeQuery = true)
+  List<DbUser> findOpsUsersByContactEmail(@Param("contactEmail") String contactEmail);
+
   List<DbUser> findUsersByUserIdIn(List<Long> userIds);
 
   @Query("SELECT user.id FROM DbUser user")

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserService.java
@@ -179,4 +179,6 @@ public interface UserService {
   void signOut(DbUser user);
 
   boolean isServiceAccount(DbUser user);
+
+  boolean hasExistingAccount(String contactEmail);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -765,6 +765,19 @@ public class UserServiceImpl implements UserService {
     maybeSendAccessTierExpirationEmail(user, CONTROLLED_TIER_SHORT_NAME);
   }
 
+  /**
+   * Check if a user has an existing account before creating a new account.
+   *
+   * <p>Will allow AoU operational users to create a duplicate account
+   */
+  @Override
+  public boolean hasExistingAccount(String contactEmail) {
+    if (userDao.findUsersByContactEmail(contactEmail).isEmpty()) {
+      return false;
+    }
+    return userDao.findOpsUsersByContactEmail(contactEmail).isEmpty();
+  }
+
   @Override
   public void signOut(DbUser user) {
     directoryService.signOut(user.getUsername());

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -9409,6 +9409,10 @@ components:
           type: boolean
           description: Whether the requested email address is a valid member of the
             institution.
+        existingAccount:
+          type: boolean
+          description: Whether the requested email address already has an existing
+            account.
     WorkspaceResponse:
       required:
       - accessLevel

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -37,6 +37,7 @@ import { isBlank, reactStyles } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import {
   checkInstitutionalEmail,
+  DuplicateEmailErrorMessage,
   getEmailValidationErrorMessage,
 } from 'app/utils/institutions';
 import { notTooLong } from 'app/utils/validators';
@@ -71,7 +72,9 @@ validate.validators.checkEmailResponse = (value: CheckEmailResponse) => {
   if (value == null) {
     return '^Institutional membership check has not completed';
   }
-  if (value?.validMember) {
+  if (value?.existingAccount) {
+    return '^An account already exists with this email address ';
+  } else if (value?.validMember) {
     return null;
   } else {
     return '^Email address is not a member of the selected institution';
@@ -221,7 +224,7 @@ export class AccountCreationInstitution extends React.Component<
       return undefined;
     }
 
-    return checkEmailResponse.validMember;
+    return checkEmailResponse.validMember && !checkEmailResponse.existingAccount;
   }
 
   updateContactEmail(contactEmail: string) {
@@ -253,6 +256,12 @@ export class AccountCreationInstitution extends React.Component<
     if (!checkEmailResponse && !checkEmailError) {
       return '';
     }
+
+    // Show an error message if there is already an account with this email
+    if (checkEmailResponse?.existingAccount) {
+      return <DuplicateEmailErrorMessage />;
+    }
+
     // No error if the institution check was successful.
     if (checkEmailResponse?.validMember) {
       return '';

--- a/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
+++ b/ui/src/app/pages/login/account-creation/account-creation-institution.tsx
@@ -224,7 +224,9 @@ export class AccountCreationInstitution extends React.Component<
       return undefined;
     }
 
-    return checkEmailResponse.validMember && !checkEmailResponse.existingAccount;
+    return (
+      checkEmailResponse.validMember && !checkEmailResponse.existingAccount
+    );
   }
 
   updateContactEmail(contactEmail: string) {

--- a/ui/src/app/utils/institutions.tsx
+++ b/ui/src/app/utils/institutions.tsx
@@ -67,6 +67,14 @@ const EmailDomainMismatchErrorMessage = () => {
   );
 };
 
+export const DuplicateEmailErrorMessage = () => {
+  return (
+    <div data-test-id='email-error-message' style={{ color: colors.danger }}>
+      An account already exists with this email
+    </div>
+  );
+};
+
 export const getEmailValidationErrorMessage = (
   institution: PublicInstitutionDetails
 ) => {


### PR DESCRIPTION
Add a check for existing account during user registration. Uses new `existingAccount` property on `CheckEmailResponse`, will prevent users from continuing if `existingAccount` returns `true`.

This will allow AoU operational users to create multiple accounts.

Error message shown in UI if an existing account is found:
![Screenshot 2025-04-16 at 10 42 13 PM](https://github.com/user-attachments/assets/f2577312-c3d9-4cc9-b7d2-aad090988268)

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
