### PR TITLE
[no ticket][risk=no] Converted DataUserCodeOfConduct to a functional component

### DIFF
--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -524,10 +524,7 @@ export const DataUserCodeOfConduct = fp.flow(
       )}
       {showSignaturePage && (
         <DuccSignaturePage
-          errors={errors}
-          submitting={submitting}
-          signatureState={signatureState}
-          username={username}
+          {...{ errors, submitting, signatureState, username }}
           fullName={givenName + ' ' + familyName}
           signedInitials={duccSignedInitials}
           signedDate={duccCompletionTimeEpochMillis}

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -441,18 +441,18 @@ export const DataUserCodeOfConduct = fp.flow(
       message: 'Please try submitting the agreement again.',
     })
   )(async (initials) => {
-    const profile = await profileApi().submitDUCC(
+    const updatedProfile = await profileApi().submitDUCC(
       getLiveDUCCVersion(),
       initials
     );
-    profileState.updateCache(profile);
+    profileState.updateCache(updatedProfile);
   });
 
   const submitDataUserCodeOfConduct = (initials) => {
     profileApi()
       .submitDUCC(getLiveDUCCVersion(), initials)
-      .then((profile) => {
-        profileState.updateCache(profile);
+      .then((updatedProfile) => {
+        profileState.updateCache(updatedProfile);
         history.back();
       });
   };

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -506,7 +506,7 @@ export const DataUserCodeOfConduct = fp.flow(
     <div style={containerStyle}>
       {signatureState === DuccSignatureState.SIGNED &&
         !canRenderSignedDucc(duccSignedVersion) && (
-          <SignedVersionFailure duccSignedVersion={duccSignedVersion} />
+          <SignedVersionFailure {...{ duccSignedVersion }} />
         )}
       {showContentPage && (
         <DuccContentPage

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSProperties, useState, useEffect } from 'react';
+import { CSSProperties, useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 import { validate } from 'validate.js';
@@ -401,9 +401,17 @@ export const DataUserCodeOfConduct = fp.flow(
   withNavigation,
   withRouter
 )((props: Props) => {
-  const { profileState, signatureState, location, navigate, hideSpinner } = props;
+  const { profileState, signatureState, location, navigate, hideSpinner } =
+    props;
   const { profile } = profileState;
-  const { username, givenName, familyName, duccSignedInitials, duccSignedVersion, duccCompletionTimeEpochMillis } = profile;
+  const {
+    username,
+    givenName,
+    familyName,
+    duccSignedInitials,
+    duccSignedVersion,
+    duccCompletionTimeEpochMillis,
+  } = profile;
 
   const [name, setName] = useState('');
   const [initialMonitoring, setInitialMonitoring] = useState('');
@@ -415,7 +423,7 @@ export const DataUserCodeOfConduct = fp.flow(
 
   useEffect(() => {
     hideSpinner();
-  }, [hideSpinner]);
+  }, []);
 
   const submitCodeOfConductWithRenewal = fp.flow(
     withSuccessModal({
@@ -478,7 +486,7 @@ export const DataUserCodeOfConduct = fp.flow(
     signatureState === DuccSignatureState.SIGNED
       ? canRenderSignedDucc(duccSignedVersion)
       : page === DataUserCodeOfConductPage.CONTENT;
-      
+
   const showSignaturePage =
     signatureState === DuccSignatureState.SIGNED
       ? canRenderSignedDucc(duccSignedVersion)

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -413,7 +413,6 @@ export const DataUserCodeOfConduct = fp.flow(
     duccCompletionTimeEpochMillis,
   } = profile;
 
-  const [name, setName] = useState('');
   const [initialMonitoring, setInitialMonitoring] = useState('');
   const [initialPublic, setInitialPublic] = useState('');
   const [initialAccess, setInitialAccess] = useState('');

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -510,7 +510,7 @@ export const DataUserCodeOfConduct = fp.flow(
         )}
       {showContentPage && (
         <DuccContentPage
-          signatureState={signatureState}
+          {...{ signatureState }}
           versionToRender={
             signatureState === DuccSignatureState.SIGNED
               ? duccSignedVersion

--- a/ui/src/app/components/data-user-code-of-conduct.tsx
+++ b/ui/src/app/components/data-user-code-of-conduct.tsx
@@ -527,9 +527,9 @@ export const DataUserCodeOfConduct = fp.flow(
           fullName={givenName + ' ' + familyName}
           signedInitials={duccSignedInitials}
           signedDate={duccCompletionTimeEpochMillis}
-          onChangeMonitoring={(v) => setInitialMonitoring(v)}
-          onChangePublic={(v) => setInitialPublic(v)}
-          onChangeAccess={(v) => setInitialAccess(v)}
+          onChangeMonitoring={setInitialMonitoring}
+          onChangePublic={setInitialPublic}
+          onChangeAccess={setInitialAccess}
           onBack={() => setPage(DataUserCodeOfConductPage.CONTENT)}
           onAccept={handleAccept}
         />


### PR DESCRIPTION
Functionality should not change.

To test

Ensure that your user does not have data user code of conduct (ducc) signed or bypassed.

Navigate to http://localhost:4200/data-code-of-conduct

Sign the ducc.

Ensure that your ducc shows as signed on today's date on http://localhost:4200/data-access-requirements


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
