### PR TITLE
[RW-14979][risk=no] Split WRD upload job into tasks

### DIFF
--- a/api/db/changelog/db.changelog-267-add-reporting-upload-verification-table.xml
+++ b/api/db/changelog/db.changelog-267-add-reporting-upload-verification-table.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="mtalbott" id="changelog-267-add-reporting-upload-verification-table">
+    <createTable tableName="reporting_upload_verification">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="table" type="varchar(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="snapshot_timestamp" type="datetime">
+        <constraints nullable="false"/>
+      </column>
+      <column name="uploaded" type="boolean">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-269-add-reporting-upload-verification-table.xml
+++ b/api/db/changelog/db.changelog-269-add-reporting-upload-verification-table.xml
@@ -9,7 +9,7 @@
       <column name="id" type="bigint" autoIncrement="true">
         <constraints primaryKey="true" nullable="false"/>
       </column>
-      <column name="table" type="varchar(255)">
+      <column name="table_name" type="varchar(255)">
         <constraints nullable="false"/>
       </column>
       <column name="snapshot_timestamp" type="datetime">

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -274,6 +274,7 @@
   <include file="changelog/db.changelog-264-add-user-disabled-events-table.xml"/>
   <include file="changelog/db.changelog-265-add-unique-constraint-user-initial-credits-expiration.xml"/>
   <include file="changelog/db.changelog-266-update-user-initial-credits-expiration-to-365-days.xml"/>
+  <include file="changelog/db.changelog-267-add-reporting-upload-verification-table.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
@@ -5,9 +5,9 @@ import static org.pmiops.workbench.utils.ResponseEntities.noContentRun;
 import org.pmiops.workbench.model.ReportingUploadQueueTaskRequest;
 import org.pmiops.workbench.reporting.ReportingService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
 
-@Service
+@RestController
 public class CloudTaskReportingController implements CloudTaskReportingApiDelegate {
 
   private final ReportingService reportingService;

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
@@ -1,0 +1,24 @@
+package org.pmiops.workbench.api;
+
+import static org.pmiops.workbench.utils.ResponseEntities.noContentRun;
+
+import org.pmiops.workbench.model.ReportingUploadQueueTaskRequest;
+import org.pmiops.workbench.reporting.ReportingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CloudTaskReportingController implements CloudTaskReportingApiDelegate {
+
+  private final ReportingService reportingService;
+
+  public CloudTaskReportingController(ReportingService reportingService) {
+    this.reportingService = reportingService;
+  }
+
+  @Override
+  public ResponseEntity<Void> processReportingUploadQueueTask(
+      ReportingUploadQueueTaskRequest body) {
+    return noContentRun(() -> reportingService.collectRecordsAndUpload(body.getTables(), body.getSnapshotTimestamp().toEpochSecond()));
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
@@ -19,6 +19,9 @@ public class CloudTaskReportingController implements CloudTaskReportingApiDelega
   @Override
   public ResponseEntity<Void> processReportingUploadQueueTask(
       ReportingUploadQueueTaskRequest body) {
-    return noContentRun(() -> reportingService.collectRecordsAndUpload(body.getTables(), body.getSnapshotTimestamp()));
+    return noContentRun(
+        () ->
+            reportingService.collectRecordsAndUpload(
+                body.getTables(), body.getSnapshotTimestamp()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskReportingController.java
@@ -19,6 +19,6 @@ public class CloudTaskReportingController implements CloudTaskReportingApiDelega
   @Override
   public ResponseEntity<Void> processReportingUploadQueueTask(
       ReportingUploadQueueTaskRequest body) {
-    return noContentRun(() -> reportingService.collectRecordsAndUpload(body.getTables(), body.getSnapshotTimestamp().toEpochSecond()));
+    return noContentRun(() -> reportingService.collectRecordsAndUpload(body.getTables(), body.getSnapshotTimestamp()));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineReportingController.java
@@ -17,6 +17,6 @@ public class OfflineReportingController implements OfflineReportingApiDelegate {
 
   @Override
   public ResponseEntity<Void> uploadReportingSnapshot() {
-    return noContentRun(reportingService::collectRecordsAndUpload);
+    return noContentRun(reportingService::splitUploadIntoTasksAndQueue);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -83,6 +83,8 @@ public class TaskQueueService {
   public static final TaskQueuePair VWB_POD_CREATION =
       new TaskQueuePair("vwbPodCreationQueue", "createVwbPod");
 
+  public static final TaskQueuePair REPORTING_UPLOAD = new TaskQueuePair("reportingUploadQueue", "reportingUpload");
+
   private static final Logger LOGGER = Logger.getLogger(TaskQueueService.class.getName());
 
   private final WorkbenchLocationConfigService locationConfigService;
@@ -247,7 +249,7 @@ public class TaskQueueService {
 
   public void pushReportingUploadTask(String table, Long captureSnapshotTime) {
     createAndPushTask(
-        new TaskQueuePair("reportingUploadQueue", "reportingUpload"),
+        REPORTING_UPLOAD,
         new ReportingUploadQueueTaskRequest()
             .tables(List.of(table))
             .snapshotTimestamp(captureSnapshotTime));

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -84,7 +84,7 @@ public class TaskQueueService {
       new TaskQueuePair("vwbPodCreationQueue", "createVwbPod");
 
   public static final TaskQueuePair REPORTING_UPLOAD =
-      new TaskQueuePair("reportingUploadQueue", "reportingUpload");
+      new TaskQueuePair("reportingUploadQueue", "reportingUploadQueue");
 
   private static final Logger LOGGER = Logger.getLogger(TaskQueueService.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -83,7 +83,8 @@ public class TaskQueueService {
   public static final TaskQueuePair VWB_POD_CREATION =
       new TaskQueuePair("vwbPodCreationQueue", "createVwbPod");
 
-  public static final TaskQueuePair REPORTING_UPLOAD = new TaskQueuePair("reportingUploadQueue", "reportingUpload");
+  public static final TaskQueuePair REPORTING_UPLOAD =
+      new TaskQueuePair("reportingUploadQueue", "reportingUpload");
 
   private static final Logger LOGGER = Logger.getLogger(TaskQueueService.class.getName());
 

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -245,6 +245,14 @@ public class TaskQueueService {
         VWB_POD_CREATION, new CreateVwbPodTaskRequest().userName(email));
   }
 
+  public void pushReportingUploadTask(String table, Long captureSnapshotTime) {
+    createAndPushTask(
+        new TaskQueuePair("reportingUploadQueue", "reportingUpload"),
+        new ReportingUploadQueueTaskRequest()
+            .tables(List.of(table))
+            .snapshotTimestamp(captureSnapshotTime));
+  }
+
   private TaskQueuePair withRdrBackfill(TaskQueuePair pair) {
     return new TaskQueuePair(pair.queueName(), pair.endpoint() + "?backfill=true");
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
@@ -1,0 +1,19 @@
+package org.pmiops.workbench.db.dao;
+
+import java.sql.Timestamp;
+import java.util.List;
+import org.pmiops.workbench.db.model.DbReportingUploadVerification;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface ReportingUploadVerificationDao extends CrudRepository<DbReportingUploadVerification, Long> {
+  List<DbReportingUploadVerification> findBySnapshotTimestamp(Timestamp snapshotTimestamp);
+
+  // Update the uploaded status for a specific table and timestamp
+  @Modifying
+  @Query("UPDATE DbReportingUploadVerification r SET r.uploaded = :uploaded WHERE r.tableName = :tableName AND r.snapshotTimestamp = :snapshotTimestamp")
+  int updateUploadedStatus(@Param("tableName") String tableName, @Param("snapshotTimestamp") Timestamp snapshotTimestamp, @Param("uploaded") Boolean uploaded);
+}

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
@@ -16,4 +16,9 @@ public interface ReportingUploadVerificationDao extends CrudRepository<DbReporti
   @Modifying
   @Query("UPDATE DbReportingUploadVerification r SET r.uploaded = :uploaded WHERE r.tableName = :tableName AND r.snapshotTimestamp = :snapshotTimestamp")
   int updateUploadedStatus(@Param("tableName") String tableName, @Param("snapshotTimestamp") Timestamp snapshotTimestamp, @Param("uploaded") Boolean uploaded);
+
+  // Create a new entry for a given table and timestamp
+  @Modifying
+  @Query("INSERT INTO DbReportingUploadVerification (tableName, snapshotTimestamp) VALUES (:tableName, :snapshotTimestamp)")
+  int createVerificationEntry(@Param("tableName") String tableName, @Param("snapshotTimestamp") Timestamp snapshotTimestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
@@ -7,18 +7,25 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
-public interface ReportingUploadVerificationDao extends CrudRepository<DbReportingUploadVerification, Long> {
+public interface ReportingUploadVerificationDao
+    extends CrudRepository<DbReportingUploadVerification, Long> {
   List<DbReportingUploadVerification> findBySnapshotTimestamp(Timestamp snapshotTimestamp);
 
   // Update the uploaded status for a specific table and timestamp
   @Modifying
-  @Query("UPDATE DbReportingUploadVerification r SET r.uploaded = :uploaded WHERE r.tableName = :tableName AND r.snapshotTimestamp = :snapshotTimestamp")
-  int updateUploadedStatus(@Param("tableName") String tableName, @Param("snapshotTimestamp") Timestamp snapshotTimestamp, @Param("uploaded") Boolean uploaded);
+  @Query(
+      "UPDATE DbReportingUploadVerification r SET r.uploaded = :uploaded WHERE r.tableName = :tableName AND r.snapshotTimestamp = :snapshotTimestamp")
+  int updateUploadedStatus(
+      @Param("tableName") String tableName,
+      @Param("snapshotTimestamp") Timestamp snapshotTimestamp,
+      @Param("uploaded") Boolean uploaded);
 
   // Create a new entry for a given table and timestamp
   @Modifying
-  @Query("INSERT INTO DbReportingUploadVerification (tableName, snapshotTimestamp) VALUES (:tableName, :snapshotTimestamp)")
-  int createVerificationEntry(@Param("tableName") String tableName, @Param("snapshotTimestamp") Timestamp snapshotTimestamp);
+  @Query(
+      "INSERT INTO DbReportingUploadVerification (tableName, snapshotTimestamp) VALUES (:tableName, :snapshotTimestamp)")
+  int createVerificationEntry(
+      @Param("tableName") String tableName,
+      @Param("snapshotTimestamp") Timestamp snapshotTimestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
@@ -1,0 +1,61 @@
+package org.pmiops.workbench.db.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "reporting_upload_verification")
+public class DbReportingUploadVerification {
+
+  private long id;
+  private String tableName;
+  private Timestamp snapshotTimestamp;
+  private Boolean uploaded;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  public long getId() {
+    return id;
+  }
+
+  public DbReportingUploadVerification setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  @Column(name = "table", nullable = false)
+  public String getTableName() {
+    return tableName;
+  }
+
+  public DbReportingUploadVerification setTableName(String tableName) {
+    this.tableName = tableName;
+    return this;
+  }
+
+  @Column(name = "snapshot_timestamp", nullable = false)
+  public Timestamp getSnapshotTimestamp() {
+    return snapshotTimestamp;
+  }
+
+  public DbReportingUploadVerification setSnapshotTimestamp(Timestamp snapshotTimestamp) {
+    this.snapshotTimestamp = snapshotTimestamp;
+    return this;
+  }
+
+  @Column(name = "uploaded")
+  public Boolean getUploaded() {
+    return uploaded;
+  }
+
+  public DbReportingUploadVerification setUploaded(Boolean uploaded) {
+    this.uploaded = uploaded;
+    return this;
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
@@ -29,7 +29,7 @@ public class DbReportingUploadVerification {
     return this;
   }
 
-  @Column(name = "table", nullable = false)
+  @Column(name = "table_name", nullable = false)
   public String getTableName() {
     return tableName;
   }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
@@ -10,5 +10,7 @@ import java.util.List;
 public interface ReportingService {
   void collectRecordsAndUpload();
 
+  void splitUploadIntoTasksAndQueue();
+
   void collectRecordsAndUpload(List<String> tables, long captureTimestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingService.java
@@ -1,5 +1,7 @@
 package org.pmiops.workbench.reporting;
 
+import java.util.List;
+
 /*
  * Captures a snapshot of analyst-facing data and uploads it to a dataset in BigQuery for this
  * GCP project. The tables are associated with a timestamp to distinguish periodic (most likely
@@ -7,4 +9,6 @@ package org.pmiops.workbench.reporting;
  */
 public interface ReportingService {
   void collectRecordsAndUpload();
+
+  void collectRecordsAndUpload(List<String> tables, long captureTimestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -95,6 +95,8 @@ public class ReportingServiceImpl implements ReportingService {
             });
   }
 
+  // Upload data in batches for specified tables, verify the counts, and try to mark this snapshot valid.
+  // If there are still tables that have not been uploaded successfully, the snapshot will not be marked valid.
   @Transactional(isolation = Isolation.SERIALIZABLE)
   @Override
   public void collectRecordsAndUpload(List<String> tables, long captureTimestamp) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -85,10 +85,14 @@ public class ReportingServiceImpl implements ReportingService {
   public void splitUploadIntoTasksAndQueue() {
     final long captureTimestamp = clock.millis();
 
-    reportingTableService.getAll().forEach(tableParams -> {
-      reportingUploadVerificationDao.createVerificationEntry(tableParams.bqTableName(), new Timestamp(captureTimestamp));
-      taskQueueService.pushReportingUploadTask(tableParams.bqTableName(), captureTimestamp);
-    });
+    reportingTableService
+        .getAll()
+        .forEach(
+            tableParams -> {
+              reportingUploadVerificationDao.createVerificationEntry(
+                  tableParams.bqTableName(), new Timestamp(captureTimestamp));
+              taskQueueService.pushReportingUploadTask(tableParams.bqTableName(), captureTimestamp);
+            });
   }
 
   @Transactional(isolation = Isolation.SERIALIZABLE)
@@ -103,7 +107,9 @@ public class ReportingServiceImpl implements ReportingService {
     if (batchUploadSuccess) {
       reportingUploadService.uploadVerifiedSnapshot(captureTimestamp);
     } else {
-      logger.info("Some tables have not been uploaded successfully yet for snapshot at " + captureTimestamp);
+      logger.info(
+          "Some tables have not been uploaded successfully yet for snapshot at "
+              + captureTimestamp);
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -95,8 +95,9 @@ public class ReportingServiceImpl implements ReportingService {
             });
   }
 
-  // Upload data in batches for specified tables, verify the counts, and try to mark this snapshot valid.
-  // If there are still tables that have not been uploaded successfully, the snapshot will not be marked valid.
+  // Upload data in batches for specified tables, verify the counts, and check to see if all tables
+  // in snapshot have successfully uploaded. If they have, mark snapshot as valid. If they haven't,
+  // do nothing
   @Transactional(isolation = Isolation.SERIALIZABLE)
   @Override
   public void collectRecordsAndUpload(List<String> tables, long captureTimestamp) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
@@ -90,6 +90,13 @@ public class ReportingTableService {
         workspaceFreeTierUsage());
   }
 
+  public List<ReportingTableParams<? extends ReportingBase>> getAll(
+      List<String> tableNames) {
+    return getAll().stream()
+        .filter(table -> tableNames.contains(table.bqTableName()))
+        .toList();
+  }
+
   private int batchSize(String bqTableName) {
     ReportingConfig config = workbenchConfigProvider.get().reporting;
     int wantedSize =

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
@@ -90,11 +90,8 @@ public class ReportingTableService {
         workspaceFreeTierUsage());
   }
 
-  public List<ReportingTableParams<? extends ReportingBase>> getAll(
-      List<String> tableNames) {
-    return getAll().stream()
-        .filter(table -> tableNames.contains(table.bqTableName()))
-        .toList();
+  public List<ReportingTableParams<? extends ReportingBase>> getAll(List<String> tableNames) {
+    return getAll().stream().filter(table -> tableNames.contains(table.bqTableName())).toList();
   }
 
   private int batchSize(String bqTableName) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
@@ -93,7 +93,9 @@ public class ReportingTableService {
 
   public List<ReportingTableParams<? extends ReportingBase>> getAll(List<String> tableNames) {
     var lowerCaseTables = tableNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
-    return getAll().stream().filter(table -> lowerCaseTables.contains(table.bqTableName().toLowerCase())).toList();
+    return getAll().stream()
+        .filter(table -> lowerCaseTables.contains(table.bqTableName().toLowerCase()))
+        .toList();
   }
 
   private int batchSize(String bqTableName) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingTableService.java
@@ -6,6 +6,7 @@ import jakarta.inject.Provider;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.ReportingConfig;
 import org.pmiops.workbench.db.jdbc.ReportingQueryService;
@@ -91,7 +92,8 @@ public class ReportingTableService {
   }
 
   public List<ReportingTableParams<? extends ReportingBase>> getAll(List<String> tableNames) {
-    return getAll().stream().filter(table -> tableNames.contains(table.bqTableName())).toList();
+    var lowerCaseTables = tableNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    return getAll().stream().filter(table -> lowerCaseTables.contains(table.bqTableName().toLowerCase())).toList();
   }
 
   private int batchSize(String bqTableName) {

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
@@ -6,7 +6,9 @@ public interface ReportingVerificationService {
   /** Verifies batched uploaded result for each table. Returns {@code true} if all are verified. */
   boolean verifyBatchesAndLog(long captureSnapshotTime);
 
+  /** Verifies batched uploaded result specified tables. */
   void verifyBatchesAndLog(List<String> tables, long captureSnapshotTime);
 
+  /** Verifies all tables associated with captureSnapshotTime uploaded successfully. Returns {@code true} if all are verified. */
   boolean verifySnapshot(long captureSnapshotTime);
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
@@ -1,6 +1,12 @@
 package org.pmiops.workbench.reporting;
 
+import java.util.List;
+
 public interface ReportingVerificationService {
   /** Verifies batched uploaded result for each table. Returns {@code true} if all are verified. */
   boolean verifyBatchesAndLog(long captureSnapshotTime);
+
+  void verifyBatchesAndLog(List<String> tables, long captureSnapshotTime);
+
+  boolean verifySnapshot(long captureSnapshotTime);
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationService.java
@@ -9,6 +9,9 @@ public interface ReportingVerificationService {
   /** Verifies batched uploaded result specified tables. */
   void verifyBatchesAndLog(List<String> tables, long captureSnapshotTime);
 
-  /** Verifies all tables associated with captureSnapshotTime uploaded successfully. Returns {@code true} if all are verified. */
+  /**
+   * Verifies all tables associated with captureSnapshotTime uploaded successfully. Returns {@code
+   * true} if all are verified.
+   */
   boolean verifySnapshot(long captureSnapshotTime);
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -82,9 +82,16 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
   public boolean verifySnapshot(long captureSnapshotTime) {
     var tablesInSnapshot =
         reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(captureSnapshotTime));
-    return !tablesInSnapshot.isEmpty()
-        && // todo: may want to throw if no tables are found for a given snapshot
-        tablesInSnapshot.stream().allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
+    if (tablesInSnapshot.isEmpty()) {
+      // This really shouldn't happen, but if it does, we return false to avoid uploading a falsely verified snapshot.
+      logger.warning(
+          String.format(
+              "No tables found for snapshot at %d. Cannot verify snapshot.",
+              captureSnapshotTime));
+      return false;
+    } else {
+      return tablesInSnapshot.stream().allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
+    }
   }
 
   /** Verifies source count equals to destination count. Returns {@code true} of match. */

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -83,14 +83,15 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
     var tablesInSnapshot =
         reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(captureSnapshotTime));
     if (tablesInSnapshot.isEmpty()) {
-      // This really shouldn't happen, but if it does, we return false to avoid uploading a falsely verified snapshot.
+      // This really shouldn't happen, but if it does, we return false to avoid uploading a falsely
+      // verified snapshot.
       logger.warning(
           String.format(
-              "No tables found for snapshot at %d. Cannot verify snapshot.",
-              captureSnapshotTime));
+              "No tables found for snapshot at %d. Cannot verify snapshot.", captureSnapshotTime));
       return false;
     } else {
-      return tablesInSnapshot.stream().allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
+      return tablesInSnapshot.stream()
+          .allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -4,10 +4,14 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.common.collect.Streams;
 import jakarta.inject.Provider;
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.pmiops.workbench.api.BigQueryService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.ReportingUploadVerificationDao;
+import org.pmiops.workbench.db.model.DbReportingUploadVerification;
 import org.pmiops.workbench.utils.FieldValues;
 import org.springframework.stereotype.Service;
 
@@ -19,14 +23,17 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
   private final BigQueryService bigQueryService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
   private final ReportingTableService reportingTableService;
+  private final ReportingUploadVerificationDao reportingUploadVerificationDao;
 
   public ReportingVerificationServiceImpl(
       BigQueryService bigQueryService,
       Provider<WorkbenchConfig> workbenchConfigProvider,
-      ReportingTableService reportingTableService) {
+      ReportingTableService reportingTableService,
+      ReportingUploadVerificationDao reportingUploadVerificationDao) {
     this.bigQueryService = bigQueryService;
     this.workbenchConfigProvider = workbenchConfigProvider;
     this.reportingTableService = reportingTableService;
+    this.reportingUploadVerificationDao = reportingUploadVerificationDao;
   }
 
   @Override
@@ -49,6 +56,32 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
 
     logger.log(verified ? Level.INFO : Level.WARNING, sb.toString());
     return verified;
+  }
+
+  @Override
+  public void verifyBatchesAndLog(List<String> tables, long captureSnapshotTime) {
+    final StringBuilder sb =
+        new StringBuilder(String.format("Verifying batches at %d:\n", captureSnapshotTime));
+
+    sb.append("Table\tSource\tDestination\tDifference(%)\n");
+
+    reportingTableService.getAll(tables)
+        .forEach(
+            table -> {
+              final String bqTableName = table.bqTableName();
+              long sourceCount = table.rwbTableCountFn().getAsInt();
+              long destCount = getBigQueryRowCount(bqTableName, captureSnapshotTime);
+              boolean uploadOutcome = verifyCount(bqTableName, sourceCount, destCount, sb);
+              reportingUploadVerificationDao.updateUploadedStatus(bqTableName, new Timestamp(captureSnapshotTime), uploadOutcome);
+            });
+  }
+
+  @Override
+  public boolean verifySnapshot(long captureSnapshotTime) {
+    var tablesInSnapshot = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(captureSnapshotTime));
+    return !tablesInSnapshot.isEmpty() &&
+        tablesInSnapshot.stream()
+            .allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
   }
 
   /** Verifies source count equals to destination count. Returns {@code true} of match. */

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -74,12 +74,13 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
               boolean uploadOutcome = verifyCount(bqTableName, sourceCount, destCount, sb);
               reportingUploadVerificationDao.updateUploadedStatus(bqTableName, new Timestamp(captureSnapshotTime), uploadOutcome);
             });
+    logger.log(Level.INFO, sb.toString());
   }
 
   @Override
   public boolean verifySnapshot(long captureSnapshotTime) {
     var tablesInSnapshot = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(captureSnapshotTime));
-    return !tablesInSnapshot.isEmpty() &&
+    return !tablesInSnapshot.isEmpty() && // todo: may want to throw if no tables are found for a given snapshot
         tablesInSnapshot.stream()
             .allMatch(record -> Boolean.TRUE.equals(record.getUploaded()));
   }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -13436,9 +13436,9 @@ components:
             type: string
           description: The names of the tables to be uploaded
         snapshotTimestamp:
-          type: string
-          description: The timestamp of the snapshot to be uploaded, in ISO 8601 format
-          format: date-time
+          type: integer
+          format: int64
+          description: The timestamp of the snapshot to be uploaded, in milliseconds
 
   parameters:
     userId:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4561,6 +4561,26 @@ paths:
           description: Vwb Pod created
           content: {}
       x-codegen-request-body-name: request
+  /v1/cloudTask/reportingUploadQueue:
+    post:
+      tags:
+      - cloudTaskReporting
+      - cloudTask
+      description: |
+        Asynchronously uploads reporting data to the reporting service.
+      operationId: processReportingUploadQueueTask
+      requestBody:
+        description: Reporting upload task to process.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportingUploadQueueTaskRequest'
+        required: true
+      responses:
+        200:
+          description: Reporting data uploaded successfully
+          content: {}
+      x-codegen-request-body-name: request
   /v1/institutions:
     get:
       tags:
@@ -13407,6 +13427,18 @@ components:
         userName:
           type: string
           description: The user name of the user who is creating the pod
+    ReportingUploadQueueTaskRequest:
+      type: object
+      properties:
+        tables:
+          type: array
+          items:
+            type: string
+          description: The names of the tables to be uploaded
+        snapshotTimestamp:
+          type: string
+          description: The timestamp of the snapshot to be uploaded, in ISO 8601 format
+          format: date-time
 
   parameters:
     userId:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4569,6 +4569,7 @@ paths:
       description: |
         Asynchronously uploads reporting data to the reporting service.
       operationId: processReportingUploadQueueTask
+      security: [ ]
       requestBody:
         description: Reporting upload task to process.
         content:

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -168,3 +168,11 @@ queue:
   retry_parameters:
     task_retry_limit: 3
     task_age_limit: 5m
+
+- name: reportingUploadQueue
+  target: api
+
+  # rate parameters
+  bucket_size: 10
+  rate: 1/s
+  max_concurrent_requests: 1

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskReportingControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskReportingControllerTest.java
@@ -1,0 +1,80 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.model.ReportingUploadQueueTaskRequest;
+import org.pmiops.workbench.reporting.ReportingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class CloudTaskReportingControllerTest {
+
+  @Mock
+  private ReportingService mockReportingService;
+
+  private CloudTaskReportingController controller;
+  private static final long SNAPSHOT_TIMESTAMP = 1640995200000L; // 2022-01-01T00:00:00.000Z
+
+  @BeforeEach
+  void setUp() {
+    controller = new CloudTaskReportingController(mockReportingService);
+  }
+
+  @Test
+  void processReportingUploadQueueTask_withValidRequest_callsServiceAndReturnsNoContent() {
+    //Arrange
+    List<String> tables = Arrays.asList("table1", "table2", "table3");
+
+    ReportingUploadQueueTaskRequest request = new ReportingUploadQueueTaskRequest();
+    request.setTables(tables);
+    request.setSnapshotTimestamp(SNAPSHOT_TIMESTAMP);
+
+    doNothing().when(mockReportingService).collectRecordsAndUpload(tables, SNAPSHOT_TIMESTAMP);
+
+    //Act
+    ResponseEntity<Void> response = controller.processReportingUploadQueueTask(request);
+
+    //Assert
+    assertValidResponse(response);
+    verify(mockReportingService).collectRecordsAndUpload(eq(tables), eq(SNAPSHOT_TIMESTAMP));
+    verifyNoMoreInteractions(mockReportingService);
+  }
+
+  @Test
+  void processReportingUploadQueueTask_withEmptyTablesList_callsServiceWithEmptyList() {
+    // Arrange
+    List<String> emptyTables = Collections.emptyList();
+    ReportingUploadQueueTaskRequest request = new ReportingUploadQueueTaskRequest();
+    request.setTables(emptyTables);
+    request.setSnapshotTimestamp(SNAPSHOT_TIMESTAMP);
+
+    doNothing().when(mockReportingService).collectRecordsAndUpload(emptyTables, SNAPSHOT_TIMESTAMP);
+
+    // Act
+    ResponseEntity<Void> response = controller.processReportingUploadQueueTask(request);
+
+    // Assert
+    assertValidResponse(response);
+    verify(mockReportingService).collectRecordsAndUpload(eq(emptyTables), eq(SNAPSHOT_TIMESTAMP));
+    verifyNoMoreInteractions(mockReportingService);
+  }
+
+  private void assertValidResponse(ResponseEntity<Void> response) {
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(response.getBody()).isNull();
+  }
+
+}

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskReportingControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskReportingControllerTest.java
@@ -22,8 +22,7 @@ import org.springframework.http.ResponseEntity;
 @ExtendWith(MockitoExtension.class)
 class CloudTaskReportingControllerTest {
 
-  @Mock
-  private ReportingService mockReportingService;
+  @Mock private ReportingService mockReportingService;
 
   private CloudTaskReportingController controller;
   private static final long SNAPSHOT_TIMESTAMP = 1640995200000L; // 2022-01-01T00:00:00.000Z
@@ -35,7 +34,7 @@ class CloudTaskReportingControllerTest {
 
   @Test
   void processReportingUploadQueueTask_withValidRequest_callsServiceAndReturnsNoContent() {
-    //Arrange
+    // Arrange
     List<String> tables = Arrays.asList("table1", "table2", "table3");
 
     ReportingUploadQueueTaskRequest request = new ReportingUploadQueueTaskRequest();
@@ -44,10 +43,10 @@ class CloudTaskReportingControllerTest {
 
     doNothing().when(mockReportingService).collectRecordsAndUpload(tables, SNAPSHOT_TIMESTAMP);
 
-    //Act
+    // Act
     ResponseEntity<Void> response = controller.processReportingUploadQueueTask(request);
 
-    //Assert
+    // Assert
     assertValidResponse(response);
     verify(mockReportingService).collectRecordsAndUpload(eq(tables), eq(SNAPSHOT_TIMESTAMP));
     verifyNoMoreInteractions(mockReportingService);
@@ -76,5 +75,4 @@ class CloudTaskReportingControllerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     assertThat(response.getBody()).isNull();
   }
-
 }

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
@@ -53,8 +53,6 @@ public class ReportingServiceTest {
             mockReportingVerificationService,
             mockReportingUploadVerificationDao,
             mockTaskQueueService);
-
-    when(mockClock.millis()).thenReturn(NOW_MILLIS);
   }
 
   @Test
@@ -63,6 +61,7 @@ public class ReportingServiceTest {
     ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
 
     when(mockReportingTableService.getAll()).thenReturn(List.of(cohortTableParams));
+    when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
@@ -96,6 +95,7 @@ public class ReportingServiceTest {
 
     when(mockReportingTableService.getAll())
         .thenReturn(List.of(cohortTableParams, userTableParams));
+    when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
@@ -133,6 +133,7 @@ public class ReportingServiceTest {
   public void testSplitUploadIntoTasksAndQueue_emptyTableList() {
     // Arrange
     when(mockReportingTableService.getAll()).thenReturn(List.of());
+    when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
@@ -153,6 +154,7 @@ public class ReportingServiceTest {
 
     when(mockReportingTableService.getAll())
         .thenReturn(List.of(cohortTableParams, userTableParams));
+    when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
@@ -181,8 +183,8 @@ public class ReportingServiceTest {
     List<String> tables = List.of("cohort", "user");
     long captureTimestamp = 1640995200000L;
 
-    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
-    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
+    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort", false);
+    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user", false);
 
     when(mockReportingTableService.getAll(tables))
         .thenReturn(List.of(cohortTableParams, userTableParams));
@@ -204,8 +206,8 @@ public class ReportingServiceTest {
     List<String> tables = List.of("cohort", "user");
     long captureTimestamp = 1640995200000L;
 
-    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
-    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
+    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort", false);
+    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user", false);
 
     when(mockReportingTableService.getAll(tables))
         .thenReturn(List.of(cohortTableParams, userTableParams));
@@ -244,9 +246,17 @@ public class ReportingServiceTest {
   /** Helper method to create a mock ReportingTableParams with the specified table name. */
   @SuppressWarnings("unchecked")
   private <T extends ReportingBase> ReportingTableParams<T> createMockTableParams(
-      String tableName) {
+      String tableName, boolean stubBqTableName) {
     ReportingTableParams<T> tableParams = mock(ReportingTableParams.class);
-    when(tableParams.bqTableName()).thenReturn(tableName);
+    if (stubBqTableName) {
+      when(tableParams.bqTableName()).thenReturn(tableName);
+    }
     return tableParams;
+  }
+
+  /** Helper method to create a mock ReportingTableParams with bqTableName stubbed. */
+  private <T extends ReportingBase> ReportingTableParams<T> createMockTableParams(
+      String tableName) {
+    return createMockTableParams(tableName, true);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
@@ -183,7 +183,8 @@ public class ReportingServiceTest {
     List<String> tables = List.of("cohort", "user");
     long captureTimestamp = 1640995200000L;
 
-    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort", false);
+    ReportingTableParams<ReportingCohort> cohortTableParams =
+        createMockTableParams("cohort", false);
     ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user", false);
 
     when(mockReportingTableService.getAll(tables))
@@ -206,7 +207,8 @@ public class ReportingServiceTest {
     List<String> tables = List.of("cohort", "user");
     long captureTimestamp = 1640995200000L;
 
-    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort", false);
+    ReportingTableParams<ReportingCohort> cohortTableParams =
+        createMockTableParams("cohort", false);
     ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user", false);
 
     when(mockReportingTableService.getAll(tables))

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
@@ -1,0 +1,189 @@
+package org.pmiops.workbench.reporting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.cloudtasks.TaskQueueService;
+import org.pmiops.workbench.db.dao.ReportingUploadVerificationDao;
+import org.pmiops.workbench.db.jdbc.ReportingQueryService;
+import org.pmiops.workbench.model.ReportingBase;
+import org.pmiops.workbench.model.ReportingCohort;
+import org.pmiops.workbench.model.ReportingUser;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportingServiceTest {
+
+  private static final Instant NOW = Instant.parse("2023-06-15T10:15:30.00Z");
+  private static final long NOW_MILLIS = NOW.toEpochMilli();
+
+  @Mock private Clock mockClock;
+  @Mock private ReportingTableService mockReportingTableService;
+  @Mock private ReportingQueryService mockReportingQueryService;
+  @Mock private ReportingUploadService mockReportingUploadService;
+  @Mock private ReportingVerificationService mockReportingVerificationService;
+  @Mock private ReportingUploadVerificationDao mockReportingUploadVerificationDao;
+  @Mock private TaskQueueService mockTaskQueueService;
+
+  private ReportingServiceImpl reportingService;
+
+  @BeforeEach
+  public void setUp() {
+    reportingService = new ReportingServiceImpl(
+        mockClock,
+        mockReportingTableService,
+        mockReportingQueryService,
+        mockReportingUploadService,
+        mockReportingVerificationService,
+        mockReportingUploadVerificationDao,
+        mockTaskQueueService);
+
+    when(mockClock.millis()).thenReturn(NOW_MILLIS);
+  }
+
+  @Test
+  public void testSplitUploadIntoTasksAndQueue_singleTable() {
+    // Arrange
+    ReportingTableParams<ReportingCohort> cohortTableParams =
+        createMockTableParams("cohort");
+
+    when(mockReportingTableService.getAll()).thenReturn(List.of(cohortTableParams));
+
+    // Act
+    reportingService.splitUploadIntoTasksAndQueue();
+
+    // Assert
+    verify(mockClock).millis();
+    verify(mockReportingTableService).getAll();
+
+    // Verify verification entry is created for the cohort table
+    ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    verify(mockReportingUploadVerificationDao).createVerificationEntry(
+        tableNameCaptor.capture(), timestampCaptor.capture());
+    assertThat(tableNameCaptor.getValue()).isEqualTo("cohort");
+    assertThat(timestampCaptor.getValue()).isEqualTo(new Timestamp(NOW_MILLIS));
+
+    // Verify task is queued for the cohort table
+    ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(mockTaskQueueService).pushReportingUploadTask(
+        taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
+    assertThat(taskTableNameCaptor.getValue()).isEqualTo("cohort");
+    assertThat(taskTimestampCaptor.getValue()).isEqualTo(NOW_MILLIS);
+  }
+
+  @Test
+  public void testSplitUploadIntoTasksAndQueue_multipleTables() {
+    // Arrange
+    ReportingTableParams<ReportingCohort> cohortTableParams =
+        createMockTableParams("cohort");
+    ReportingTableParams<ReportingUser> userTableParams =
+        createMockTableParams("user");
+
+    when(mockReportingTableService.getAll()).thenReturn(
+        List.of(cohortTableParams, userTableParams));
+
+    // Act
+    reportingService.splitUploadIntoTasksAndQueue();
+
+    // Assert
+    verify(mockClock).millis();
+    verify(mockReportingTableService).getAll();
+
+    // Verify verification entries are created for both tables
+    ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    verify(mockReportingUploadVerificationDao, times(2)).createVerificationEntry(
+        tableNameCaptor.capture(), timestampCaptor.capture());
+    List<String> capturedTableNames = tableNameCaptor.getAllValues();
+    assertThat(capturedTableNames).containsExactly("cohort", "user");
+    List<Timestamp> capturedTimestamps = timestampCaptor.getAllValues();
+    assertThat(capturedTimestamps).hasSize(2);
+    assertThat(capturedTimestamps.get(0)).isEqualTo(new Timestamp(NOW_MILLIS));
+    assertThat(capturedTimestamps.get(1)).isEqualTo(new Timestamp(NOW_MILLIS));
+
+    // Verify tasks are queued for both tables
+    ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(mockTaskQueueService, times(2)).pushReportingUploadTask(
+        taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
+    List<String> capturedTaskTableNames = taskTableNameCaptor.getAllValues();
+    assertThat(capturedTaskTableNames).containsExactly("cohort", "user");
+    List<Long> capturedTaskTimestamps = taskTimestampCaptor.getAllValues();
+    assertThat(capturedTaskTimestamps).hasSize(2);
+    assertThat(capturedTaskTimestamps.get(0)).isEqualTo(NOW_MILLIS);
+    assertThat(capturedTaskTimestamps.get(1)).isEqualTo(NOW_MILLIS);
+  }
+
+  @Test
+  public void testSplitUploadIntoTasksAndQueue_emptyTableList() {
+    // Arrange
+    when(mockReportingTableService.getAll()).thenReturn(List.of());
+
+    // Act
+    reportingService.splitUploadIntoTasksAndQueue();
+
+    // Assert
+    verify(mockClock).millis();
+    verify(mockReportingTableService).getAll();
+    // Verify no verification entries or tasks are created
+    verify(mockReportingUploadVerificationDao, times(0)).createVerificationEntry(any(), any());
+    verify(mockTaskQueueService, times(0)).pushReportingUploadTask(any(), any());
+  }
+
+  @Test
+  public void testSplitUploadIntoTasksAndQueue_captureTimestampConsistency() {
+    // Arrange
+    ReportingTableParams<ReportingCohort> cohortTableParams =
+        createMockTableParams("cohort");
+    ReportingTableParams<ReportingUser> userTableParams =
+        createMockTableParams("user");
+
+    when(mockReportingTableService.getAll()).thenReturn(
+        List.of(cohortTableParams, userTableParams));
+
+    // Act
+    reportingService.splitUploadIntoTasksAndQueue();
+
+    // Assert
+    // Verify that the same timestamp is used for all verification entries and tasks
+    ArgumentCaptor<Timestamp> verificationTimestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    verify(mockReportingUploadVerificationDao, times(2)).createVerificationEntry(
+        any(), verificationTimestampCaptor.capture());
+
+    ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(mockTaskQueueService, times(2)).pushReportingUploadTask(
+        any(), taskTimestampCaptor.capture());
+
+    // All timestamps should be the same
+    List<Long> verificationTimestamps = verificationTimestampCaptor.getAllValues().stream().map(Timestamp::getTime).toList();
+    List<Long> taskTimestamps = taskTimestampCaptor.getAllValues();
+    assertEquals(new HashSet<>(verificationTimestamps), new HashSet<>(taskTimestamps));
+  }
+
+  /**
+   * Helper method to create a mock ReportingTableParams with the specified table name.
+   */
+  @SuppressWarnings("unchecked")
+  private <T extends ReportingBase> ReportingTableParams<T> createMockTableParams(String tableName) {
+    ReportingTableParams<T> tableParams = mock(ReportingTableParams.class);
+    when(tableParams.bqTableName()).thenReturn(tableName);
+    return tableParams;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
@@ -44,14 +44,15 @@ public class ReportingServiceTest {
 
   @BeforeEach
   public void setUp() {
-    reportingService = new ReportingServiceImpl(
-        mockClock,
-        mockReportingTableService,
-        mockReportingQueryService,
-        mockReportingUploadService,
-        mockReportingVerificationService,
-        mockReportingUploadVerificationDao,
-        mockTaskQueueService);
+    reportingService =
+        new ReportingServiceImpl(
+            mockClock,
+            mockReportingTableService,
+            mockReportingQueryService,
+            mockReportingUploadService,
+            mockReportingVerificationService,
+            mockReportingUploadVerificationDao,
+            mockTaskQueueService);
 
     when(mockClock.millis()).thenReturn(NOW_MILLIS);
   }
@@ -59,8 +60,7 @@ public class ReportingServiceTest {
   @Test
   public void testSplitUploadIntoTasksAndQueue_singleTable() {
     // Arrange
-    ReportingTableParams<ReportingCohort> cohortTableParams =
-        createMockTableParams("cohort");
+    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
 
     when(mockReportingTableService.getAll()).thenReturn(List.of(cohortTableParams));
 
@@ -74,16 +74,16 @@ public class ReportingServiceTest {
     // Verify verification entry is created for the cohort table
     ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
-    verify(mockReportingUploadVerificationDao).createVerificationEntry(
-        tableNameCaptor.capture(), timestampCaptor.capture());
+    verify(mockReportingUploadVerificationDao)
+        .createVerificationEntry(tableNameCaptor.capture(), timestampCaptor.capture());
     assertThat(tableNameCaptor.getValue()).isEqualTo("cohort");
     assertThat(timestampCaptor.getValue()).isEqualTo(new Timestamp(NOW_MILLIS));
 
     // Verify task is queued for the cohort table
     ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(mockTaskQueueService).pushReportingUploadTask(
-        taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
+    verify(mockTaskQueueService)
+        .pushReportingUploadTask(taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
     assertThat(taskTableNameCaptor.getValue()).isEqualTo("cohort");
     assertThat(taskTimestampCaptor.getValue()).isEqualTo(NOW_MILLIS);
   }
@@ -91,13 +91,11 @@ public class ReportingServiceTest {
   @Test
   public void testSplitUploadIntoTasksAndQueue_multipleTables() {
     // Arrange
-    ReportingTableParams<ReportingCohort> cohortTableParams =
-        createMockTableParams("cohort");
-    ReportingTableParams<ReportingUser> userTableParams =
-        createMockTableParams("user");
+    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
+    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
 
-    when(mockReportingTableService.getAll()).thenReturn(
-        List.of(cohortTableParams, userTableParams));
+    when(mockReportingTableService.getAll())
+        .thenReturn(List.of(cohortTableParams, userTableParams));
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
@@ -109,8 +107,8 @@ public class ReportingServiceTest {
     // Verify verification entries are created for both tables
     ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
-    verify(mockReportingUploadVerificationDao, times(2)).createVerificationEntry(
-        tableNameCaptor.capture(), timestampCaptor.capture());
+    verify(mockReportingUploadVerificationDao, times(2))
+        .createVerificationEntry(tableNameCaptor.capture(), timestampCaptor.capture());
     List<String> capturedTableNames = tableNameCaptor.getAllValues();
     assertThat(capturedTableNames).containsExactly("cohort", "user");
     List<Timestamp> capturedTimestamps = timestampCaptor.getAllValues();
@@ -121,8 +119,8 @@ public class ReportingServiceTest {
     // Verify tasks are queued for both tables
     ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(mockTaskQueueService, times(2)).pushReportingUploadTask(
-        taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
+    verify(mockTaskQueueService, times(2))
+        .pushReportingUploadTask(taskTableNameCaptor.capture(), taskTimestampCaptor.capture());
     List<String> capturedTaskTableNames = taskTableNameCaptor.getAllValues();
     assertThat(capturedTaskTableNames).containsExactly("cohort", "user");
     List<Long> capturedTaskTimestamps = taskTimestampCaptor.getAllValues();
@@ -150,29 +148,29 @@ public class ReportingServiceTest {
   @Test
   public void testSplitUploadIntoTasksAndQueue_captureTimestampConsistency() {
     // Arrange
-    ReportingTableParams<ReportingCohort> cohortTableParams =
-        createMockTableParams("cohort");
-    ReportingTableParams<ReportingUser> userTableParams =
-        createMockTableParams("user");
+    ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
+    ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
 
-    when(mockReportingTableService.getAll()).thenReturn(
-        List.of(cohortTableParams, userTableParams));
+    when(mockReportingTableService.getAll())
+        .thenReturn(List.of(cohortTableParams, userTableParams));
 
     // Act
     reportingService.splitUploadIntoTasksAndQueue();
 
     // Assert
     // Verify that the same timestamp is used for all verification entries and tasks
-    ArgumentCaptor<Timestamp> verificationTimestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
-    verify(mockReportingUploadVerificationDao, times(2)).createVerificationEntry(
-        any(), verificationTimestampCaptor.capture());
+    ArgumentCaptor<Timestamp> verificationTimestampCaptor =
+        ArgumentCaptor.forClass(Timestamp.class);
+    verify(mockReportingUploadVerificationDao, times(2))
+        .createVerificationEntry(any(), verificationTimestampCaptor.capture());
 
     ArgumentCaptor<Long> taskTimestampCaptor = ArgumentCaptor.forClass(Long.class);
-    verify(mockTaskQueueService, times(2)).pushReportingUploadTask(
-        any(), taskTimestampCaptor.capture());
+    verify(mockTaskQueueService, times(2))
+        .pushReportingUploadTask(any(), taskTimestampCaptor.capture());
 
     // All timestamps should be the same
-    List<Long> verificationTimestamps = verificationTimestampCaptor.getAllValues().stream().map(Timestamp::getTime).toList();
+    List<Long> verificationTimestamps =
+        verificationTimestampCaptor.getAllValues().stream().map(Timestamp::getTime).toList();
     List<Long> taskTimestamps = taskTimestampCaptor.getAllValues();
     assertEquals(new HashSet<>(verificationTimestamps), new HashSet<>(taskTimestamps));
   }
@@ -186,7 +184,8 @@ public class ReportingServiceTest {
     ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
     ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
 
-    when(mockReportingTableService.getAll(tables)).thenReturn(List.of(cohortTableParams, userTableParams));
+    when(mockReportingTableService.getAll(tables))
+        .thenReturn(List.of(cohortTableParams, userTableParams));
     when(mockReportingVerificationService.verifySnapshot(captureTimestamp)).thenReturn(true);
 
     // Act
@@ -208,7 +207,8 @@ public class ReportingServiceTest {
     ReportingTableParams<ReportingCohort> cohortTableParams = createMockTableParams("cohort");
     ReportingTableParams<ReportingUser> userTableParams = createMockTableParams("user");
 
-    when(mockReportingTableService.getAll(tables)).thenReturn(List.of(cohortTableParams, userTableParams));
+    when(mockReportingTableService.getAll(tables))
+        .thenReturn(List.of(cohortTableParams, userTableParams));
     when(mockReportingVerificationService.verifySnapshot(captureTimestamp)).thenReturn(false);
 
     // Act
@@ -241,11 +241,10 @@ public class ReportingServiceTest {
     verify(mockReportingUploadService).uploadVerifiedSnapshot(captureTimestamp);
   }
 
-  /**
-   * Helper method to create a mock ReportingTableParams with the specified table name.
-   */
+  /** Helper method to create a mock ReportingTableParams with the specified table name. */
   @SuppressWarnings("unchecked")
-  private <T extends ReportingBase> ReportingTableParams<T> createMockTableParams(String tableName) {
+  private <T extends ReportingBase> ReportingTableParams<T> createMockTableParams(
+      String tableName) {
     ReportingTableParams<T> tableParams = mock(ReportingTableParams.class);
     when(tableParams.bqTableName()).thenReturn(tableName);
     return tableParams;

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
@@ -32,10 +32,8 @@ public class ReportingTableServiceTest {
 
     when(mockWorkbenchConfigProvider.get()).thenReturn(workbenchConfig);
 
-    reportingTableService = new ReportingTableService(
-        mockWorkbenchConfigProvider,
-        mockReportingQueryService
-    );
+    reportingTableService =
+        new ReportingTableService(mockWorkbenchConfigProvider, mockReportingQueryService);
   }
 
   @Test
@@ -49,9 +47,8 @@ public class ReportingTableServiceTest {
     assertThat(result).hasSize(3);
 
     // Verify that the returned tables match the requested table names
-    List<String> returnedTableNames = result.stream()
-        .map(ReportingTableParams::bqTableName)
-        .toList();
+    List<String> returnedTableNames =
+        result.stream().map(ReportingTableParams::bqTableName).toList();
 
     assertThat(returnedTableNames).containsExactlyElementsIn(requestedTables);
   }
@@ -79,22 +76,16 @@ public class ReportingTableServiceTest {
 
   @Test
   public void testGetAll_withMixedValidAndInvalidTableNames_returnsOnlyValidTables() {
-    List<String> requestedTables = Arrays.asList(
-        "cohort",
-        "invalid_table",
-        "user",
-        "another_invalid_table",
-        "dataset"
-    );
+    List<String> requestedTables =
+        Arrays.asList("cohort", "invalid_table", "user", "another_invalid_table", "dataset");
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(requestedTables);
 
     assertThat(result).hasSize(3);
 
-    List<String> returnedTableNames = result.stream()
-        .map(ReportingTableParams::bqTableName)
-        .toList();
+    List<String> returnedTableNames =
+        result.stream().map(ReportingTableParams::bqTableName).toList();
 
     assertThat(returnedTableNames).containsExactly("cohort", "user", "dataset");
   }
@@ -111,19 +102,19 @@ public class ReportingTableServiceTest {
 
   @Test
   public void testGetAll_withAllValidTableNames_returnsAllTables() {
-    List<String> allValidTableNames = Arrays.asList(
-        "cohort",
-        "dataset",
-        "dataset_domain_value",
-        "institution",
-        "leonardo_app_usage",
-        "new_user_satisfaction_survey",
-        "user",
-        "user_general_discovery_source",
-        "user_partner_discovery_source",
-        "workspace",
-        "workspace_free_tier_usage"
-    );
+    List<String> allValidTableNames =
+        Arrays.asList(
+            "cohort",
+            "dataset",
+            "dataset_domain_value",
+            "institution",
+            "leonardo_app_usage",
+            "new_user_satisfaction_survey",
+            "user",
+            "user_general_discovery_source",
+            "user_partner_discovery_source",
+            "workspace",
+            "workspace_free_tier_usage");
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(allValidTableNames);
@@ -131,31 +122,30 @@ public class ReportingTableServiceTest {
     // Should return all 11 tables defined in getAll()
     assertThat(result).hasSize(11);
 
-    List<String> returnedTableNames = result.stream()
-        .map(ReportingTableParams::bqTableName)
-        .toList();
+    List<String> returnedTableNames =
+        result.stream().map(ReportingTableParams::bqTableName).toList();
 
     assertThat(returnedTableNames).containsExactlyElementsIn(allValidTableNames);
   }
 
   @Test
   public void testGetAll_withDuplicateTableNames_returnsUniqueTablesOnly() {
-    List<String> requestedTablesWithDuplicates = Arrays.asList(
-        "cohort",
-        "user",
-        "cohort",  // duplicate
-        "workspace",
-        "user"     // duplicate
-    );
+    List<String> requestedTablesWithDuplicates =
+        Arrays.asList(
+            "cohort",
+            "user",
+            "cohort", // duplicate
+            "workspace",
+            "user" // duplicate
+            );
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(requestedTablesWithDuplicates);
 
     assertThat(result).hasSize(3);
 
-    List<String> returnedTableNames = result.stream()
-        .map(ReportingTableParams::bqTableName)
-        .toList();
+    List<String> returnedTableNames =
+        result.stream().map(ReportingTableParams::bqTableName).toList();
 
     assertThat(returnedTableNames).containsExactly("cohort", "user", "workspace");
   }
@@ -163,20 +153,15 @@ public class ReportingTableServiceTest {
   @Test
   public void testGetAll_preservesOriginalOrderOfValidTables() {
     // Test that the method preserves the order from getAll(), not the input order
-    List<String> requestedTablesInDifferentOrder = Arrays.asList(
-        "workspace",
-        "cohort",
-        "user"
-    );
+    List<String> requestedTablesInDifferentOrder = Arrays.asList("workspace", "cohort", "user");
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(requestedTablesInDifferentOrder);
 
     assertThat(result).hasSize(3);
 
-    List<String> returnedTableNames = result.stream()
-        .map(ReportingTableParams::bqTableName)
-        .toList();
+    List<String> returnedTableNames =
+        result.stream().map(ReportingTableParams::bqTableName).toList();
 
     // The order should match the order from getAll() method, not the input order
     // getAll() returns tables in this order: cohort, dataset, datasetDomainIdValue, institution,
@@ -187,11 +172,12 @@ public class ReportingTableServiceTest {
 
   @Test
   public void testGetAll_withCaseSensitiveTableNames_onlyMatchesExactCase() {
-    List<String> requestedTablesWithWrongCase = Arrays.asList(
-        "COHORT",      // wrong case
-        "User",        // wrong case
-        "workspace"    // correct case
-    );
+    List<String> requestedTablesWithWrongCase =
+        Arrays.asList(
+            "COHORT", // wrong case
+            "User", // wrong case
+            "workspace" // correct case
+            );
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(requestedTablesWithWrongCase);

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
@@ -1,0 +1,203 @@
+package org.pmiops.workbench.reporting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Provider;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.jdbc.ReportingQueryService;
+import org.pmiops.workbench.model.ReportingBase;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportingTableServiceTest {
+
+  @Mock private Provider<WorkbenchConfig> mockWorkbenchConfigProvider;
+  @Mock private ReportingQueryService mockReportingQueryService;
+
+  private ReportingTableService reportingTableService;
+
+  @BeforeEach
+  public void setUp() {
+    // Create real config objects since they have public fields, not getter methods
+    WorkbenchConfig workbenchConfig = WorkbenchConfig.createEmptyConfig();
+    workbenchConfig.reporting.maxRowsPerInsert = 1000;
+
+    when(mockWorkbenchConfigProvider.get()).thenReturn(workbenchConfig);
+
+    reportingTableService = new ReportingTableService(
+        mockWorkbenchConfigProvider,
+        mockReportingQueryService
+    );
+  }
+
+  @Test
+  public void testGetAll_withValidTableNames_returnsFilteredTables() {
+    // Test filtering with valid table names
+    List<String> requestedTables = Arrays.asList("cohort", "user", "workspace");
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTables);
+
+    assertThat(result).hasSize(3);
+
+    // Verify that the returned tables match the requested table names
+    List<String> returnedTableNames = result.stream()
+        .map(ReportingTableParams::bqTableName)
+        .toList();
+
+    assertThat(returnedTableNames).containsExactlyElementsIn(requestedTables);
+  }
+
+  @Test
+  public void testGetAll_withSingleTableName_returnsSingleTable() {
+    List<String> requestedTables = List.of("institution");
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTables);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).bqTableName()).isEqualTo("institution");
+  }
+
+  @Test
+  public void testGetAll_withNonExistentTableNames_returnsEmptyList() {
+    List<String> requestedTables = Arrays.asList("non_existent_table", "another_fake_table");
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTables);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testGetAll_withMixedValidAndInvalidTableNames_returnsOnlyValidTables() {
+    List<String> requestedTables = Arrays.asList(
+        "cohort",
+        "invalid_table",
+        "user",
+        "another_invalid_table",
+        "dataset"
+    );
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTables);
+
+    assertThat(result).hasSize(3);
+
+    List<String> returnedTableNames = result.stream()
+        .map(ReportingTableParams::bqTableName)
+        .toList();
+
+    assertThat(returnedTableNames).containsExactly("cohort", "user", "dataset");
+  }
+
+  @Test
+  public void testGetAll_withEmptyTableNamesList_returnsEmptyList() {
+    List<String> requestedTables = Collections.emptyList();
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTables);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testGetAll_withAllValidTableNames_returnsAllTables() {
+    List<String> allValidTableNames = Arrays.asList(
+        "cohort",
+        "dataset",
+        "dataset_domain_value",
+        "institution",
+        "leonardo_app_usage",
+        "new_user_satisfaction_survey",
+        "user",
+        "user_general_discovery_source",
+        "user_partner_discovery_source",
+        "workspace",
+        "workspace_free_tier_usage"
+    );
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(allValidTableNames);
+
+    // Should return all 11 tables defined in getAll()
+    assertThat(result).hasSize(11);
+
+    List<String> returnedTableNames = result.stream()
+        .map(ReportingTableParams::bqTableName)
+        .toList();
+
+    assertThat(returnedTableNames).containsExactlyElementsIn(allValidTableNames);
+  }
+
+  @Test
+  public void testGetAll_withDuplicateTableNames_returnsUniqueTablesOnly() {
+    List<String> requestedTablesWithDuplicates = Arrays.asList(
+        "cohort",
+        "user",
+        "cohort",  // duplicate
+        "workspace",
+        "user"     // duplicate
+    );
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTablesWithDuplicates);
+
+    assertThat(result).hasSize(3);
+
+    List<String> returnedTableNames = result.stream()
+        .map(ReportingTableParams::bqTableName)
+        .toList();
+
+    assertThat(returnedTableNames).containsExactly("cohort", "user", "workspace");
+  }
+
+  @Test
+  public void testGetAll_preservesOriginalOrderOfValidTables() {
+    // Test that the method preserves the order from getAll(), not the input order
+    List<String> requestedTablesInDifferentOrder = Arrays.asList(
+        "workspace",
+        "cohort",
+        "user"
+    );
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTablesInDifferentOrder);
+
+    assertThat(result).hasSize(3);
+
+    List<String> returnedTableNames = result.stream()
+        .map(ReportingTableParams::bqTableName)
+        .toList();
+
+    // The order should match the order from getAll() method, not the input order
+    // getAll() returns tables in this order: cohort, dataset, datasetDomainIdValue, institution,
+    // leoAppUsage, newUserSatisfactionSurvey, user, userGeneralDiscoverySource,
+    // userPartnerDiscoverySource, workspace, workspaceFreeTierUsage
+    assertThat(returnedTableNames).containsExactly("cohort", "user", "workspace").inOrder();
+  }
+
+  @Test
+  public void testGetAll_withCaseSensitiveTableNames_onlyMatchesExactCase() {
+    List<String> requestedTablesWithWrongCase = Arrays.asList(
+        "COHORT",      // wrong case
+        "User",        // wrong case
+        "workspace"    // correct case
+    );
+
+    List<ReportingTableParams<? extends ReportingBase>> result =
+        reportingTableService.getAll(requestedTablesWithWrongCase);
+
+    // Only "workspace" should match (case-sensitive)
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).bqTableName()).isEqualTo("workspace");
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
@@ -152,12 +152,7 @@ public class ReportingTableServiceTest {
 
   @Test
   public void testGetAll_withCaseSensitiveTableNames_matchesCaseInsensitive() {
-    List<String> requestedTablesWithWrongCase =
-        Arrays.asList(
-            "COHORT",
-            "User",
-            "workspace"
-            );
+    List<String> requestedTablesWithWrongCase = Arrays.asList("COHORT", "User", "workspace");
 
     List<ReportingTableParams<? extends ReportingBase>> result =
         reportingTableService.getAll(requestedTablesWithWrongCase);

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingTableServiceTest.java
@@ -151,39 +151,21 @@ public class ReportingTableServiceTest {
   }
 
   @Test
-  public void testGetAll_preservesOriginalOrderOfValidTables() {
-    // Test that the method preserves the order from getAll(), not the input order
-    List<String> requestedTablesInDifferentOrder = Arrays.asList("workspace", "cohort", "user");
+  public void testGetAll_withCaseSensitiveTableNames_matchesCaseInsensitive() {
+    List<String> requestedTablesWithWrongCase =
+        Arrays.asList(
+            "COHORT",
+            "User",
+            "workspace"
+            );
 
     List<ReportingTableParams<? extends ReportingBase>> result =
-        reportingTableService.getAll(requestedTablesInDifferentOrder);
-
+        reportingTableService.getAll(requestedTablesWithWrongCase);
     assertThat(result).hasSize(3);
 
     List<String> returnedTableNames =
         result.stream().map(ReportingTableParams::bqTableName).toList();
 
-    // The order should match the order from getAll() method, not the input order
-    // getAll() returns tables in this order: cohort, dataset, datasetDomainIdValue, institution,
-    // leoAppUsage, newUserSatisfactionSurvey, user, userGeneralDiscoverySource,
-    // userPartnerDiscoverySource, workspace, workspaceFreeTierUsage
-    assertThat(returnedTableNames).containsExactly("cohort", "user", "workspace").inOrder();
-  }
-
-  @Test
-  public void testGetAll_withCaseSensitiveTableNames_onlyMatchesExactCase() {
-    List<String> requestedTablesWithWrongCase =
-        Arrays.asList(
-            "COHORT", // wrong case
-            "User", // wrong case
-            "workspace" // correct case
-            );
-
-    List<ReportingTableParams<? extends ReportingBase>> result =
-        reportingTableService.getAll(requestedTablesWithWrongCase);
-
-    // Only "workspace" should match (case-sensitive)
-    assertThat(result).hasSize(1);
-    assertThat(result.get(0).bqTableName()).isEqualTo("workspace");
+    assertThat(returnedTableNames).containsExactly("cohort", "user", "workspace");
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -320,7 +320,8 @@ public class ReportingVerificationServiceTest {
     assertThat(reportingVerificationService.verifySnapshot(snapshotTimestamp2)).isFalse();
   }
 
-  private void createVerificationRecord(String tableName, Timestamp snapshotTimestamp, Boolean uploaded) {
+  private void createVerificationRecord(
+      String tableName, Timestamp snapshotTimestamp, Boolean uploaded) {
     DbReportingUploadVerification record = new DbReportingUploadVerification();
     record.setTableName(tableName);
     record.setSnapshotTimestamp(snapshotTimestamp);

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -223,7 +223,7 @@ public class ReportingVerificationServiceTest {
         table ->
             reportingUploadVerificationDao.createVerificationEntry(
                 table, new Timestamp(timestamp)));
-    reportingVerificationService.verifyBatchesAndLog(tables, NOW.toEpochMilli());
+    reportingVerificationService.verifyBatchesAndLog(tables, timestamp);
 
     var res = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(timestamp));
     assertThat(res.size()).isEqualTo(4);
@@ -240,7 +240,7 @@ public class ReportingVerificationServiceTest {
             reportingUploadVerificationDao.createVerificationEntry(
                 table, new Timestamp(timestamp)));
     reportingVerificationService.verifyBatchesAndLog(
-        List.of("cohort", "user", "workspace", "new_user_satisfaction_survey"), NOW.toEpochMilli());
+        List.of("cohort", "user", "workspace", "new_user_satisfaction_survey"), timestamp);
 
     var res = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(timestamp));
     assertThat(res.size()).isEqualTo(4);

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -219,7 +219,10 @@ public class ReportingVerificationServiceTest {
     createTableEntries(ACTUAL_COUNT);
     var tables = List.of("cohort", "user", "workspace", "new_user_satisfaction_survey");
     var timestamp = NOW.toEpochMilli();
-    tables.forEach(table -> reportingUploadVerificationDao.createVerificationEntry(table, new Timestamp(timestamp)));
+    tables.forEach(
+        table ->
+            reportingUploadVerificationDao.createVerificationEntry(
+                table, new Timestamp(timestamp)));
     reportingVerificationService.verifyBatchesAndLog(tables, NOW.toEpochMilli());
 
     var res = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(timestamp));
@@ -232,8 +235,12 @@ public class ReportingVerificationServiceTest {
     createTableEntries(ACTUAL_COUNT * 2);
     var tables = List.of("cohort", "user", "workspace", "new_user_satisfaction_survey");
     var timestamp = NOW.toEpochMilli();
-    tables.forEach(table -> reportingUploadVerificationDao.createVerificationEntry(table, new Timestamp(timestamp)));
-    reportingVerificationService.verifyBatchesAndLog(List.of("cohort", "user", "workspace", "new_user_satisfaction_survey"), NOW.toEpochMilli());
+    tables.forEach(
+        table ->
+            reportingUploadVerificationDao.createVerificationEntry(
+                table, new Timestamp(timestamp)));
+    reportingVerificationService.verifyBatchesAndLog(
+        List.of("cohort", "user", "workspace", "new_user_satisfaction_survey"), NOW.toEpochMilli());
 
     var res = reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(timestamp));
     assertThat(res.size()).isEqualTo(4);

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingVerificationServiceTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import jakarta.persistence.EntityManager;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import org.pmiops.workbench.db.dao.CohortDao;
 import org.pmiops.workbench.db.dao.DataSetDao;
 import org.pmiops.workbench.db.dao.InstitutionDao;
 import org.pmiops.workbench.db.dao.NewUserSatisfactionSurveyDao;
+import org.pmiops.workbench.db.dao.ReportingUploadVerificationDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.dao.WorkspaceFreeTierUsageDao;
@@ -43,6 +45,7 @@ import org.pmiops.workbench.db.model.DbCdrVersion;
 import org.pmiops.workbench.db.model.DbCohort;
 import org.pmiops.workbench.db.model.DbDatasetValue;
 import org.pmiops.workbench.db.model.DbInstitution;
+import org.pmiops.workbench.db.model.DbReportingUploadVerification;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUser.DbGeneralDiscoverySource;
 import org.pmiops.workbench.db.model.DbWorkspace;
@@ -87,6 +90,7 @@ public class ReportingVerificationServiceTest {
   @Autowired private DataSetDao dataSetDao;
   @Autowired private InstitutionDao institutionDao;
   @Autowired private NewUserSatisfactionSurveyDao newUserSatisfactionSurveyDao;
+  @Autowired private ReportingUploadVerificationDao reportingUploadVerificationDao;
   @Autowired private UserDao userDao;
   @Autowired private WorkspaceDao workspaceDao;
   @Autowired private WorkspaceFreeTierUsageDao workspaceFreeTierUsageDao;
@@ -208,5 +212,120 @@ public class ReportingVerificationServiceTest {
   private static String getTestCapturedLog() {
     customLogHandler.flush();
     return logCapturingStream.toString();
+  }
+
+  @Test
+  public void testVerifySnapshot_withAllTablesUploaded_returnsTrue() {
+    // Arrange
+    long snapshotTimestamp = NOW.toEpochMilli();
+    Timestamp timestamp = new Timestamp(snapshotTimestamp);
+
+    // Create verification records for multiple tables, all uploaded successfully
+    createVerificationRecord("cohort", timestamp, true);
+    createVerificationRecord("user", timestamp, true);
+    createVerificationRecord("workspace", timestamp, true);
+
+    // Act
+    boolean result = reportingVerificationService.verifySnapshot(snapshotTimestamp);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void testVerifySnapshot_withSomeTablesNotUploaded_returnsFalse() {
+    // Arrange
+    long snapshotTimestamp = NOW.toEpochMilli();
+    Timestamp timestamp = new Timestamp(snapshotTimestamp);
+
+    // Create verification records with mixed upload status
+    createVerificationRecord("cohort", timestamp, true);
+    createVerificationRecord("user", timestamp, false); // This one failed
+    createVerificationRecord("workspace", timestamp, true);
+
+    // Act
+    boolean result = reportingVerificationService.verifySnapshot(snapshotTimestamp);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testVerifySnapshot_withNoTablesUploaded_returnsFalse() {
+    // Arrange
+    long snapshotTimestamp = NOW.toEpochMilli();
+    Timestamp timestamp = new Timestamp(snapshotTimestamp);
+
+    // Create verification records where none are uploaded
+    createVerificationRecord("cohort", timestamp, false);
+    createVerificationRecord("user", timestamp, false);
+
+    // Act
+    boolean result = reportingVerificationService.verifySnapshot(snapshotTimestamp);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testVerifySnapshot_withEmptySnapshot_returnsFalse() {
+    // Arrange
+    long snapshotTimestamp = NOW.toEpochMilli();
+    // Don't create any verification records
+
+    // Act
+    boolean result = reportingVerificationService.verifySnapshot(snapshotTimestamp);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testVerifySnapshot_withNullUploadedValues_returnsFalse() {
+    // Arrange
+    long snapshotTimestamp = NOW.toEpochMilli();
+    Timestamp timestamp = new Timestamp(snapshotTimestamp);
+
+    // Create verification records with mixed status including null
+    createVerificationRecord("cohort", timestamp, true);
+    createVerificationRecord("user", timestamp, null); // null uploaded value
+    createVerificationRecord("workspace", timestamp, true);
+
+    // Act
+    boolean result = reportingVerificationService.verifySnapshot(snapshotTimestamp);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void testVerifySnapshot_withDifferentTimestamp_returnsCorrectResult() {
+    // Arrange
+    long snapshotTimestamp1 = NOW.toEpochMilli();
+    long snapshotTimestamp2 = NOW.toEpochMilli() + 1000L; // Different timestamp
+
+    Timestamp timestamp1 = new Timestamp(snapshotTimestamp1);
+    Timestamp timestamp2 = new Timestamp(snapshotTimestamp2);
+
+    // Create records for timestamp1 (all uploaded)
+    createVerificationRecord("cohort", timestamp1, true);
+    createVerificationRecord("user", timestamp1, true);
+
+    // Create records for timestamp2 (some not uploaded)
+    createVerificationRecord("cohort", timestamp2, true);
+    createVerificationRecord("user", timestamp2, false);
+
+    // Act & Assert
+    assertThat(reportingVerificationService.verifySnapshot(snapshotTimestamp1)).isTrue();
+    assertThat(reportingVerificationService.verifySnapshot(snapshotTimestamp2)).isFalse();
+  }
+
+  private void createVerificationRecord(String tableName, Timestamp snapshotTimestamp, Boolean uploaded) {
+    DbReportingUploadVerification record = new DbReportingUploadVerification();
+    record.setTableName(tableName);
+    record.setSnapshotTimestamp(snapshotTimestamp);
+    record.setUploaded(uploaded);
+    reportingUploadVerificationDao.save(record);
+    entityManager.flush();
   }
 }


### PR DESCRIPTION
Ticket: [RW-14979](https://precisionmedicineinitiative.atlassian.net/browse/RW-14979)

Splits the WRD upload into distinct Cloud Tasks to get around the 600 second GAE cron job timeout.

Every nightly upload to the WRD has a single timestamp associated with it that can be thought of as the snapshot identifier. When the current upload job completes, there is a final verification step that checks that the number of rows uploaded to the WRD snapshot matches the number of rows in the database. If we are able to verify the snapshot, we upload the timestamp to the `verified_snapshot` table in the WRD BQ dataset to certify it as a successful upload.

How will we continue to certify the snapshot once we’ve split the upload job into a series of asynchronous tasks? Despite its name, GCP makes no guarantee that a cloud task queue will follow FIFO, so we cannot simply enqueue a verification task last in the queue.

In this POC, each task verifies that the tables it is responsible for were uploaded correctly. If they did, it marks each table as successfully uploaded in the new `reporting_upload_verification` table. Then the task checks to see if all the other tables in its snapshot have finished successfully. If they have, the task certifies the snapshot by uploading the timestamp to the `verified_snapshot` table in the WRD.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.


[RW-14979]: https://precisionmedicineinitiative.atlassian.net/browse/RW-14979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ