### PR TITLE
[RW-15146][risk=no] Changed language relating to initial credits on the DAR page

### DIFF
--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1030,8 +1030,6 @@ describe('DataAccessRequirements', () => {
           },
           {
             accessTierShortName: AccessTierShortNames.Controlled,
-            // User not eligible for CT i.e user email doesnt match
-            // Institution's Controlled Tier email list
             eligible: false,
           },
         ],
@@ -1259,7 +1257,6 @@ describe('DataAccessRequirements', () => {
     profileStore.set({
       profile: {
         ...ProfileStubVariables.PROFILE_STUB,
-        // no CT eligibility object
         tierEligibilities: [
           {
             accessTierShortName: AccessTierShortNames.Registered,
@@ -1915,7 +1912,6 @@ describe('DataAccessRequirements', () => {
       registerApiClient(InstitutionApi, new InstitutionApiStub());
       registerApiClient(ProfileApi, new ProfileApiStub());
 
-      // Set up a complete profile to ensure CompletionBanner appears
       profileStore.set({
         profile: {
           ...ProfileStubVariables.PROFILE_STUB,
@@ -1938,26 +1934,30 @@ describe('DataAccessRequirements', () => {
       serverConfigStore.set({
         config: {
           ...defaultServerConfig,
-          enableInitialCreditsExpiration: true
+          enableInitialCreditsExpiration: true,
         },
       });
     });
 
     it('should show remaining credits when initial credits feature is enabled', () => {
       component();
-      expect(screen.getByText(/You have \$250 in initial credits remaining/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/You have \$250 in initial credits remaining/)
+      ).toBeInTheDocument();
     });
 
     it('should show correct expiration date for credits', () => {
       const expirationDate = new Date(oneYearFromNow());
-      const formattedDate = expirationDate.toLocaleDateString('en-US', { 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
+      const formattedDate = expirationDate.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
       });
-      
+
       component();
-      expect(screen.getByText(new RegExp(`These credits expire on ${formattedDate}`))).toBeInTheDocument();
+      expect(
+        screen.getByText(new RegExp(`These credits expire on ${formattedDate}`))
+      ).toBeInTheDocument();
     });
 
     it('should display full quota amount when freeTierUsage is null or undefined', () => {
@@ -1972,19 +1972,23 @@ describe('DataAccessRequirements', () => {
       });
 
       component();
-      expect(screen.getByText(/You have \$300 in initial credits remaining/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/You have \$300 in initial credits remaining/)
+      ).toBeInTheDocument();
     });
 
     it('should not show credit information when enableInitialCreditsExpiration is false', () => {
       serverConfigStore.set({
         config: {
           ...serverConfigStore.get().config,
-          enableInitialCreditsExpiration: false
+          enableInitialCreditsExpiration: false,
         },
       });
 
       component();
-      expect(screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)
+      ).not.toBeInTheDocument();
     });
 
     it('should not show credit information when initialCreditsExpirationEpochMillis is not set', () => {
@@ -1999,8 +2003,9 @@ describe('DataAccessRequirements', () => {
       });
 
       component();
-      expect(screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)
+      ).not.toBeInTheDocument();
     });
-
   });
 });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1921,8 +1921,8 @@ describe('DataAccessRequirements', () => {
               completionEpochMillis: 1,
             })),
           },
-          freeTierDollarQuota: 300,
-          freeTierUsage: 50,
+          initialCreditsLimit: 300,
+          initialCreditsUsage: 50,
           initialCreditsExpirationEpochMillis: oneYearFromNow(),
         },
         load,
@@ -1959,11 +1959,11 @@ describe('DataAccessRequirements', () => {
       ).toBeInTheDocument();
     });
 
-    it('should display full quota amount when freeTierUsage is null or undefined', () => {
+    it('should display full quota amount when initialCreditsUsage is null or undefined', () => {
       profileStore.set({
         profile: {
           ...profileStore.get().profile,
-          freeTierUsage: null,
+          initialCreditsUsage: null,
         },
         load,
         reload,

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1941,7 +1941,7 @@ describe('DataAccessRequirements', () => {
     it('should show remaining credits when initial credits feature is enabled', () => {
       component();
       expect(
-        screen.getByText(/You have \$250 in initial credits remaining/)
+        screen.getByText(/You have \$250.00 in initial credits remaining/)
       ).toBeInTheDocument();
     });
 
@@ -1972,7 +1972,7 @@ describe('DataAccessRequirements', () => {
 
       component();
       expect(
-        screen.getByText(/You have \$300 in initial credits remaining/)
+        screen.getByText(/You have \$300.00 in initial credits remaining/)
       ).toBeInTheDocument();
     });
 

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1938,13 +1938,6 @@ describe('DataAccessRequirements', () => {
       });
     });
 
-    it('should show remaining credits when initial credits feature is enabled', () => {
-      component();
-      expect(
-        screen.getByText(/You have \$250.00 in initial credits remaining/)
-      ).toBeInTheDocument();
-    });
-
     it('should show correct expiration date for credits', () => {
       const expirationDate = new Date(oneYearFromNow());
       const formattedDate = expirationDate.toLocaleDateString('en-US', {
@@ -1974,37 +1967,6 @@ describe('DataAccessRequirements', () => {
       expect(
         screen.getByText(/You have \$300.00 in initial credits remaining/)
       ).toBeInTheDocument();
-    });
-
-    it('should not show credit information when enableInitialCreditsExpiration is false', () => {
-      serverConfigStore.set({
-        config: {
-          ...serverConfigStore.get().config,
-          enableInitialCreditsExpiration: false,
-        },
-      });
-
-      component();
-      expect(
-        screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)
-      ).not.toBeInTheDocument();
-    });
-
-    it('should not show credit information when initialCreditsExpirationEpochMillis is not set', () => {
-      profileStore.set({
-        profile: {
-          ...profileStore.get().profile,
-          initialCreditsExpirationEpochMillis: null,
-        },
-        load,
-        reload,
-        updateCache,
-      });
-
-      component();
-      expect(
-        screen.queryByText(/You have \$[0-9]+ in initial credits remaining/)
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/src/app/pages/access/data-access-requirements.spec.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.spec.tsx
@@ -1921,7 +1921,6 @@ describe('DataAccessRequirements', () => {
               completionEpochMillis: 1,
             })),
           },
-          // Default values for credits
           freeTierDollarQuota: 300,
           freeTierUsage: 50,
           initialCreditsExpirationEpochMillis: oneYearFromNow(),

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -16,7 +16,7 @@ import { withProfileErrorModal } from 'app/components/with-error-modal-wrapper';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { profileApi, userAdminApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
-import { reactStyles } from 'app/utils';
+import { formatInitialCreditsUSD, reactStyles } from 'app/utils';
 import {
   buildRasRedirectUrl,
   DARPageMode,
@@ -531,10 +531,12 @@ const CompletionBanner = ({ profile }: CompletionBannerProps) => {
           profile.initialCreditsExpirationEpochMillis && (
             <>
               <div style={styles.completedText}>
-                You have $
-                {initialCreditsUsage
-                  ? initialCreditsLimit - initialCreditsUsage
-                  : initialCreditsLimit}{' '}
+                You have{' '}
+                {formatInitialCreditsUSD(
+                  initialCreditsUsage
+                    ? initialCreditsLimit - initialCreditsUsage
+                    : initialCreditsLimit
+                )}{' '}
                 in initial credits remaining. These credits expire on{' '}
                 {displayDateWithoutHours(
                   profile.initialCreditsExpirationEpochMillis

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -97,6 +97,7 @@ export const styles = reactStyles({
   },
   completedText: {
     fontSize: '14px',
+    marginBottom: '0.5rem',
   },
   controlledRenewal: {
     padding: '1em',
@@ -512,16 +513,11 @@ const ControlledTierRenewalBanner = () => (
 );
 interface CompletionBannerProps {
   profile: Profile;
-  initialCreditsValidityPeriodDays: number;
-  initialCreditsExtensionPeriodDays: number;
 }
-const CompletionBanner = ({
-  profile,
-  initialCreditsValidityPeriodDays,
-  initialCreditsExtensionPeriodDays,
-}: CompletionBannerProps) => {
+const CompletionBanner = ({ profile }: CompletionBannerProps) => {
   const enableInitialCreditsExpiration =
     serverConfigStore.get().config.enableInitialCreditsExpiration;
+  const { freeTierDollarQuota, freeTierUsage } = profile;
   return (
     <FlexRow data-test-id='dar-completed' style={styles.completed}>
       <FlexColumn style={{ flex: 0.5 }}>
@@ -535,31 +531,39 @@ const CompletionBanner = ({
           profile.initialCreditsExpirationEpochMillis && (
             <>
               <div style={styles.completedText}>
-                Your credits expire on{' '}
+                You have{' $'}
+                {freeTierUsage
+                  ? freeTierDollarQuota - freeTierUsage
+                  : freeTierDollarQuota}{' '}
+                in initial credits remaining. These credits expire on{' '}
                 {displayDateWithoutHours(
                   profile.initialCreditsExpirationEpochMillis
                 )}
                 .
               </div>
               <div style={styles.completedText}>
-                (You have {initialCreditsValidityPeriodDays} days to use credit
-                after gaining data access. You may request an extension when it
-                gets closer to your credit expiration date, which will extend
-                your credit expiration date to a total of{' '}
-                {initialCreditsExtensionPeriodDays} days from the day you gained
-                data access.)
+                You will need to set up a billing account before your initial
+                credits expire or are fully used in order to avoid a disruption
+                in service.
               </div>
               <div style={styles.completedText}>
-                Learn more{' '}
+                You can learn more about{' '}
                 <LinkButton
                   style={{ display: 'inline' }}
                   onClick={() =>
                     window.open(supportUrls.initialCredits, '_blank')
                   }
                 >
-                  here
-                </LinkButton>
-                .
+                  initial credits
+                </LinkButton>{' '}
+                and setting up your own{' '}
+                <LinkButton
+                  style={{ display: 'inline' }}
+                  onClick={() => window.open(supportUrls.billing, '_blank')}
+                >
+                  billing account
+                </LinkButton>{' '}
+                in the linked articles.
               </div>
             </>
           )}

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -517,7 +517,7 @@ interface CompletionBannerProps {
 const CompletionBanner = ({ profile }: CompletionBannerProps) => {
   const enableInitialCreditsExpiration =
     serverConfigStore.get().config.enableInitialCreditsExpiration;
-  const { freeTierDollarQuota, freeTierUsage } = profile;
+  const { initialCreditsLimit, initialCreditsUsage } = profile;
   return (
     <FlexRow data-test-id='dar-completed' style={styles.completed}>
       <FlexColumn style={{ flex: 0.5 }}>
@@ -532,9 +532,9 @@ const CompletionBanner = ({ profile }: CompletionBannerProps) => {
             <>
               <div style={styles.completedText}>
                 You have{' $'}
-                {freeTierUsage
-                  ? freeTierDollarQuota - freeTierUsage
-                  : freeTierDollarQuota}{' '}
+                {initialCreditsUsage
+                  ? initialCreditsLimit - initialCreditsUsage
+                  : initialCreditsLimit}{' '}
                 in initial credits remaining. These credits expire on{' '}
                 {displayDateWithoutHours(
                   profile.initialCreditsExpirationEpochMillis

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -531,11 +531,9 @@ const CompletionBanner = ({ profile }: CompletionBannerProps) => {
           profile.initialCreditsExpirationEpochMillis && (
             <>
               <div style={styles.completedText}>
-                You have{' $'}
-                {initialCreditsUsage
+                You have ${initialCreditsUsage
                   ? initialCreditsLimit - initialCreditsUsage
-                  : initialCreditsLimit}{' '}
-                in initial credits remaining. These credits expire on{' '}
+                  : initialCreditsLimit} in initial credits remaining. These credits expire on{' '}
                 {displayDateWithoutHours(
                   profile.initialCreditsExpirationEpochMillis
                 )}

--- a/ui/src/app/pages/access/data-access-requirements.tsx
+++ b/ui/src/app/pages/access/data-access-requirements.tsx
@@ -531,9 +531,11 @@ const CompletionBanner = ({ profile }: CompletionBannerProps) => {
           profile.initialCreditsExpirationEpochMillis && (
             <>
               <div style={styles.completedText}>
-                You have ${initialCreditsUsage
+                You have $
+                {initialCreditsUsage
                   ? initialCreditsLimit - initialCreditsUsage
-                  : initialCreditsLimit} in initial credits remaining. These credits expire on{' '}
+                  : initialCreditsLimit}{' '}
+                in initial credits remaining. These credits expire on{' '}
                 {displayDateWithoutHours(
                   profile.initialCreditsExpirationEpochMillis
                 )}


### PR DESCRIPTION
Modified the banner notification that is shown when user's complete their data access requirements.

![image](https://github.com/user-attachments/assets/c61eb399-9c0d-43db-8dc1-89c1678790b5)

Should this banner look different after a user has swapped to their own billing account?

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
