### PR TITLE
[risk=low][no ticket] Bump Spring Boot to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,10 +83,10 @@ executors:
   # due to garbage collection timeout. This should be reassessed after upgrading to Junit 5. See RW-6460.
   api-unit-test-executor:
     <<: *workbench-executor
-    resource_class: medium+
+    resource_class: large
     environment:
       <<: *env-default
-      # The medium+ machine has 6GB.  Increase the Java memory from the default 2G to 4G. This increase is possible for unit tests as they are run
+      # The large machine has 8GB.  Increase the Java memory from the default 2G to 4G. This increase is possible for unit tests as they are run
       # as a ~single-process workflow - in other cases using 4GB may starve other processes. For example,
       # this should not be used for the Local API integration test (which starts both a server, and a test process).
       JAVA_TOOL_OPTIONS: -Xmx4g

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,10 @@ executors:
     resource_class: medium+
     environment:
       <<: *env-default
-      # The medium+ machine has 6GB.  Increase the Java memory from the default 2G to 3G. This increase is possible for unit tests as they are run
-      # as a ~single-process workflow - in other cases using 3GB may starve other processes. For example,
+      # The medium+ machine has 6GB.  Increase the Java memory from the default 2G to 4G. This increase is possible for unit tests as they are run
+      # as a ~single-process workflow - in other cases using 4GB may starve other processes. For example,
       # this should not be used for the Local API integration test (which starts both a server, and a test process).
-      JAVA_TOOL_OPTIONS: -Xmx3g
+      JAVA_TOOL_OPTIONS: -Xmx4g
 
   # Default workbench environment plus MySQL database docker image
   db-executor:

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -680,8 +680,8 @@ tasks.withType(Test) {
         }
     }
     // As of Q1 2021, API unit tests need a larger heap due to memory retention across individual test cases.
-    // Bumping 2GB -> 4 GB in May 2025 for Spring Boot 3.3
-    maxHeapSize = "4g"
+    // May 2025: Bumping 2GB -> 3 GB for Spring Boot 3.3
+    maxHeapSize = "3g"
 }
 
 appengine {  // App Engine tasks configuration

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -678,7 +678,7 @@ tasks.withType(Test) {
         }
     }
     // As of Q1 2021, API unit tests need a larger heap due to memory retention across individual test cases.
-    // May 2025: Bumping 2GB -> 4 GB for Spring Boot 3.3
+    // May 2025: Bumping 2GB -> 4 GB for Spring Boot 3.3+
     maxHeapSize = "4g"
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -52,7 +52,7 @@ plugins {
 
     id 'io.spring.dependency-management' version '1.1.7'
     // keep in sync with the dependencyManagement block below
-    id 'org.springframework.boot' version '3.3.11'
+    id 'org.springframework.boot' version '3.4.5'
 
     id 'com.diffplug.spotless' version '6.23.3'
     id 'com.google.cloud.tools.appengine-appenginewebxml' version '2.8.0'
@@ -77,7 +77,7 @@ dependencyManagement {
     dependencies {
         dependency group: 'org.springframework', name: 'spring-core', version: '6.2.7'
         // keep in sync with the plugin block above
-        dependency group: 'org.springframework.boot', name: 'spring-boot', version: '3.3.11'
+        dependency group: 'org.springframework.boot', name: 'spring-boot', version: '3.4.5'
         dependency group: 'org.springframework.security', name: 'spring-security', version: '6.4.5'
     }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -56,7 +56,7 @@ plugins {
 
     id 'io.spring.dependency-management' version '1.1.7'
     // keep in sync with the dependencyManagement block below
-    id 'org.springframework.boot' version '3.2.12'
+    id 'org.springframework.boot' version '3.3.11'
 
     id 'com.diffplug.spotless' version '6.23.3'
     id 'com.google.cloud.tools.appengine-appenginewebxml' version '2.8.0'
@@ -81,7 +81,7 @@ dependencyManagement {
     dependencies {
         dependency group: 'org.springframework', name: 'spring-core', version: '6.2.7'
         // keep in sync with the plugin block above
-        dependency group: 'org.springframework.boot', name: 'spring-boot', version: '3.2.12'
+        dependency group: 'org.springframework.boot', name: 'spring-boot', version: '3.3.11'
         dependency group: 'org.springframework.security', name: 'spring-security', version: '6.4.5'
     }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -29,10 +29,6 @@ buildscript {
         HIBERNATE_VERSION = '6.5.3.Final'
         JACKSON_VERSION = '2.18.3'
         LIQUIBASE_VERSION = '4.31.1'
-        // 1.5.7+ results in a runtime error:
-        // Logging system failed to initialize using configuration from 'null'
-        //  java.lang.NoSuchMethodError: 'java.lang.Object ch.qos.logback.classic.LoggerContext.getConfigurationLock()'
-        LOGBACK_VERSION = '1.5.6'
         MAPSTRUCT_VERSION = '1.6.2'
         OKHTTP_VERSION = '4.12.0'
         OPENTELEMETRY_SDK_VERSION = '1.48.0'
@@ -440,8 +436,6 @@ dependencies {
 
 
 
-    implementation "ch.qos.logback:logback-classic:$project.ext.LOGBACK_VERSION"
-    implementation "ch.qos.logback:logback-core:$project.ext.LOGBACK_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$project.ext.JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-core:$project.ext.JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-databind:$project.ext.JACKSON_VERSION"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -680,8 +680,8 @@ tasks.withType(Test) {
         }
     }
     // As of Q1 2021, API unit tests need a larger heap due to memory retention across individual test cases.
-    // May 2025: Bumping 2GB -> 3 GB for Spring Boot 3.3
-    maxHeapSize = "3g"
+    // May 2025: Bumping 2GB -> 4 GB for Spring Boot 3.3
+    maxHeapSize = "4g"
 }
 
 appengine {  // App Engine tasks configuration

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -680,7 +680,8 @@ tasks.withType(Test) {
         }
     }
     // As of Q1 2021, API unit tests need a larger heap due to memory retention across individual test cases.
-    maxHeapSize = "2g"
+    // Bumping 2GB -> 4 GB in May 2025 for Spring Boot 3.3
+    maxHeapSize = "4g"
 }
 
 appengine {  // App Engine tasks configuration

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -470,9 +470,7 @@ dependencies {
     implementation "org.apache.commons:commons-collections4:4.5.0-M3"
     implementation 'org.apache.commons:commons-lang3:3.15.0'
     implementation 'org.apache.commons:commons-text:1.13.0'
-    // 5.4+ results in a runtime error:
-    // java.lang.NoSuchMethodError: 'void org.apache.hc.core5.http.impl.io.DefaultHttpRequestWriterFactory.<init>(org.apache.hc.core5.http.config.Http1Config)'
-    implementation "org.apache.httpcomponents.client5:httpclient5:5.3.1"
+    implementation "org.apache.httpcomponents.client5:httpclient5:5.4.4"
     implementation 'commons-codec:commons-codec:1.17.0'
     implementation 'com.auth0:java-jwt:4.5.0'
     implementation 'org.json:json:20250107'


### PR DESCRIPTION
Bump Spring Boot (and httpclient5) to latest.  Also remove the explicit logback version - a newer version is now chosen automatically to be compatible with spring-boot 3.4.5.

Tested locally - everything seems to work fine.

It's worth noting that this upgrade requires giving tests more memory resources to pass.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
