### PR TITLE
[RW-14937][risk=no] Remove instances of includeDeleted that are no longer included in Leo's yaml

### DIFF
--- a/api/src/main/resources/leonardo.yaml
+++ b/api/src/main/resources/leonardo.yaml
@@ -448,13 +448,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: includeDeleted
-          description: Optional filter that includes any persistent disks with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
-        - in: query
           name: includeLabels
           description: >
             Optional label keys of the labels returned in response. Example:
@@ -517,13 +510,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any persistent disks with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - in: query
           name: includeLabels
           description: >
@@ -748,13 +734,6 @@ paths:
           required: false
           schema:
             type: string
-        - in: query
-          name: includeDeleted
-          description: Optional filter that includes any apps with a Deleted status.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - in: query
           name: includeLabels
           description: >


### PR DESCRIPTION
Our version of Leo's yaml still included references to includeDeleted parameters that [Leo's version](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/resources/swagger/api-docs.yaml) no longer has.

The only remaining instance is in `listAppByProject`. All other usages were unused and have been removed.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
