### PR TITLE
[DT-1007][risk=no] Remove delete option from genomic extraction menu

### DIFF
--- a/ui/src/app/components/genomics-extraction-menu.spec.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.spec.tsx
@@ -70,7 +70,6 @@ describe(GenomicsExtractionMenu.name, () => {
     await waitFor(() => {
       expect(screen.getByText('View Path')).toBeInTheDocument();
       expect(screen.getByText('Abort Extraction')).toBeInTheDocument();
-      expect(screen.getByText('Delete Extract')).toBeInTheDocument();
     });
   });
 
@@ -239,20 +238,4 @@ describe(GenomicsExtractionMenu.name, () => {
       });
     }
   );
-
-  // always disabled - not implemented yet?
-  it('Disables clicking Delete Extract', async () => {
-    const user = userEvent.setup();
-    await component();
-
-    const menuTitle = screen.getByTitle('Genomic Extractions Action Menu');
-    const menuIcon = menuTitle.parentElement;
-
-    user.click(menuIcon);
-    await waitFor(() => {
-      const deleteExtractionMenuItem = screen.getByText('Delete Extract');
-      expect(deleteExtractionMenuItem).toBeInTheDocument();
-      expectMenuItemElementDisabled(deleteExtractionMenuItem);
-    });
-  });
 });

--- a/ui/src/app/components/genomics-extraction-menu.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { faBan, faEllipsisV, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faBan, faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { GenomicExtractionJob, TerraJobStatus } from 'generated/fetch';

--- a/ui/src/app/components/genomics-extraction-menu.tsx
+++ b/ui/src/app/components/genomics-extraction-menu.tsx
@@ -98,15 +98,6 @@ export const GenomicsExtractionMenu = ({
             >
               Abort Extraction
             </MenuItem>
-            <hr style={styles.hr} />
-            <MenuItem
-              style={styles.menuItem}
-              faIcon={faTrash}
-              disabled
-              onClick={() => {}}
-            >
-              Delete Extract
-            </MenuItem>
           </React.Fragment>
         }
       >


### PR DESCRIPTION
`Delete Extract` option no longer appears in the menu
![Screenshot 2025-04-29 at 12 41 57 PM](https://github.com/user-attachments/assets/b6b414b2-3e76-4c61-a2c3-c313414f56ff)
