### PR TITLE
Revert "[risk=no] RW-14240 promote to preprod"

### DIFF
--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -12,7 +12,7 @@
     "xAppIdValue": "preprod-AoU-RW",
     "timeoutInSeconds": 40,
     "lenientTimeoutInSeconds": 180,
-    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.15",
+    "jupyterDockerImage": "us.gcr.io/broad-dsp-gcr-public/terra-jupyter-aou:2.2.13",
     "workspaceLogsProject": "fc-aou-logs-preprod",
     "workspaceBucketLocation": "us-central1",
     "gceVmZones": ["us-central1-a","us-central1-b","us-central1-c", "us-central1-f"],


### PR DESCRIPTION
Reverts all-of-us/workbench#9258

2.2.15 won't work for dataproc, so reverting in preprod for now

I'm not reverting in Test since we're expecting a fix soon and no one uses dataproc much in Test, but lmk if ppl prefer Test is also reverted