### PR TITLE
[risk=low] [RW-14611] remove revokeWorkflowRunnerRoleForUsers

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -862,12 +862,4 @@ public class WorkspacesController implements WorkspacesApiDelegate {
         new WorkspaceCreatorFreeCreditsRemainingResponse()
             .freeCreditsRemaining(freeCreditsRemaining));
   }
-
-  /** Returns {@true} if the user is 1: workspace OWNER or WRITER; 2: NOT current logged in user */
-  private static boolean shouldGrantWorkflowRunnerAsService(
-      DbUser loggedInUser, Map.Entry<String, WorkspaceAccessLevel> userNameToAclMapEntry) {
-    return !userNameToAclMapEntry.getKey().equals(loggedInUser.getUsername())
-        && (WorkspaceAccessLevel.OWNER.equals(userNameToAclMapEntry.getValue())
-            || WorkspaceAccessLevel.WRITER.equals(userNameToAclMapEntry.getValue()));
-  }
 }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerService.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerService.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.google;
 
-import com.google.api.services.cloudresourcemanager.v3.model.Policy;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import java.io.IOException;
 import java.util.List;
@@ -9,10 +8,4 @@ import org.pmiops.workbench.db.model.DbUser;
 /** Encapsulate Google APIs for interfacing with Google Cloud ResourceManager. */
 public interface CloudResourceManagerService {
   List<Project> getAllProjectsForUser(DbUser user) throws IOException;
-
-  /** Gets IAM policy on a project. */
-  Policy getIamPolicy(String googleProject);
-
-  /** Gets IAM policy on a project. */
-  Policy setIamPolicy(String googleProject, Policy policy);
 }

--- a/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/google/CloudResourceManagerServiceImpl.java
@@ -7,11 +7,8 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.services.cloudresourcemanager.v3.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.v3.CloudResourceManager.Builder;
 import com.google.api.services.cloudresourcemanager.v3.CloudResourceManagerScopes;
-import com.google.api.services.cloudresourcemanager.v3.model.GetIamPolicyRequest;
-import com.google.api.services.cloudresourcemanager.v3.model.Policy;
 import com.google.api.services.cloudresourcemanager.v3.model.Project;
 import com.google.api.services.cloudresourcemanager.v3.model.SearchProjectsResponse;
-import com.google.api.services.cloudresourcemanager.v3.model.SetIamPolicyRequest;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
@@ -101,31 +98,6 @@ public class CloudResourceManagerServiceImpl implements CloudResourceManagerServ
                     .filter(((Predicate<String>) String::isEmpty).negate());
           } while (pageToken.isPresent());
           return projects;
-        });
-  }
-
-  @Override
-  public Policy getIamPolicy(String googleProject) {
-    return retryHandler.run(
-        (context) -> {
-          return serviceCloudResouceManager
-              .get()
-              .projects()
-              .getIamPolicy("projects/" + googleProject, new GetIamPolicyRequest())
-              .execute();
-        });
-  }
-
-  @Override
-  public Policy setIamPolicy(String googleProject, Policy policy) {
-    return retryHandler.run(
-        (context) -> {
-          return serviceCloudResouceManager
-              .get()
-              .projects()
-              .setIamPolicy(
-                  "projects/" + googleProject, new SetIamPolicyRequest().setPolicy(policy))
-              .execute();
         });
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/iam/IamService.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamService.java
@@ -9,13 +9,4 @@ public interface IamService {
 
   Optional<String> getOrCreatePetServiceAccountUsingImpersonation(
       String googleProject, String userEmail) throws IOException, ApiException;
-
-  /**
-   * Revokes permissions to run Google Life Sciences jobs for the provided user email lists.
-   *
-   * <p>For now just revoke lifesciences.workflowsRunner permission but keep petSA ActAS permission.
-   *
-   * @return the list of users whose workflow runner roles we failed to revoke, if any
-   */
-  List<String> revokeWorkflowRunnerRoleForUsers(String googleProject, List<String> userEmails);
 }

--- a/api/src/main/java/org/pmiops/workbench/iam/IamService.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamService.java
@@ -1,7 +1,6 @@
 package org.pmiops.workbench.iam;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.firecloud.ApiException;
 

--- a/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
@@ -1,15 +1,11 @@
 package org.pmiops.workbench.iam;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
-import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.ApiException;
 import org.pmiops.workbench.firecloud.FirecloudApiClientFactory;
 import org.pmiops.workbench.firecloud.api.TermsOfServiceApi;
-import org.pmiops.workbench.google.CloudResourceManagerService;
 import org.pmiops.workbench.sam.SamApiClientFactory;
 import org.pmiops.workbench.sam.SamRetryHandler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,18 +14,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class IamServiceImpl implements IamService {
 
-  private final CloudResourceManagerService cloudResourceManagerService;
   private final FirecloudApiClientFactory firecloudApiClientFactory;
   private final SamApiClientFactory samApiClientFactory;
   private final SamRetryHandler samRetryHandler;
 
   @Autowired
   public IamServiceImpl(
-      CloudResourceManagerService cloudResourceManagerService,
       FirecloudApiClientFactory firecloudApiClientFactory,
       SamApiClientFactory samApiClientFactory,
       SamRetryHandler samRetryHandler) {
-    this.cloudResourceManagerService = cloudResourceManagerService;
     this.firecloudApiClientFactory = firecloudApiClientFactory;
     this.samApiClientFactory = samApiClientFactory;
     this.samRetryHandler = samRetryHandler;

--- a/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/iam/IamServiceImpl.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.firecloud.ApiException;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class IamServiceImpl implements IamService {
-  private static final String LIFESCIENCE_RUNNER_ROLE = "roles/lifesciences.workflowsRunner";
 
   private final CloudResourceManagerService cloudResourceManagerService;
   private final FirecloudApiClientFactory firecloudApiClientFactory;
@@ -65,53 +63,5 @@ public class IamServiceImpl implements IamService {
     } else {
       return Optional.empty();
     }
-  }
-
-  @Override
-  public List<String> revokeWorkflowRunnerRoleForUsers(
-      String googleProject, List<String> userEmails) {
-    List<String> petServiceAccountFailures = new ArrayList<>();
-
-    try {
-      List<String> petServiceAccountsToRevokePermission = new ArrayList<>();
-      for (String userEmail : userEmails) {
-        // TODO can we make these requests in parallel?
-        getOrCreatePetServiceAccountUsingImpersonation(googleProject, userEmail)
-            .ifPresentOrElse(
-                petServiceAccountsToRevokePermission::add,
-                () -> petServiceAccountFailures.add(userEmail));
-      }
-      revokeLifeScienceRunnerRole(googleProject, petServiceAccountsToRevokePermission);
-    } catch (IOException | ApiException e) {
-      throw new ServerErrorException(e);
-    }
-
-    return petServiceAccountFailures;
-  }
-
-  /** Revokes life science runner role to list of service accounts. */
-  private void revokeLifeScienceRunnerRole(
-      String googleProject, List<String> petServiceAccountsLostAccess) {
-    com.google.api.services.cloudresourcemanager.v3.model.Policy policy =
-        cloudResourceManagerService.getIamPolicy(googleProject);
-    List<com.google.api.services.cloudresourcemanager.v3.model.Binding> bindingList =
-        Optional.ofNullable(policy.getBindings()).orElse(new ArrayList<>());
-    com.google.api.services.cloudresourcemanager.v3.model.Binding binding =
-        bindingList.stream()
-            .filter(b -> LIFESCIENCE_RUNNER_ROLE.equals(b.getRole()))
-            .findFirst()
-            .orElse(
-                new com.google.api.services.cloudresourcemanager.v3.model.Binding()
-                    .setRole(LIFESCIENCE_RUNNER_ROLE)
-                    .setMembers(new ArrayList<>()));
-
-    binding
-        .getMembers()
-        .removeAll(
-            petServiceAccountsLostAccess.stream()
-                .map(s -> "serviceAccount:" + s)
-                .collect(Collectors.toList()));
-
-    cloudResourceManagerService.setIamPolicy(googleProject, policy);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/WorkspacesControllerTest.java
@@ -698,7 +698,6 @@ public class WorkspacesControllerTest {
             workspace.getNamespace(), registeredTier.getServicePerimeter());
     assertThat(retrievedWorkspace.getBillingAccountName())
         .isEqualTo(TestMockFactory.WORKSPACE_BILLING_ACCOUNT_NAME);
-    verify(mockIamService, never()).revokeWorkflowRunnerRoleForUsers(anyString(), anyList());
   }
 
   @Test
@@ -2498,7 +2497,6 @@ public class WorkspacesControllerTest {
     List<RawlsWorkspaceACLUpdate> updateACLRequestList =
         convertUserRolesToUpdateAclRequestList(shareWorkspaceRequest.getItems());
     verify(fireCloudService).updateWorkspaceACL(any(), any(), eq(updateACLRequestList));
-    verify(mockIamService, never()).revokeWorkflowRunnerRoleForUsers(anyString(), anyList());
   }
 
   @Test


### PR DESCRIPTION
Now that we're no long using GLS (to be exact, we haven't addressed dsub and cromwell.jar against batch yet), we can remove the code for `revokeWorkflowRunnerRoleForUsers` I think.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
