### PR TITLE
[risk=low][RW-14827] Add AIAN fields to reporting.

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -496,6 +496,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
             + "  last_modified_time,\n"
             + "  w.name AS name,\n"
             + "  rp_additional_notes,\n"
+            + "  rp_aian_research_type,\n"
+            + "  rp_aian_research_details,\n"
             + "  rp_ancestry,\n"
             + "  rp_anticipated_findings,\n"
             + "  rp_approved,\n"
@@ -545,6 +547,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 .lastModifiedTime(offsetDateTimeUtc(rs.getTimestamp("last_modified_time")))
                 .name(rs.getString("name"))
                 .rpAdditionalNotes(rs.getString("rp_additional_notes"))
+                .rpAianResearchType(rs.getString("rp_aian_research_type"))
+                .rpAianResearchDetails(rs.getString("rp_aian_research_details"))
                 .rpAncestry(rs.getBoolean("rp_ancestry"))
                 .rpAnticipatedFindings(rs.getString("rp_anticipated_findings"))
                 .rpApproved(rs.getBoolean("rp_approved"))

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -23,7 +23,8 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   NAME("name", ReportingWorkspace::getName),
   RP_ADDITIONAL_NOTES("rp_additional_notes", ReportingWorkspace::getRpAdditionalNotes),
   RP_AIAN_RESEARCH_TYPE("rp_aian_research_type", ReportingWorkspace::getRpAianResearchType),
-  RP_AIAN_RESEARCH_DETAILS("rp_aian_research_details", ReportingWorkspace::getRpAianResearchDetails),
+  RP_AIAN_RESEARCH_DETAILS(
+      "rp_aian_research_details", ReportingWorkspace::getRpAianResearchDetails),
   RP_ANCESTRY("rp_ancestry", ReportingWorkspace::isRpAncestry),
   RP_ANTICIPATED_FINDINGS("rp_anticipated_findings", ReportingWorkspace::getRpAnticipatedFindings),
   RP_APPROVED("rp_approved", ReportingWorkspace::isRpApproved),

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -22,6 +22,8 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   LAST_MODIFIED_TIME("last_modified_time", w -> toInsertRowString(w.getLastModifiedTime())),
   NAME("name", ReportingWorkspace::getName),
   RP_ADDITIONAL_NOTES("rp_additional_notes", ReportingWorkspace::getRpAdditionalNotes),
+  RP_AIAN_RESEARCH_TYPE("rp_aian_research_type", ReportingWorkspace::getRpAianResearchType),
+  RP_AIAN_RESEARCH_DETAILS("rp_aian_research_details", ReportingWorkspace::getRpAianResearchDetails),
   RP_ANCESTRY("rp_ancestry", ReportingWorkspace::isRpAncestry),
   RP_ANTICIPATED_FINDINGS("rp_anticipated_findings", ReportingWorkspace::getRpAnticipatedFindings),
   RP_APPROVED("rp_approved", ReportingWorkspace::isRpApproved),

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -12582,6 +12582,12 @@ components:
         rpAdditionalNotes:
           type: string
           description: Research purpose additional notes input.
+        rpAianResearchType:
+          type: string
+          description: Type of research involving American Indian and Alaska Native populations.
+        rpAianResearchDetails:
+          type: string
+          description: Additional details about American Indian and Alaska Native research.
         rpAncestry:
           type: boolean
           description: If true, user has reported this workspace will study ancestry.

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -16,6 +16,7 @@ import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey;
 import org.pmiops.workbench.db.model.DbNewUserSatisfactionSurvey.Satisfaction;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.db.model.DbWorkspace.AIANResearchType;
 import org.pmiops.workbench.model.BillingAccountType;
 import org.pmiops.workbench.model.FeaturedWorkspaceCategory;
 import org.pmiops.workbench.model.NewUserSatisfactionSurveySatisfaction;
@@ -38,8 +39,11 @@ public class ReportingTestUtils {
       Timestamp.from(Instant.parse("2015-05-13T00:00:00.00Z"));
   public static final String WORKSPACE__NAME = "foo_9";
   public static final String WORKSPACE__RP_ADDITIONAL_NOTES = "foo_12";
+  public static final String WORKSPACE__RP_AIAN_RESEARCH_TYPE = 
+      AIANResearchType.NO_AI_AN_ANALYSIS.toString();
+  public static final String WORKSPACE__RP_AIAN_RESEARCH_DETAILS = "foo_14";
   public static final Boolean WORKSPACE__RP_ANCESTRY = false;
-  public static final String WORKSPACE__RP_ANTICIPATED_FINDINGS = "foo_14";
+  public static final String WORKSPACE__RP_ANTICIPATED_FINDINGS = "foo_15";
   public static final Boolean WORKSPACE__RP_APPROVED = false;
   public static final Boolean WORKSPACE__RP_COMMERCIAL_PURPOSE = true;
   public static final Boolean WORKSPACE__RP_CONTROL_SET = false;
@@ -112,6 +116,8 @@ public class ReportingTestUtils {
         .lastModifiedTime(offsetDateTimeUtc(WORKSPACE__LAST_MODIFIED_TIME))
         .name(WORKSPACE__NAME)
         .rpAdditionalNotes(WORKSPACE__RP_ADDITIONAL_NOTES)
+        .rpAianResearchType(WORKSPACE__RP_AIAN_RESEARCH_TYPE)
+        .rpAianResearchDetails(WORKSPACE__RP_AIAN_RESEARCH_DETAILS)
         .rpAncestry(WORKSPACE__RP_ANCESTRY)
         .rpAnticipatedFindings(WORKSPACE__RP_ANTICIPATED_FINDINGS)
         .rpApproved(WORKSPACE__RP_APPROVED)
@@ -146,6 +152,8 @@ public class ReportingTestUtils {
     workspace.setLastModifiedTime(WORKSPACE__LAST_MODIFIED_TIME);
     workspace.setName(WORKSPACE__NAME);
     workspace.setAdditionalNotes(WORKSPACE__RP_ADDITIONAL_NOTES);
+    workspace.setAianResearchType(AIANResearchType.NO_AI_AN_ANALYSIS);
+    workspace.setAianResearchDetails(WORKSPACE__RP_AIAN_RESEARCH_DETAILS);
     workspace.setAncestry(WORKSPACE__RP_ANCESTRY);
     workspace.setAnticipatedFindings(WORKSPACE__RP_ANTICIPATED_FINDINGS);
     workspace.setApproved(WORKSPACE__RP_APPROVED);

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -39,7 +39,7 @@ public class ReportingTestUtils {
       Timestamp.from(Instant.parse("2015-05-13T00:00:00.00Z"));
   public static final String WORKSPACE__NAME = "foo_9";
   public static final String WORKSPACE__RP_ADDITIONAL_NOTES = "foo_12";
-  public static final String WORKSPACE__RP_AIAN_RESEARCH_TYPE = 
+  public static final String WORKSPACE__RP_AIAN_RESEARCH_TYPE =
       AIANResearchType.NO_AI_AN_ANALYSIS.toString();
   public static final String WORKSPACE__RP_AIAN_RESEARCH_DETAILS = "foo_14";
   public static final Boolean WORKSPACE__RP_ANCESTRY = false;


### PR DESCRIPTION
Don't merge until we update the BigQuery table: https://github.com/all-of-us/workbench-terraform-modules/pull/68

The above will update the BigQuery schema, but the change in this PR enables the api to export the correct data.

In order to run the appropriate cron job, follow [these instructions](https://github.com/all-of-us/workbench/wiki/Workbench-Reporting-Dataset-(WRD)#testing).

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
