### PR TITLE
[RW-15521][risk=no] Set initial credits account to pod when the credits are increased

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -287,6 +287,10 @@ public class InitialCreditsService {
         updateInitialCreditsExhaustion(user, false);
       }
 
+      // Link the initial credits billing account to the user's pod if the feature flag is enabled
+      // and update the status to active
+      linkInitialCreditsAccountAndSetVwbInitialCreditsActive(user);
+
       userServiceAuditor.fireSetInitialCreditsOverride(
           user.getUserId(), previousLimitMaybe, newDollarLimit);
       return true;
@@ -833,5 +837,16 @@ public class InitialCreditsService {
             vwbUserPodDao.save(pod);
           }
         });
+  }
+
+  private void linkInitialCreditsAccountAndSetVwbInitialCreditsActive(DbUser user) {
+    if (workbenchConfigProvider.get().featureFlags.enableVWBInitialCreditsExhaustion) {
+      DbVwbUserPod pod = user.getVwbUserPod();
+      if (pod != null) {
+        vwbUserService.linkInitialCreditsBillingAccountToPod(pod);
+        pod.setInitialCreditsActive(true);
+        vwbUserPodDao.save(pod);
+      }
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -840,13 +840,14 @@ public class InitialCreditsService {
   }
 
   private void linkInitialCreditsAccountAndSetVwbInitialCreditsActive(DbUser user) {
-    if (workbenchConfigProvider.get().featureFlags.enableVWBInitialCreditsExhaustion) {
-      DbVwbUserPod pod = user.getVwbUserPod();
-      if (pod != null) {
-        vwbUserService.linkInitialCreditsBillingAccountToPod(pod);
-        pod.setInitialCreditsActive(true);
-        vwbUserPodDao.save(pod);
-      }
+    if (!workbenchConfigProvider.get().featureFlags.enableVWBInitialCreditsExhaustion) {
+      return;
+    }
+    DbVwbUserPod pod = user.getVwbUserPod();
+    if (pod != null) {
+      vwbUserService.linkInitialCreditsBillingAccountToPod(pod);
+      pod.setInitialCreditsActive(true);
+      vwbUserPodDao.save(pod);
     }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
@@ -141,4 +141,10 @@ public class VwbUserService {
                         .getBillingAccountId())
             .orElse("");
   }
+
+  public void linkInitialCreditsBillingAccountToPod(DbVwbUserPod pod) {
+    vwbUserManagerClient.updatePodBillingAccount(
+        pod.getVwbPodId(),
+        workbenchConfigProvider.get().billing.initialCreditsBillingAccountName());
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -130,8 +130,7 @@ public class VwbUserManagerClient {
           podApiProvider
               .get()
               .deletePod(
-                  new DeletePodRequest()
-                      .jobControl(new JobControl().id(UUID.randomUUID().toString())),
+                  new DeletePodRequest().jobControl(generateJobControlWithUUID()),
                   organizationId,
                   podId.toString());
           return null;
@@ -166,9 +165,30 @@ public class VwbUserManagerClient {
             podApiProvider
                 .get()
                 .unlinkBillingFromPod(
-                    new PodUnlinkBillingRequest()
-                        .jobControl(new JobControl().id(UUID.randomUUID().toString())),
+                    new PodUnlinkBillingRequest().jobControl(generateJobControlWithUUID()),
                     organizationId,
                     podId));
+  }
+
+  public void updatePodBillingAccount(String vwbPodId, String billingAccount) {
+    String organizationId = workbenchConfigProvider.get().vwb.organizationId;
+    vwbUserManagerRetryHandler.run(
+        context ->
+            podApiProvider
+                .get()
+                .updatePod(
+                    new PodUpdateRequest()
+                        .jobControl(generateJobControlWithUUID())
+                        .environment(
+                            new PodEnvironment()
+                                .environmentDataGcp(
+                                    new PodEnvironmentDataGcp()
+                                        .billingAccountId("billingAccounts/" + billingAccount))),
+                    organizationId,
+                    vwbPodId));
+  }
+
+  private static JobControl generateJobControlWithUUID() {
+    return new JobControl().id(UUID.randomUUID().toString());
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -181,9 +181,9 @@ public class VwbUserManagerClient {
                         .jobControl(generateJobControlWithUUID())
                         .environment(
                             new PodEnvironment()
+                                .environmentType(PodEnvironmentType.GCP)
                                 .environmentDataGcp(
-                                    new PodEnvironmentDataGcp()
-                                        .billingAccountId("billingAccounts/" + billingAccount))),
+                                    new PodEnvironmentDataGcp().billingAccountId(billingAccount))),
                     organizationId,
                     vwbPodId));
   }


### PR DESCRIPTION
When the initial credits are increased in the admin page, the RWB should update the pod to link the initial credits billing account and update the database.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
