### PR TITLE
[risk=no][RW-15247] Fix query to use the new bigquery table

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -33,7 +33,7 @@
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "minutesBeforeLastInitialCreditsJob": 60,
     "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2,
-    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_vwb_billing_view"
+    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.vwb_test_billing_export"
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -32,7 +32,8 @@
     "initialCreditsExpirationWarningDays": 14,
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "minutesBeforeLastInitialCreditsJob": 60,
-    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 7
+    "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 7,
+    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.vwb_billing_export"
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -33,7 +33,7 @@
     "carahsoftEmail": "NIHStrides@Carahsoft.com",
     "minutesBeforeLastInitialCreditsJob": 60,
     "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 7,
-    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.vwb_billing_export"
+    "vwbExportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.vwb_billing_export"
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -33,7 +33,7 @@
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "minutesBeforeLastInitialCreditsJob": 60,
     "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2,
-    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_vwb_billing_view"
+    "vwbExportBigQueryTable": "all-of-us-rw-prod-bdata.RwProdBillingDataExport.vwb_billing_export"
   },
   "auth": {
     "serviceAccountApiUsers": [
@@ -125,7 +125,7 @@
     "enableVWBEgressMonitor": true,
     "enableVWBUserAccessManagement": true,
     "enableVWBUserAndPodCreation": true,
-    "enableVWBInitialCreditsExhaustion": false
+    "enableVWBInitialCreditsExhaustion": true
   },
   "actionAudit": {
     "logName": "workbench-action-audit-stable",

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -33,7 +33,7 @@
     "carahsoftEmail": "workbench-notificatio-aaaaekogch7vg3c6hi4sgyx4le@pmi-engteam.slack.com",
     "minutesBeforeLastInitialCreditsJob": 60,
     "numberOfDaysToConsiderForInitialCreditsUsageUpdate": 2,
-    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.rw_test_vwb_billing_view"
+    "vwbExportBigQueryTable": "all-of-us-workbench-test-bd.billing_data.vwb_test_billing_export"
   },
   "auth": {
     "serviceAccountApiUsers": [

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsBatchUpdateService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsBatchUpdateService.java
@@ -96,7 +96,7 @@ public class InitialCreditsBatchUpdateService {
     return userWorkspaceCosts;
   }
 
-  /** Return a map of user_id -> total_cost for VWB pods */
+  /** Return a map of user_id -> cost for VWB pods */
   private Map<Long, Double> findVwbUsersLiveCosts(List<DbUser> users) {
     if (!workbenchConfigProvider.get().featureFlags.enableVWBInitialCreditsExhaustion) {
       return Collections.emptyMap();

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
@@ -102,8 +102,7 @@ class InitialCreditsBigQueryServiceTest {
     List<FieldValueList> tableRows =
         List.of(
             tableRow("1", "50.0", "pod1"),
-            tableRow("2", "75.0", "pod2"),
-            tableRow("3", "25.0", "pod1"));
+            tableRow("2", "75.0", "pod2"));
 
     when(mockBigQueryService.executeQuery(any()))
         .thenReturn(BigQueryUtils.newTableResult(schema, tableRows));
@@ -111,7 +110,7 @@ class InitialCreditsBigQueryServiceTest {
     Map<String, Double> result = initialCreditsBigQueryService.getAllVWBProjectCostsFromBQ();
 
     assertEquals(2, result.size());
-    assertEquals(75.0, result.get("pod1"));
+    assertEquals(50.0, result.get("pod1"));
     assertEquals(75.0, result.get("pod2"));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
@@ -96,7 +96,7 @@ class InitialCreditsBigQueryServiceTest {
     Schema schema =
         Schema.of(
             Field.of("id", LegacySQLTypeName.STRING),
-            Field.of("total_cost", LegacySQLTypeName.STRING),
+            Field.of("cost", LegacySQLTypeName.STRING),
             Field.of("vwb_pod_id", LegacySQLTypeName.STRING));
 
     List<FieldValueList> tableRows =
@@ -120,7 +120,7 @@ class InitialCreditsBigQueryServiceTest {
     Schema schema =
         Schema.of(
             Field.of("id", LegacySQLTypeName.STRING),
-            Field.of("total_cost", LegacySQLTypeName.FLOAT),
+            Field.of("cost", LegacySQLTypeName.FLOAT),
             Field.of("vwb_pod_id", LegacySQLTypeName.STRING));
 
     List<FieldValueList> tableRows =
@@ -140,7 +140,7 @@ class InitialCreditsBigQueryServiceTest {
     Schema schema =
         Schema.of(
             Field.of("id", LegacySQLTypeName.STRING),
-            Field.of("total_cost", LegacySQLTypeName.FLOAT),
+            Field.of("cost", LegacySQLTypeName.FLOAT),
             Field.of("vwb_pod_id", LegacySQLTypeName.STRING));
 
     when(mockBigQueryService.executeQuery(any()))

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsBigQueryServiceTest.java
@@ -100,9 +100,7 @@ class InitialCreditsBigQueryServiceTest {
             Field.of("vwb_pod_id", LegacySQLTypeName.STRING));
 
     List<FieldValueList> tableRows =
-        List.of(
-            tableRow("1", "50.0", "pod1"),
-            tableRow("2", "75.0", "pod2"));
+        List.of(tableRow("1", "50.0", "pod1"), tableRow("2", "75.0", "pod2"));
 
     when(mockBigQueryService.executeQuery(any()))
         .thenReturn(BigQueryUtils.newTableResult(schema, tableRows));


### PR DESCRIPTION
I tested this change by running the cron job using
`curl --header "X-AppEngine-Cron: true" localhost:8081/v1/cron/checkInitialCreditsUsage`

For a user who exceeded their initial credits usage, they get an email and their billing is unlinked in VWB.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
