### PR TITLE
RW-15004 [risk=low] validate.js pre-work part1

### DIFF
--- a/ui/src/app/pages/workspace/workspace-edit-providers.ts
+++ b/ui/src/app/pages/workspace/workspace-edit-providers.ts
@@ -1,0 +1,15 @@
+import { serverConfigStore } from 'app/utils/stores';
+
+export function getDiseaseNames(keyword: string): Promise<Array<string>> {
+  const baseurl = serverConfigStore.get().config.firecloudURL;
+  const url = baseurl + '/duos/autocomplete/' + keyword;
+  return fetch(encodeURI(url))
+    .then((response) => {
+      return response.json();
+    })
+    .then((matches) =>
+      matches
+        .filter((elt) => elt.hasOwnProperty('label'))
+        .map((elt) => elt.label)
+    );
+}

--- a/ui/src/app/pages/workspace/workspace-edit-validation.ts
+++ b/ui/src/app/pages/workspace/workspace-edit-validation.ts
@@ -1,0 +1,93 @@
+import { validate } from 'validate.js';
+
+import {
+  DisseminateResearchEnum,
+  SpecificPopulationEnum,
+  Workspace,
+} from 'generated/fetch';
+
+export type WorkspaceEditValidationArgs = Required<
+  Pick<
+    Workspace['researchPurpose'],
+    | 'aianResearchDetails'
+    | 'aianResearchType'
+    | 'intendedStudy'
+    | 'anticipatedFindings'
+    | 'diseaseFocusedResearch'
+    | 'populationDetails'
+    | 'scientificApproach'
+    | 'reviewRequested'
+    | 'researchOutcomeList'
+    | 'disseminateResearchFindingList'
+    | 'otherPurpose'
+    | 'otherDisseminateResearchFindings'
+    | 'otherPopulationDetails'
+    | 'otherPurposeDetails'
+    | 'diseaseOfFocus'
+  >
+> &
+  Pick<Workspace, 'name' | 'billingAccountName'> & {
+    primaryPurpose: boolean;
+    populationChecked: boolean;
+  };
+
+export const validateWorkspaceEdit = (
+  values: WorkspaceEditValidationArgs,
+  askAboutAIAN: boolean
+) => {
+  const requiredStringWithMaxLength = (maximum: number, prefix = '') => ({
+    presence: {
+      allowEmpty: false,
+      message: `${prefix} cannot be blank`,
+    },
+    length: {
+      maximum,
+      tooLong: `${prefix} cannot exceed %{count} characters`,
+    },
+  });
+
+  // TODO: This validation spec should include error messages which get
+  // surfaced directly. Currently these constraints are entirely separate
+  // from the user facing error strings we render.
+  const constraints: object = {
+    name: requiredStringWithMaxLength(80, 'Name'),
+    // The prefix for these lengthMessages require HTML formatting
+    // The prefix string is omitted here and included in the React template below
+    billingAccountName: { presence: true },
+    intendedStudy: requiredStringWithMaxLength(1000),
+    populationChecked: { presence: true },
+    anticipatedFindings: requiredStringWithMaxLength(1000),
+    reviewRequested: { presence: true },
+    scientificApproach: requiredStringWithMaxLength(1000),
+    researchOutcomeList: { presence: { allowEmpty: false } },
+    disseminateResearchFindingList: { presence: { allowEmpty: false } },
+    primaryPurpose: { truthiness: true },
+
+    // Conditionally include optional fields for validation.
+    otherPurposeDetails: values.otherPurpose
+      ? requiredStringWithMaxLength(500, 'Other primary purpose')
+      : {},
+    populationDetails: values.populationChecked ? { presence: true } : {},
+    otherPopulationDetails: values.populationDetails?.includes(
+      SpecificPopulationEnum.OTHER
+    )
+      ? requiredStringWithMaxLength(100, 'Other Specific Population')
+      : {},
+    diseaseOfFocus: values.diseaseFocusedResearch
+      ? requiredStringWithMaxLength(80, 'Disease of Focus')
+      : {},
+    otherDisseminateResearchFindings:
+      values.disseminateResearchFindingList?.includes(
+        DisseminateResearchEnum.OTHER
+      )
+        ? requiredStringWithMaxLength(
+            100,
+            'Other methods of disseminating research findings'
+          )
+        : {},
+    aianResearchType: askAboutAIAN ? { presence: true } : {},
+    aianResearchDetails: askAboutAIAN ? requiredStringWithMaxLength(1000) : {},
+  };
+
+  return validate(values, constraints, { fullMessages: false });
+};


### PR DESCRIPTION
- pre-work to make zod library introduction easier to review.
- shifted validation realted code out of workplace-edit and into a wokrplace-edit-validation.ts sister-file.
- added unit tests on validation call that will later be used to add more confidence to zod validation repacement.
- also moved data calls to a -providers sister file to aid in improved unit test mocks, and silenced google-analytics unit test noise with a mock.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [x] None of the above apply to this change.
