### PR TITLE
[RW=15200][risk=no] Add user id constraint to user initial credits table.

### DIFF
--- a/api/db/changelog/db.changelog-265-add-unique-constraint-user-initial-credits-expiration.xml
+++ b/api/db/changelog/db.changelog-265-add-unique-constraint-user-initial-credits-expiration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="erollins" id="changelog-2024-add-unique-constraint-user-initial-credits-expiration">
+    <!-- Add a unique constraint to user_id in user_initial_credits_expiration table -->
+    <addUniqueConstraint 
+      columnNames="user_id"
+      constraintName="uk_user_initial_credits_expiration_user_id"
+      tableName="user_initial_credits_expiration"/>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -272,6 +272,7 @@
   <include file="changelog/db.changelog-262-add-status-alert-time-range.xml"/>
   <include file="changelog/db.changelog-263-rm-workspace-billing-account-type.xml"/>
   <include file="changelog/db.changelog-264-add-user-disabled-events-table.xml"/>
+  <include file="changelog/db.changelog-265-add-unique-constraint-user-initial-credits-expiration.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`


### PR DESCRIPTION
Added a unique constraint to the the user_id field in the user_initial_credits_expiration table. Duplicate records cause issues with our cron jobs.

To test, try to add two rows to user_initial_credits_expiration with the same user_id in your local database.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
