### PR TITLE
[RW-14663][risk=low] Update Jupyter's Download/View Click Handlers 

### DIFF
--- a/api/src/main/webapp/static/aou-file-tree-policy-extension.js
+++ b/api/src/main/webapp/static/aou-file-tree-policy-extension.js
@@ -54,6 +54,7 @@ define([
         var fileExt = fileName.substring( (fileName.lastIndexOf('.') +1) );
         if (viewableFileExtension !== fileExt) {
           openInANewTab = false;
+          return false;
         }
       });
       // Only show download dialog if some of the selected Files

--- a/api/src/main/webapp/static/aou-file-tree-policy-extension.js
+++ b/api/src/main/webapp/static/aou-file-tree-policy-extension.js
@@ -14,15 +14,21 @@ define([
         'is uploaded into the Workspace should be exclusively for the research purpose that was ' +
         'provided for this Workspace.'));
 
-    // notebook-list.js in the Jupyter UI serves the download and view button by using it's own
-    // jQuery click handler. We have no way of ordering our click handler ahead
-    // of it without digging into jQuery internals. Instead, we insert a span
-    // on top of the button to gain click priority.
-    $('.dynamic-buttons .download-button').empty().append(
-        '<span id="aou-download-button-overlay">Download</span>');
-    $('.dynamic-buttons .view-button').empty().append(
-        '<span id="aou-view-button-overlay">View</span>');
+    // Function to check if user affirmed the download policy and stop propagation if not
+    function handlePolicyAffirmation(event) {
+      const affirmed = downloadPolicyPopUp();
+      if (!affirmed) {
+        event.stopPropagation();
+      }
+    }
 
+    // notebook-list.js in the Jupyter UI serves the download and view button by using it's own
+    // jQuery click handler. We have no way of ensuring that our click handler is ahead
+    // of it without digging into jQuery internals, however using an event listener with event capturing
+    // seems to work.
+    document.querySelector('.download-button').addEventListener('click', function(e) {
+      handlePolicyAffirmation(e);
+    }, true);
 
     function downloadPolicyPopUp() {
       var affirm =  prompt(
@@ -35,16 +41,11 @@ define([
       return !!affirm && 'affirm' === affirm.replace(/\W/g, '').toLowerCase()
     }
 
-
-    $('#aou-download-button-overlay').click(() => {
-      return downloadPolicyPopUp();
-    });
-
     const viewableFileExtenstions = ['ipynb', 'txt', 'sh'];
     // Clicking the view button will
     // 1) Open All Jupyter, text or shell files in a new tab.
     // 2) Display a download policy prompt for all other files as they will be downloaded
-    $('#aou-view-button-overlay').click(() => {
+    document.querySelector('.dynamic-buttons .view-button').addEventListener('click', function(e) {
       var openInANewTab = true;
       $('#notebook_list input:checked').each(function() {
         // Find the selected file name
@@ -53,16 +54,14 @@ define([
         var fileExt = fileName.substring( (fileName.lastIndexOf('.') +1) );
         if (viewableFileExtenstions.indexOf(fileExt) === -1) {
           openInANewTab = false;
-          return false;
         }
-       });
-      // If all selected Files are files that open in a new tab (ipynb, txt or sh), return now
-      if (!!openInANewTab) {
-        return true;
+      });
+      // Only show download dialog if some of the selected Files
+      // are not in the viewable file extensions list.
+      if(!openInANewTab) {
+        handlePolicyAffirmation(e);
       }
-
-      return downloadPolicyPopUp();
-    });
+    }, true);
   };
 
   return {

--- a/api/src/main/webapp/static/aou-file-tree-policy-extension.js
+++ b/api/src/main/webapp/static/aou-file-tree-policy-extension.js
@@ -41,7 +41,7 @@ define([
       return !!affirm && 'affirm' === affirm.replace(/\W/g, '').toLowerCase()
     }
 
-    const viewableFileExtenstions = ['ipynb', 'txt', 'sh'];
+    const viewableFileExtension = 'ipynb';
     // Clicking the view button will
     // 1) Open All Jupyter, text or shell files in a new tab.
     // 2) Display a download policy prompt for all other files as they will be downloaded
@@ -52,7 +52,7 @@ define([
         const elem = $(this).siblings().find($('.item_link .item_name'));
         const fileName = elem.text();
         var fileExt = fileName.substring( (fileName.lastIndexOf('.') +1) );
-        if (viewableFileExtenstions.indexOf(fileExt) === -1) {
+        if (viewableFileExtension !== fileExt) {
           openInANewTab = false;
         }
       });


### PR DESCRIPTION
In all cases below, the "download" and "view" buttons only appear and take action on behalf of the files that are selected.

**Previous Behavior:**
The listener that triggers the download popup is only listening for the overlay (text in the middle of the download button). If you happen to click in the corner of the button (outside of the overlay/blue outline), you will not get the download warning. Also, the dialog was not showing when triggering a button via "Enter" or "Space" when focused. Likewise for the "View" button.

https://github.com/user-attachments/assets/3a21e45e-78b6-4924-990d-4ac8861b9e69

**Current/Desired Behavior**
You should be able to click the "download" button or press "enter" or "space" (when the "download" button is focused), and then, the download warning dialog should appear.

Should only show the download warning when clicking "View" for files that are not ipynb, sh, or txt.

**How to test:**
- Delete existing Jupyter environment if one exists in the workspace that you are testing.
- Stop API 
- Copy the file aou-file-tree-policy-extension.js to a public bucket. I suggest [aou-test-jupyter-view](https://console.cloud.google.com/storage/browser/aou-test-jupyter-view;tab=objects?forceOnBucketsSortingFiltering=true&project=terra-dev-14905480)
- Update the path at https://github.com/all-of-us/workbench/blob/main/api/src/main/java/org/pmiops/workbench/leonardo/LeonardoApiClientImpl.java#L155 to "https://storage.googleapis.com/aou-test-jupyter-view/aou-file-tree-policy-extension.js"
- Start API
- Start Jupyter Environment


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
