### PR TITLE
[RW-14979][risk=no] Store raw timestamp instead of datetime in reporting_upload_verification table

### DIFF
--- a/api/db/changelog/db.changelog-270-replace-reporting-upload-verification-timestamp.xml
+++ b/api/db/changelog/db.changelog-270-replace-reporting-upload-verification-timestamp.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet author="mtalbott" id="changelog-270-replace-reporting-upload-verification-timestamp">
+    <dropColumn tableName="reporting_upload_verification" columnName="snapshot_timestamp"/>
+    <addColumn tableName="reporting_upload_verification">
+      <column name="snapshot_timestamp" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -277,6 +277,7 @@
   <include file="changelog/db.changelog-267-vwb-initial-credits.xml"/>
   <include file="changelog/db.changelog-268-recreate-vwb-pod-columns.xml"/>
   <include file="changelog/db.changelog-269-add-reporting-upload-verification-table.xml"/>
+  <include file="changelog/db.changelog-270-replace-reporting-upload-verification-timestamp.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/ReportingUploadVerificationDao.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.db.dao;
 
-import java.sql.Timestamp;
 import java.util.List;
 import org.pmiops.workbench.db.model.DbReportingUploadVerification;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReportingUploadVerificationDao
     extends CrudRepository<DbReportingUploadVerification, Long> {
-  List<DbReportingUploadVerification> findBySnapshotTimestamp(Timestamp snapshotTimestamp);
+  List<DbReportingUploadVerification> findBySnapshotTimestamp(Long snapshotTimestamp);
 
   // Update the uploaded status for a specific table and timestamp
   @Modifying
@@ -18,7 +17,7 @@ public interface ReportingUploadVerificationDao
       "UPDATE DbReportingUploadVerification r SET r.uploaded = :uploaded WHERE r.tableName = :tableName AND r.snapshotTimestamp = :snapshotTimestamp")
   int updateUploadedStatus(
       @Param("tableName") String tableName,
-      @Param("snapshotTimestamp") Timestamp snapshotTimestamp,
+      @Param("snapshotTimestamp") Long snapshotTimestamp,
       @Param("uploaded") Boolean uploaded);
 
   // Create a new entry for a given table and timestamp
@@ -26,6 +25,5 @@ public interface ReportingUploadVerificationDao
   @Query(
       "INSERT INTO DbReportingUploadVerification (tableName, snapshotTimestamp) VALUES (:tableName, :snapshotTimestamp)")
   int createVerificationEntry(
-      @Param("tableName") String tableName,
-      @Param("snapshotTimestamp") Timestamp snapshotTimestamp);
+      @Param("tableName") String tableName, @Param("snapshotTimestamp") Long snapshotTimestamp);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbReportingUploadVerification.java
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.sql.Timestamp;
 
 @Entity
 @Table(name = "reporting_upload_verification")
@@ -14,7 +13,7 @@ public class DbReportingUploadVerification {
 
   private long id;
   private String tableName;
-  private Timestamp snapshotTimestamp;
+  private Long snapshotTimestamp;
   private Boolean uploaded;
 
   @Id
@@ -40,11 +39,11 @@ public class DbReportingUploadVerification {
   }
 
   @Column(name = "snapshot_timestamp", nullable = false)
-  public Timestamp getSnapshotTimestamp() {
+  public Long getSnapshotTimestamp() {
     return snapshotTimestamp;
   }
 
-  public DbReportingUploadVerification setSnapshotTimestamp(Timestamp snapshotTimestamp) {
+  public DbReportingUploadVerification setSnapshotTimestamp(Long snapshotTimestamp) {
     this.snapshotTimestamp = snapshotTimestamp;
     return this;
   }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingServiceImpl.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.reporting;
 
-import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.List;
 import java.util.logging.Logger;
@@ -90,7 +89,7 @@ public class ReportingServiceImpl implements ReportingService {
         .forEach(
             tableParams -> {
               reportingUploadVerificationDao.createVerificationEntry(
-                  tableParams.bqTableName(), new Timestamp(captureTimestamp));
+                  tableParams.bqTableName(), captureTimestamp);
               taskQueueService.pushReportingUploadTask(tableParams.bqTableName(), captureTimestamp);
             });
   }

--- a/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/ReportingVerificationServiceImpl.java
@@ -4,7 +4,6 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.common.collect.Streams;
 import jakarta.inject.Provider;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -73,7 +72,7 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
               long destCount = getBigQueryRowCount(bqTableName, captureSnapshotTime);
               boolean uploadOutcome = verifyCount(bqTableName, sourceCount, destCount, sb);
               reportingUploadVerificationDao.updateUploadedStatus(
-                  bqTableName, new Timestamp(captureSnapshotTime), uploadOutcome);
+                  bqTableName, captureSnapshotTime, uploadOutcome);
             });
     logger.log(Level.INFO, sb.toString());
   }
@@ -81,7 +80,7 @@ public class ReportingVerificationServiceImpl implements ReportingVerificationSe
   @Override
   public boolean verifySnapshot(long captureSnapshotTime) {
     var tablesInSnapshot =
-        reportingUploadVerificationDao.findBySnapshotTimestamp(new Timestamp(captureSnapshotTime));
+        reportingUploadVerificationDao.findBySnapshotTimestamp(captureSnapshotTime);
     if (tablesInSnapshot.isEmpty()) {
       // This really shouldn't happen, but if it does, we return false to avoid uploading a falsely
       // verified snapshot.

--- a/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/reporting/ReportingServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.HashSet;
@@ -72,11 +71,11 @@ public class ReportingServiceTest {
 
     // Verify verification entry is created for the cohort table
     ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
     verify(mockReportingUploadVerificationDao)
         .createVerificationEntry(tableNameCaptor.capture(), timestampCaptor.capture());
     assertThat(tableNameCaptor.getValue()).isEqualTo("cohort");
-    assertThat(timestampCaptor.getValue()).isEqualTo(new Timestamp(NOW_MILLIS));
+    assertThat(timestampCaptor.getValue()).isEqualTo(NOW_MILLIS);
 
     // Verify task is queued for the cohort table
     ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -106,15 +105,15 @@ public class ReportingServiceTest {
 
     // Verify verification entries are created for both tables
     ArgumentCaptor<String> tableNameCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<Timestamp> timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
     verify(mockReportingUploadVerificationDao, times(2))
         .createVerificationEntry(tableNameCaptor.capture(), timestampCaptor.capture());
     List<String> capturedTableNames = tableNameCaptor.getAllValues();
     assertThat(capturedTableNames).containsExactly("cohort", "user");
-    List<Timestamp> capturedTimestamps = timestampCaptor.getAllValues();
+    List<Long> capturedTimestamps = timestampCaptor.getAllValues();
     assertThat(capturedTimestamps).hasSize(2);
-    assertThat(capturedTimestamps.get(0)).isEqualTo(new Timestamp(NOW_MILLIS));
-    assertThat(capturedTimestamps.get(1)).isEqualTo(new Timestamp(NOW_MILLIS));
+    assertThat(capturedTimestamps.get(0)).isEqualTo(NOW_MILLIS);
+    assertThat(capturedTimestamps.get(1)).isEqualTo(NOW_MILLIS);
 
     // Verify tasks are queued for both tables
     ArgumentCaptor<String> taskTableNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -161,8 +160,7 @@ public class ReportingServiceTest {
 
     // Assert
     // Verify that the same timestamp is used for all verification entries and tasks
-    ArgumentCaptor<Timestamp> verificationTimestampCaptor =
-        ArgumentCaptor.forClass(Timestamp.class);
+    ArgumentCaptor<Long> verificationTimestampCaptor = ArgumentCaptor.forClass(Long.class);
     verify(mockReportingUploadVerificationDao, times(2))
         .createVerificationEntry(any(), verificationTimestampCaptor.capture());
 
@@ -171,8 +169,7 @@ public class ReportingServiceTest {
         .pushReportingUploadTask(any(), taskTimestampCaptor.capture());
 
     // All timestamps should be the same
-    List<Long> verificationTimestamps =
-        verificationTimestampCaptor.getAllValues().stream().map(Timestamp::getTime).toList();
+    List<Long> verificationTimestamps = verificationTimestampCaptor.getAllValues();
     List<Long> taskTimestamps = taskTimestampCaptor.getAllValues();
     assertEquals(new HashSet<>(verificationTimestamps), new HashSet<>(taskTimestamps));
   }


### PR DESCRIPTION
Ticket: [RW-14979](https://precisionmedicineinitiative.atlassian.net/browse/RW-14979)
* The new Task Queue was failing to verify the snapshot in `test` because a difference in timestamp precision was preventing the correct records from being marked as uploaded. This converts the datetime field stored in the database to a raw timestamp to prevent that from occurring.

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [x] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.


[RW-14979]: https://precisionmedicineinitiative.atlassian.net/browse/RW-14979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ