### PR TITLE
[RW-15002][risk=no] Cleanup orphaned workspaces

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -174,7 +174,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -164,7 +164,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "termsOfService": {
     "minimumAcceptedAouVersion": 2

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -177,7 +177,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": true,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -163,7 +163,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -159,7 +159,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 50,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": false,

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -174,7 +174,8 @@
     "usersPerCheckInitialCreditsExpirationTask": 50,
     "usersPerAccessExpirationEmailTask": 500,
     "workspacesPerDeleteWorkspaceEnvironmentsTask": 10,
-    "disksPerCheckPersistentDiskTask": 500
+    "disksPerCheckPersistentDiskTask": 500,
+    "workspacesPerCleanupOrphanedWorkspacesTask": 50
   },
   "egressAlertRemediationPolicy": {
     "enableJiraTicketing": true,

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
@@ -7,7 +7,6 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
 import org.pmiops.workbench.model.TestUserRawlsWorkspace;
 import org.pmiops.workbench.model.TestUserWorkspace;
-import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,14 +19,10 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
   private static final boolean DELETE_BILLING_PROJECTS = true;
 
   private final ImpersonatedWorkspaceService impersonatedWorkspaceService;
-  private final WorkspaceService workspaceService;
 
   @Autowired
-  public CloudTaskWorkspacesController(
-      ImpersonatedWorkspaceService impersonatedWorkspaceService,
-      WorkspaceService workspaceService) {
+  public CloudTaskWorkspacesController(ImpersonatedWorkspaceService impersonatedWorkspaceService) {
     this.impersonatedWorkspaceService = impersonatedWorkspaceService;
-    this.workspaceService = workspaceService;
   }
 
   @Override
@@ -94,8 +89,7 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
     request.forEach(
         namespace -> {
           try {
-            workspaceService.deleteWorkspace(
-                workspaceService.lookupWorkspaceByNamespace(namespace), false);
+            impersonatedWorkspaceService.cleanupWorkspace(namespace, "CleanupOrphanedWorkspaces Cron Job");
           } catch (NotFoundException e) {
             LOGGER.info(String.format("Workspace (%s) was not found in database", namespace));
           }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
@@ -87,7 +87,7 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
   }
 
   @Override
-  public ResponseEntity<Void> cleanupOrphanedWorkspaces(List<String> request) {
+  public ResponseEntity<Void> cleanupOrphanedWorkspacesBatch(List<String> request) {
     LOGGER.info(
         String.format("Cleanup up %d orphaned workspaces in internal database...", request.size()));
 

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskWorkspacesController.java
@@ -84,12 +84,14 @@ public class CloudTaskWorkspacesController implements CloudTaskWorkspacesApiDele
   @Override
   public ResponseEntity<Void> cleanupOrphanedWorkspacesBatch(List<String> request) {
     LOGGER.info(
-        String.format("Cleanup up %d orphaned workspaces in internal database...", request.size()));
+        String.format(
+            "Cleaning up %d orphaned workspaces in internal database...", request.size()));
 
     request.forEach(
         namespace -> {
           try {
-            impersonatedWorkspaceService.cleanupWorkspace(namespace, "CleanupOrphanedWorkspaces Cron Job");
+            impersonatedWorkspaceService.cleanupWorkspace(
+                namespace, "CleanupOrphanedWorkspaces Cron Job");
           } catch (NotFoundException e) {
             LOGGER.info(String.format("Workspace (%s) was not found in database", namespace));
           }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 /** Handles offline / cron-based API requests related to workspace management. */
 @RestController
 public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
-  //  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
-  //
   private final TaskQueueService taskQueueService;
   private final WorkspaceService workspaceService;
 

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Handles offline / cron-based API requests related to workspace management. */
 @RestController
 public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
   private final TaskQueueService taskQueueService;

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -1,12 +1,8 @@
 package org.pmiops.workbench.api;
 
-import com.google.common.base.Stopwatch;
-import jakarta.inject.Provider;
 import java.util.List;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,18 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 /** Handles offline / cron-based API requests related to workspace management. */
 @RestController
 public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
-  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
-
-  private final Provider<Stopwatch> stopwatchProvider;
+//  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
+//
   private final TaskQueueService taskQueueService;
   private final WorkspaceService workspaceService;
 
   @Autowired
   public OfflineWorkspaceController(
-      Provider<Stopwatch> stopwatchProvider,
       TaskQueueService taskQueueService,
       WorkspaceService workspaceService) {
-    this.stopwatchProvider = stopwatchProvider;
     this.taskQueueService = taskQueueService;
     this.workspaceService = workspaceService;
   }
@@ -48,7 +41,7 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
     //
     //    stopwatch.reset().start();
     //    List<String> taskIds =
-     taskQueueService.groupAndPushCleanupOrphanedWorkspacesTasks(orphanedNamespaces);
+    taskQueueService.groupAndPushCleanupOrphanedWorkspacesTasks(orphanedNamespaces);
     //    elapsed = stopwatch.stop().elapsed();
     //    logger.info(
     //        String.format(

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -1,0 +1,61 @@
+package org.pmiops.workbench.api;
+
+import com.google.common.base.Stopwatch;
+import jakarta.inject.Provider;
+import java.util.List;
+import org.pmiops.workbench.cloudtasks.TaskQueueService;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Handles offline / cron-based API requests related to workspace management. */
+@RestController
+public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
+  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
+
+  private final Provider<Stopwatch> stopwatchProvider;
+  private final TaskQueueService taskQueueService;
+  private final WorkspaceService workspaceService;
+
+  @Autowired
+  public OfflineWorkspaceController(
+      Provider<Stopwatch> stopwatchProvider,
+      TaskQueueService taskQueueService,
+      WorkspaceService workspaceService) {
+    this.stopwatchProvider = stopwatchProvider;
+    this.taskQueueService = taskQueueService;
+    this.workspaceService = workspaceService;
+  }
+
+  /**
+   * Audits GCP access for all users in the database.
+   *
+   * <p>This API method is called by a cron job and is not part of our normal user-facing surface.
+   */
+  @Override
+  public ResponseEntity<Void> cleanupMissingWorkspaces() {
+    List<String> activeNamespaces = workspaceService.getOrphanedWorkspaceNamespacesAsService();
+    //    Stopwatch stopwatch = stopwatchProvider.get().start();
+    //    List<Long> userIds = userService.getAllUserIdsWithActiveInitialCredits();
+    //    Duration elapsed = stopwatch.stop().elapsed();
+    //    logger.info(
+    //        String.format(
+    //            "checkInitialCreditsExpiration: Retrieved %d user IDs from DB in %s",
+    //            userIds.size(), formatDurationPretty(elapsed)));
+    //
+    //    stopwatch.reset().start();
+    //    List<String> taskIds =
+    // taskQueueService.groupAndPushCheckInitialCreditsExpirationTasks(userIds);
+    //    elapsed = stopwatch.stop().elapsed();
+    //    logger.info(
+    //        String.format(
+    //            "checkInitialCreditsExpiration: Grouped and pushed %d user IDs into %d tasks in
+    // %s",
+    //            userIds.size(), taskIds.size(), formatDurationPretty(elapsed)));
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -22,31 +22,10 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
     this.workspaceService = workspaceService;
   }
 
-  /**
-   * Audits GCP access for all users in the database.
-   *
-   * <p>This API method is called by a cron job and is not part of our normal user-facing surface.
-   */
   @Override
   public ResponseEntity<Void> cleanupOrphanedWorkspaces() {
     List<String> orphanedNamespaces = workspaceService.getOrphanedWorkspaceNamespacesAsService();
-    //    Stopwatch stopwatch = stopwatchProvider.get().start();
-    //    List<Long> userIds = userService.getAllUserIdsWithActiveInitialCredits();
-    //    Duration elapsed = stopwatch.stop().elapsed();
-    //    logger.info(
-    //        String.format(
-    //            "checkInitialCreditsExpiration: Retrieved %d user IDs from DB in %s",
-    //            userIds.size(), formatDurationPretty(elapsed)));
-    //
-    //    stopwatch.reset().start();
-    //    List<String> taskIds =
     taskQueueService.groupAndPushCleanupOrphanedWorkspacesTasks(orphanedNamespaces);
-    //    elapsed = stopwatch.stop().elapsed();
-    //    logger.info(
-    //        String.format(
-    //            "checkInitialCreditsExpiration: Grouped and pushed %d user IDs into %d tasks in
-    // %s",
-    //            userIds.size(), taskIds.size(), formatDurationPretty(elapsed)));
 
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -36,8 +36,8 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
    * <p>This API method is called by a cron job and is not part of our normal user-facing surface.
    */
   @Override
-  public ResponseEntity<Void> cleanupMissingWorkspaces() {
-    List<String> activeNamespaces = workspaceService.getOrphanedWorkspaceNamespacesAsService();
+  public ResponseEntity<Void> cleanupOrphanedWorkspaces() {
+    List<String> orphanedNamespaces = workspaceService.getOrphanedWorkspaceNamespacesAsService();
     //    Stopwatch stopwatch = stopwatchProvider.get().start();
     //    List<Long> userIds = userService.getAllUserIdsWithActiveInitialCredits();
     //    Duration elapsed = stopwatch.stop().elapsed();
@@ -48,7 +48,7 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
     //
     //    stopwatch.reset().start();
     //    List<String> taskIds =
-    // taskQueueService.groupAndPushCheckInitialCreditsExpirationTasks(userIds);
+     taskQueueService.groupAndPushCleanupOrphanedWorkspacesTasks(orphanedNamespaces);
     //    elapsed = stopwatch.stop().elapsed();
     //    logger.info(
     //        String.format(

--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -10,15 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 /** Handles offline / cron-based API requests related to workspace management. */
 @RestController
 public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
-//  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
-//
+  //  private final Logger logger = LoggerFactory.getLogger(OfflineWorkspaceController.class);
+  //
   private final TaskQueueService taskQueueService;
   private final WorkspaceService workspaceService;
 
   @Autowired
   public OfflineWorkspaceController(
-      TaskQueueService taskQueueService,
-      WorkspaceService workspaceService) {
+      TaskQueueService taskQueueService, WorkspaceService workspaceService) {
     this.taskQueueService = taskQueueService;
     this.workspaceService = workspaceService;
   }

--- a/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
+++ b/api/src/main/java/org/pmiops/workbench/cloudtasks/TaskQueueService.java
@@ -49,6 +49,8 @@ public class TaskQueueService {
       new TaskQueuePair("checkPersistentDiskQueue", "checkPersistentDisks");
   public static final TaskQueuePair SYNCHRONIZE_ACCESS =
       new TaskQueuePair("synchronizeAccessQueue", "synchronizeUserAccess");
+  public static final TaskQueuePair CLEANUP_ORPHANED_WORKSPACES =
+      new TaskQueuePair("cleanupOrphanedWorkspacesQueue", "cleanupOrphanedWorkspaces");
 
   // RDR exporting uniquely uses the same queue for two endpoints
 
@@ -156,6 +158,14 @@ public class TaskQueueService {
   public List<String> groupAndPushSynchronizeAccessTasks(List<Long> userIds) {
     OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
     return createAndPushAll(userIds, config.usersPerSynchronizeAccessTask, SYNCHRONIZE_ACCESS);
+  }
+
+  public void groupAndPushCleanupOrphanedWorkspacesTasks(List<String> workspaceNamespaces) {
+    OfflineBatchConfig config = workbenchConfigProvider.get().offlineBatch;
+    createAndPushAll(
+        workspaceNamespaces,
+        config.workspacesPerCleanupOrphanedWorkspacesTask,
+        CLEANUP_ORPHANED_WORKSPACES);
   }
 
   public void groupAndPushAccessExpirationEmailTasks(List<Long> userIds) {

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -432,6 +432,8 @@ public class WorkbenchConfig {
     public Integer workspacesPerDeleteWorkspaceEnvironmentsTask;
     // Number of persistent disks to process within a single check persistent disks task.
     public Integer disksPerCheckPersistentDiskTask;
+    // Number of workspaces to process within a single cleanup missing workspace task.
+    public Integer workspacesPerCleanupOrphanedWorkspacesTask;
   }
 
   /**

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -158,4 +158,7 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
           + "FROM DbWorkspace w "
           + "WHERE w.creator.userId in (:creatorIds)")
   Set<String> getWorkspaceGoogleProjectsForCreators(@Param("creatorIds") List<Long> creatorIds);
+
+  @Query("SELECT DISTINCT w.workspaceNamespace FROM DbWorkspace w WHERE w.activeStatus = 0")
+  List<String> findAllActiveWorkspaceNamespaces();
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -161,4 +161,10 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
 
   @Query("SELECT DISTINCT w.workspaceNamespace FROM DbWorkspace w WHERE w.activeStatus = 0")
   List<String> findAllActiveWorkspaceNamespaces();
+
+  @Query(
+      "SELECT DISTINCT w.workspaceNamespace FROM DbWorkspace w "
+          + "WHERE w.activeStatus = 0 AND w.workspaceNamespace NOT IN (:referencedWorkspaceNamespaces)")
+  List<String> findAllOrphanedWorkspaceNamespaces(
+      @Param("referencedWorkspaceNamespaces") List<String> referencedWorkspaceNamespaces);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -159,9 +159,6 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
           + "WHERE w.creator.userId in (:creatorIds)")
   Set<String> getWorkspaceGoogleProjectsForCreators(@Param("creatorIds") List<Long> creatorIds);
 
-  @Query("SELECT DISTINCT w.workspaceNamespace FROM DbWorkspace w WHERE w.activeStatus = 0")
-  List<String> findAllActiveWorkspaceNamespaces();
-
   @Query(
       "SELECT DISTINCT w.workspaceNamespace FROM DbWorkspace w "
           + "WHERE w.activeStatus = 0 AND w.workspaceNamespace NOT IN (:referencedWorkspaceNamespaces)")

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceService.java
@@ -30,4 +30,6 @@ public interface ImpersonatedWorkspaceService {
       String googleProject,
       String workspaceTerraName,
       boolean deleteBillingProjects);
+
+  void cleanupWorkspace(String workspaceNamespace, String lastModifiedBy);
 }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.impersonation;
 
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -241,8 +242,18 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
     DbWorkspace dbWorkspace = workspaceDao.getByNamespace(workspaceNamespace).orElse(null);
     if (dbWorkspace != null
         && dbWorkspace.getWorkspaceActiveStatusEnum() != WorkspaceActiveStatus.DELETED) {
+      String previousLastModifiedBy = dbWorkspace.getLastModifiedBy();
+      Timestamp previousLastModifiedTime = dbWorkspace.getLastModifiedTime();
       dbWorkspace.setLastModifiedBy(lastModifiedBy);
       dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
+      logger.log(
+          Level.INFO,
+          String.format(
+              "Workspace (%s), that was last updated by %s on %s, has been cleaned up by %s",
+              workspaceNamespace,
+              previousLastModifiedBy,
+              previousLastModifiedTime,
+              lastModifiedBy));
       workspaceDao.save(dbWorkspace);
     }
   }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -235,4 +235,15 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
       }
     }
   }
+
+  @Override
+  public void cleanupWorkspace(String workspaceNamespace, String lastModifiedBy) {
+    DbWorkspace dbWorkspace = workspaceDao.getByNamespace(workspaceNamespace).orElse(null);
+    if (dbWorkspace != null
+        && dbWorkspace.getWorkspaceActiveStatusEnum() != WorkspaceActiveStatus.DELETED) {
+      dbWorkspace.setLastModifiedBy(lastModifiedBy);
+      dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
+      workspaceDao.save(dbWorkspace);
+    }
+  }
 }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -258,7 +258,8 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
               previousLastModifiedTime,
               lastModifiedBy));
       workspaceDao.save(dbWorkspace);
-      // Since a deleted workspace entry still exists in the database we have to explicitly remove it from
+      // Since a deleted workspace entry still exists in the database we have to explicitly remove
+      // it from
       // the featured_workspace table if it exists
       featuredWorkspaceDao.deleteDbFeaturedWorkspaceByWorkspace(dbWorkspace);
     }

--- a/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/impersonation/ImpersonatedWorkspaceServiceImpl.java
@@ -241,7 +241,7 @@ public class ImpersonatedWorkspaceServiceImpl implements ImpersonatedWorkspaceSe
   public void cleanupWorkspace(String workspaceNamespace, String lastModifiedBy) {
     DbWorkspace dbWorkspace = workspaceDao.getByNamespace(workspaceNamespace).orElse(null);
     if (dbWorkspace != null
-        && dbWorkspace.getWorkspaceActiveStatusEnum() != WorkspaceActiveStatus.DELETED) {
+        && dbWorkspace.getWorkspaceActiveStatusEnum() == WorkspaceActiveStatus.ACTIVE) {
       String previousLastModifiedBy = dbWorkspace.getLastModifiedBy();
       Timestamp previousLastModifiedTime = dbWorkspace.getLastModifiedTime();
       dbWorkspace.setLastModifiedBy(lastModifiedBy);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -129,11 +129,6 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
-  public void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeExternalResources) {
-    logger.warn("deleteWorkspace not implemented for VWB");
-  }
-
-  @Override
   public void updateWorkspaceBillingAccount(DbWorkspace workspace, String newBillingAccountName) {
     logger.warn("updateWorkspaceBillingAccount not implemented in VWB");
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -106,6 +106,12 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  public List<String> getOrphanedWorkspaceNamespacesAsService() {
+    logger.warn("getOrphanedWorkspaceNamespacesAsService not implemented in VWB");
+    return Collections.emptyList();
+  }
+
+  @Override
   public List<WorkspaceResponse> getFeaturedWorkspaces() {
     logger.warn("getFeaturedWorkspaces not implemented in VWB");
     return Collections.emptyList();

--- a/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/VwbWorkspaceServiceImpl.java
@@ -129,6 +129,11 @@ public class VwbWorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Override
+  public void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeExternalResources) {
+    logger.warn("deleteWorkspace not implemented for VWB");
+  }
+
+  @Override
   public void updateWorkspaceBillingAccount(DbWorkspace workspace, String newBillingAccountName) {
     logger.warn("updateWorkspaceBillingAccount not implemented in VWB");
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -53,7 +53,22 @@ public interface WorkspaceService {
    */
   String getPublishedWorkspacesGroupEmail();
 
+  /**
+   * This function will delete the workspace and all of its resources, including the billing
+   * project.
+   *
+   * @param dbWorkspace The workspace to delete.
+   */
   void deleteWorkspace(DbWorkspace dbWorkspace);
+
+  /**
+   * This function will delete the workspace and all of its resources, including the billing
+   * project, if includeExternalResources is true.
+   *
+   * @param dbWorkspace The workspace to delete.
+   * @param includeExternalResources If true, delete the billing project and all external resources.
+   */
+  void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeExternalResources);
 
   /*
    * This function will call the Google Cloud Billing API to set the given billing

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -38,6 +38,8 @@ public interface WorkspaceService {
 
   List<String> getActiveWorkspaceNamespacesAsService();
 
+  List<String> getOrphanedWorkspaceNamespacesAsService();
+
   /**
    * Get all Featured workspaces from the DB.
    *

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -61,15 +61,6 @@ public interface WorkspaceService {
    */
   void deleteWorkspace(DbWorkspace dbWorkspace);
 
-  /**
-   * This function will delete the workspace and all of its resources, including the billing
-   * project, if includeExternalResources is true.
-   *
-   * @param dbWorkspace The workspace to delete.
-   * @param includeExternalResources If true, delete the billing project and all external resources.
-   */
-  void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeExternalResources);
-
   /*
    * This function will call the Google Cloud Billing API to set the given billing
    * account name to the given workspace. It will also update the billingAccountName

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceService.java
@@ -53,12 +53,6 @@ public interface WorkspaceService {
    */
   String getPublishedWorkspacesGroupEmail();
 
-  /**
-   * This function will delete the workspace and all of its resources, including the billing
-   * project.
-   *
-   * @param dbWorkspace The workspace to delete.
-   */
   void deleteWorkspace(DbWorkspace dbWorkspace);
 
   /*

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -226,9 +226,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   @Override
   public List<String> getOrphanedWorkspaceNamespacesAsService() {
     List<String> activeWorkspaceNamespaces = getActiveWorkspaceNamespacesAsService();
-    return workspaceDao.findAllActiveWorkspaceNamespaces().stream()
-        .filter(namespace -> !activeWorkspaceNamespaces.contains(namespace))
-        .toList();
+    return workspaceDao.findAllOrphanedWorkspaceNamespaces(activeWorkspaceNamespaces);
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -267,13 +267,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Transactional
-//  @Override
   public void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeTerraResources) {
     // This deletes all Firecloud and google resources, however saves all references
     // to the workspace and its resources in the Workbench database.
     // This is for auditing purposes and potentially workspace restore.
 
-    if(includeTerraResources) {
+    if (includeTerraResources) {
       // This automatically handles access control to the workspace.
       fireCloudService.deleteWorkspace(
           dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -35,7 +35,6 @@ import org.pmiops.workbench.dataset.DataSetService;
 import org.pmiops.workbench.db.dao.FeaturedWorkspaceDao;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.UserRecentWorkspaceDao;
-import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbAccessTier;
 import org.pmiops.workbench.db.model.DbCdrVersion;
@@ -141,7 +140,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
       UserDao userDao,
       UserMapper userMapper,
       UserRecentWorkspaceDao userRecentWorkspaceDao,
-      UserService userService,
       WorkspaceAuthService workspaceAuthService,
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper) {
@@ -223,6 +221,14 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             rwbNamespaces.size(), formatDurationPretty(elapsed)));
 
     return rwbNamespaces;
+  }
+
+  @Override
+  public List<String> getOrphanedWorkspaceNamespacesAsService() {
+    List<String> activeWorkspaceNamespaces = getActiveWorkspaceNamespacesAsService();
+    return workspaceDao.findAllActiveWorkspaceNamespaces().stream()
+        .filter(namespace -> !activeWorkspaceNamespaces.contains(namespace))
+        .toList();
   }
 
   @Override

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -273,12 +273,12 @@ public class WorkspaceServiceImpl implements WorkspaceService {
   }
 
   @Transactional
-  public void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeTerraResources) {
+  public void deleteWorkspace(DbWorkspace dbWorkspace, boolean includeExternalResources) {
     // This deletes all Firecloud and google resources, however saves all references
     // to the workspace and its resources in the Workbench database.
     // This is for auditing purposes and potentially workspace restore.
 
-    if (includeTerraResources) {
+    if (includeExternalResources) {
       // This automatically handles access control to the workspace.
       fireCloudService.deleteWorkspace(
           dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2640,14 +2640,14 @@ paths:
         204:
           description: No content.
           content: {}
-  /v1/cron/cleanupMissingWorkspaces:
+  /v1/cron/cleanupOrphanedWorkspaces:
     get:
       tags:
       - offlineWorkspace
       - cron
       description: Occasionally Terra workspaces are deleted without being cleaned
-        up in Workbench. This endpoint cleans up those missing workspaces.
-      operationId: cleanupMissingWorkspaces
+        up in Workbench. This endpoint cleans up those orphaned workspaces.
+      operationId: cleanupOrphanedWorkspaces
       security: []
       responses:
         204:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4601,7 +4601,7 @@ paths:
       - cloudTaskWorkspaces
       - cloudTask
       description: |
-        Cleans up workspace records in the database that are no longer Terra.
+        Cleans up workspace records in the database that are no longer in Terra.
       operationId: cleanupOrphanedWorkspacesBatch
       security: []
       requestBody:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4602,7 +4602,7 @@ paths:
       - cloudTask
       description: |
         Cleans up workspace records in the database that are no longer Terra.
-      operationId: cleanupOrphanedWorkspaces
+      operationId: cleanupOrphanedWorkspacesBatch
       security: []
       requestBody:
         description: Batch of workspaces cleanup tasks to process.

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2640,6 +2640,19 @@ paths:
         204:
           description: No content.
           content: {}
+  /v1/cron/cleanupMissingWorkspaces:
+    get:
+      tags:
+      - offlineWorkspace
+      - cron
+      description: Occasionally Terra workspaces are deleted without being cleaned
+        up in Workbench. This endpoint cleans up those missing workspaces.
+      operationId: cleanupMissingWorkspaces
+      security: []
+      responses:
+        204:
+          description: No content.
+          content: {}
   /v1/cron/deleteTestUserWorkspacesOrphanedInRawls:
     get:
       tags:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4595,6 +4595,27 @@ paths:
           description: Reporting data uploaded successfully
           content: {}
       x-codegen-request-body-name: request
+  /v1/cloudTask/cleanupOrphanedWorkspaces:
+    post:
+      tags:
+      - cloudTaskWorkspaces
+      - cloudTask
+      description: |
+        Cleans up workspace records in the database that are no longer Terra.
+      operationId: cleanupOrphanedWorkspaces
+      security: []
+      requestBody:
+        description: Batch of workspaces cleanup tasks to process.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceNamespaceList'
+        required: true
+      responses:
+        200:
+          description: Workspaces cleaned
+          content: {}
+      x-codegen-request-body-name: request
   /v1/institutions:
     get:
       tags:

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -92,3 +92,9 @@ cron:
   schedule: every day 22:30
   timezone: America/Chicago
   target: api
+- description: >
+    Cleanup orphaned workspaces in database but not in Rawls.
+  url: /v1/cron/cleanupOrphanedWorkspaces
+  schedule: every day 21:00
+  timezone: America/Chicago
+  target: api

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -176,3 +176,11 @@ queue:
   bucket_size: 10
   rate: 1/s
   max_concurrent_requests: 1
+
+- name: cleanupOrphanedWorkspacesQueue
+  target: api
+
+  # rate parameters
+  bucket_size: 10
+  rate: 1/s
+  max_concurrent_requests: 1

--- a/api/src/main/webapp/WEB-INF/queue.yaml
+++ b/api/src/main/webapp/WEB-INF/queue.yaml
@@ -181,6 +181,6 @@ queue:
   target: api
 
   # rate parameters
-  bucket_size: 10
+  bucket_size: 100
   rate: 1/s
   max_concurrent_requests: 1

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -53,36 +53,22 @@ public class CloudTaskWorkspacesControllerTest {
     assertEquals("Response should be OK", ResponseEntity.ok().build(), response);
   }
 
-  // Helper method for setting up successful cleanup
-  private void setupSuccessfulCleanup(String... namespaces) {
-    for (String namespace : namespaces) {
-      doNothing()
-          .when(mockImpersonatedWorkspaceService)
-          .cleanupWorkspace(namespace, CLEANUP_REASON);
-    }
-  }
-
-  // Helper method for setting up failed cleanup
-  private void setupFailedCleanup(String... namespaces) {
-    for (String namespace : namespaces) {
-      doThrow(new NotFoundException("Workspace not found"))
-          .when(mockImpersonatedWorkspaceService)
-          .cleanupWorkspace(namespace, CLEANUP_REASON);
-    }
-  }
-
   // Parameterized test data for successful scenarios
   static Stream<Arguments> successfulCleanupScenarios() {
     return Stream.of(
         Arguments.of("Single workspace", List.of("single-workspace-ns"), 1),
-        Arguments.of("Multiple workspaces", List.of("workspace-ns-1", "workspace-ns-2", "workspace-ns-3"), 3),
-        Arguments.of("Duplicate workspaces", List.of("workspace-ns", "workspace-ns", "workspace-ns"), 3)
-    );
+        Arguments.of(
+            "Multiple workspaces",
+            List.of("workspace-ns-1", "workspace-ns-2", "workspace-ns-3"),
+            3),
+        Arguments.of(
+            "Duplicate workspaces", List.of("workspace-ns", "workspace-ns", "workspace-ns"), 3));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("successfulCleanupScenarios")
-  void testCleanupOrphanedWorkspacesBatch_successfulScenarios(String scenario, List<String> namespaces, int expectedCalls) {
+  void testCleanupOrphanedWorkspacesBatch_successfulScenarios(
+      String scenario, List<String> namespaces, int expectedCalls) {
     // Arrange
     doNothing()
         .when(mockImpersonatedWorkspaceService)
@@ -129,12 +115,10 @@ public class CloudTaskWorkspacesControllerTest {
     assertOkResponse(response);
 
     // Verify all cleanup attempts were made
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("existing-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("existing-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService)
         .cleanupWorkspace("non-existent-workspace", CLEANUP_REASON);
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("another-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("another-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService, times(3))
         .cleanupWorkspace(any(String.class), eq(CLEANUP_REASON));
   }
@@ -166,8 +150,7 @@ public class CloudTaskWorkspacesControllerTest {
 
     // Verify the exact string "CleanupOrphanedWorkspaces Cron Job" is used as lastModifiedBy
     // parameter
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("test-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("test-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService, never())
         .cleanupWorkspace(eq("test-workspace"), eq("system"));
     verify(mockImpersonatedWorkspaceService, never())

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -61,9 +61,12 @@ public class CloudTaskWorkspacesControllerTest {
     assertEquals("Response should be OK", ResponseEntity.ok().build(), response);
     verify(mockImpersonatedWorkspaceService, times(3))
         .cleanupWorkspace(any(String.class), eq("CleanupOrphanedWorkspaces Cron Job"));
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("workspace-ns-1", "CleanupOrphanedWorkspaces Cron Job");
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("workspace-ns-2", "CleanupOrphanedWorkspaces Cron Job");
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("workspace-ns-3", "CleanupOrphanedWorkspaces Cron Job");
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("workspace-ns-1", "CleanupOrphanedWorkspaces Cron Job");
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("workspace-ns-2", "CleanupOrphanedWorkspaces Cron Job");
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("workspace-ns-3", "CleanupOrphanedWorkspaces Cron Job");
   }
 
   @Test
@@ -113,10 +116,12 @@ public class CloudTaskWorkspacesControllerTest {
     assertEquals("Response should be OK", ResponseEntity.ok().build(), response);
 
     // Verify all cleanup attempts were made
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("existing-workspace", "CleanupOrphanedWorkspaces Cron Job");
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("existing-workspace", "CleanupOrphanedWorkspaces Cron Job");
     verify(mockImpersonatedWorkspaceService)
         .cleanupWorkspace("non-existent-workspace", "CleanupOrphanedWorkspaces Cron Job");
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("another-workspace", "CleanupOrphanedWorkspaces Cron Job");
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("another-workspace", "CleanupOrphanedWorkspaces Cron Job");
     verify(mockImpersonatedWorkspaceService, times(3))
         .cleanupWorkspace(any(String.class), eq("CleanupOrphanedWorkspaces Cron Job"));
   }
@@ -187,8 +192,10 @@ public class CloudTaskWorkspacesControllerTest {
 
     controller.cleanupOrphanedWorkspacesBatch(namespaces);
 
-    // Verify the exact string "CleanupOrphanedWorkspaces Cron Job" is used as lastModifiedBy parameter
-    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("test-workspace", "CleanupOrphanedWorkspaces Cron Job");
+    // Verify the exact string "CleanupOrphanedWorkspaces Cron Job" is used as lastModifiedBy
+    // parameter
+    verify(mockImpersonatedWorkspaceService)
+        .cleanupWorkspace("test-workspace", "CleanupOrphanedWorkspaces Cron Job");
     verify(mockImpersonatedWorkspaceService, never())
         .cleanupWorkspace(eq("test-workspace"), eq("system"));
     verify(mockImpersonatedWorkspaceService, never())

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -14,15 +14,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.pmiops.workbench.exceptions.NotFoundException;
-import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,14 +43,18 @@ public class CloudTaskWorkspacesControllerTest {
   static Stream<Arguments> successfulCleanupScenarios() {
     return Stream.of(
         Arguments.of("Single workspace", List.of("single-workspace-ns"), 1),
-        Arguments.of("Multiple workspaces", List.of("workspace-ns-1", "workspace-ns-2", "workspace-ns-3"), 3),
-        Arguments.of("Duplicate workspaces", List.of("workspace-ns", "workspace-ns", "workspace-ns"), 3)
-    );
+        Arguments.of(
+            "Multiple workspaces",
+            List.of("workspace-ns-1", "workspace-ns-2", "workspace-ns-3"),
+            3),
+        Arguments.of(
+            "Duplicate workspaces", List.of("workspace-ns", "workspace-ns", "workspace-ns"), 3));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("successfulCleanupScenarios")
-  void testCleanupOrphanedWorkspacesBatch_successfulScenarios(String scenario, List<String> namespaces, int expectedCalls) {
+  void testCleanupOrphanedWorkspacesBatch_successfulScenarios(
+      String scenario, List<String> namespaces, int expectedCalls) {
     // Arrange
     doNothing()
         .when(mockImpersonatedWorkspaceService)
@@ -97,12 +101,10 @@ public class CloudTaskWorkspacesControllerTest {
     assertOkResponse(response);
 
     // Verify all cleanup attempts were made
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("existing-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("existing-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService)
         .cleanupWorkspace("non-existent-workspace", CLEANUP_REASON);
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("another-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("another-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService, times(3))
         .cleanupWorkspace(any(String.class), eq(CLEANUP_REASON));
   }
@@ -134,8 +136,7 @@ public class CloudTaskWorkspacesControllerTest {
 
     // Verify the exact string "CleanupOrphanedWorkspaces Cron Job" is used as lastModifiedBy
     // parameter
-    verify(mockImpersonatedWorkspaceService)
-        .cleanupWorkspace("test-workspace", CLEANUP_REASON);
+    verify(mockImpersonatedWorkspaceService).cleanupWorkspace("test-workspace", CLEANUP_REASON);
     verify(mockImpersonatedWorkspaceService, never())
         .cleanupWorkspace(eq("test-workspace"), eq("system"));
     verify(mockImpersonatedWorkspaceService, never())

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -39,7 +39,7 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withValidNamespaces_deletesWorkspacesAndReturnsOk() {
+  void cleanupOrphanedWorkspacesBatch_withValidNamespaces_deletesWorkspacesAndReturnsOk() {
     // Arrange
     List<String> namespaces = Arrays.asList("namespace1", "namespace2", "namespace3");
 
@@ -54,7 +54,7 @@ class CloudTaskWorkspacesControllerTest {
     doNothing().when(mockWorkspaceService).deleteWorkspace(any(DbWorkspace.class), eq(false));
 
     // Act
-    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspacesBatch(namespaces);
 
     // Assert
     assertValidResponse(response);
@@ -68,12 +68,12 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withEmptyList_doesNothingAndReturnsOk() {
+  void cleanupOrphanedWorkspacesBatch_withEmptyList_doesNothingAndReturnsOk() {
     // Arrange
     List<String> emptyNamespaces = Collections.emptyList();
 
     // Act
-    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(emptyNamespaces);
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspacesBatch(emptyNamespaces);
 
     // Assert
     assertValidResponse(response);
@@ -81,7 +81,7 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withSingleNamespace_deletesWorkspaceAndReturnsOk() {
+  void cleanupOrphanedWorkspacesBatch_withSingleNamespace_deletesWorkspaceAndReturnsOk() {
     // Arrange
     List<String> namespaces = Collections.singletonList("single-namespace");
     DbWorkspace workspace = createMockWorkspace("single-namespace");
@@ -90,7 +90,7 @@ class CloudTaskWorkspacesControllerTest {
     doNothing().when(mockWorkspaceService).deleteWorkspace(workspace, false);
 
     // Act
-    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspacesBatch(namespaces);
 
     // Assert
     assertValidResponse(response);
@@ -100,7 +100,7 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withNotFoundWorkspace_continuesProcessingAndReturnsOk() {
+  void cleanupOrphanedWorkspacesBatch_withNotFoundWorkspace_continuesProcessingAndReturnsOk() {
     // Arrange
     List<String> namespaces =
         Arrays.asList("existing-namespace", "missing-namespace", "another-existing");
@@ -118,7 +118,7 @@ class CloudTaskWorkspacesControllerTest {
     doNothing().when(mockWorkspaceService).deleteWorkspace(any(DbWorkspace.class), eq(false));
 
     // Act
-    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspacesBatch(namespaces);
 
     // Assert
     assertValidResponse(response);
@@ -131,7 +131,7 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withDeleteFailure_throwsException() {
+  void cleanupOrphanedWorkspacesBatch_withDeleteFailure_throwsException() {
     // Arrange
     List<String> namespaces = Arrays.asList("namespace1", "namespace2");
 
@@ -149,7 +149,7 @@ class CloudTaskWorkspacesControllerTest {
     // Act & Assert
     RuntimeException exception =
         org.junit.jupiter.api.Assertions.assertThrows(
-            RuntimeException.class, () -> controller.cleanupOrphanedWorkspaces(namespaces));
+            RuntimeException.class, () -> controller.cleanupOrphanedWorkspacesBatch(namespaces));
 
     assertThat(exception.getMessage()).isEqualTo("Delete failed");
     verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace1");
@@ -160,7 +160,7 @@ class CloudTaskWorkspacesControllerTest {
   }
 
   @Test
-  void cleanupOrphanedWorkspaces_withNotFoundAndSuccessfulDelete_processesAllAndReturnsOk() {
+  void cleanupOrphanedWorkspacesBatch_withNotFoundAndSuccessfulDelete_processesAllAndReturnsOk() {
     // Arrange
     List<String> namespaces = Arrays.asList("success1", "notfound", "success2");
 
@@ -176,7 +176,7 @@ class CloudTaskWorkspacesControllerTest {
     doNothing().when(mockWorkspaceService).deleteWorkspace(successWorkspace2, false);
 
     // Act
-    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspacesBatch(namespaces);
 
     // Assert
     assertValidResponse(response);

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pmiops.workbench.FakeClockConfiguration;
 import org.pmiops.workbench.exceptions.NotFoundException;
@@ -42,11 +41,6 @@ public class CloudTaskWorkspacesControllerTest {
     ImpersonatedWorkspaceService.class,
   })
   static class Configuration {}
-
-  @BeforeEach
-  public void setUp() {
-    // Reset mocks before each test
-  }
 
   @Test
   public void testCleanupOrphanedWorkspacesBatch_success() {

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskWorkspacesControllerTest.java
@@ -1,0 +1,201 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.NotFoundException;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class CloudTaskWorkspacesControllerTest {
+
+  @Mock private ImpersonatedWorkspaceService mockImpersonatedWorkspaceService;
+  @Mock private WorkspaceService mockWorkspaceService;
+
+  private CloudTaskWorkspacesController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller =
+        new CloudTaskWorkspacesController(mockImpersonatedWorkspaceService, mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withValidNamespaces_deletesWorkspacesAndReturnsOk() {
+    // Arrange
+    List<String> namespaces = Arrays.asList("namespace1", "namespace2", "namespace3");
+
+    DbWorkspace workspace1 = createMockWorkspace("namespace1");
+    DbWorkspace workspace2 = createMockWorkspace("namespace2");
+    DbWorkspace workspace3 = createMockWorkspace("namespace3");
+
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("namespace1")).thenReturn(workspace1);
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("namespace2")).thenReturn(workspace2);
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("namespace3")).thenReturn(workspace3);
+
+    doNothing().when(mockWorkspaceService).deleteWorkspace(any(DbWorkspace.class), eq(false));
+
+    // Act
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+
+    // Assert
+    assertValidResponse(response);
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace1");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace2");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace3");
+    verify(mockWorkspaceService).deleteWorkspace(workspace1, false);
+    verify(mockWorkspaceService).deleteWorkspace(workspace2, false);
+    verify(mockWorkspaceService).deleteWorkspace(workspace3, false);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withEmptyList_doesNothingAndReturnsOk() {
+    // Arrange
+    List<String> emptyNamespaces = Collections.emptyList();
+
+    // Act
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(emptyNamespaces);
+
+    // Assert
+    assertValidResponse(response);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withSingleNamespace_deletesWorkspaceAndReturnsOk() {
+    // Arrange
+    List<String> namespaces = Collections.singletonList("single-namespace");
+    DbWorkspace workspace = createMockWorkspace("single-namespace");
+
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("single-namespace")).thenReturn(workspace);
+    doNothing().when(mockWorkspaceService).deleteWorkspace(workspace, false);
+
+    // Act
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+
+    // Assert
+    assertValidResponse(response);
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("single-namespace");
+    verify(mockWorkspaceService).deleteWorkspace(workspace, false);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withNotFoundWorkspace_continuesProcessingAndReturnsOk() {
+    // Arrange
+    List<String> namespaces =
+        Arrays.asList("existing-namespace", "missing-namespace", "another-existing");
+
+    DbWorkspace existingWorkspace1 = createMockWorkspace("existing-namespace");
+    DbWorkspace existingWorkspace2 = createMockWorkspace("another-existing");
+
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("existing-namespace"))
+        .thenReturn(existingWorkspace1);
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("missing-namespace"))
+        .thenThrow(new NotFoundException("Workspace not found"));
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("another-existing"))
+        .thenReturn(existingWorkspace2);
+
+    doNothing().when(mockWorkspaceService).deleteWorkspace(any(DbWorkspace.class), eq(false));
+
+    // Act
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+
+    // Assert
+    assertValidResponse(response);
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("existing-namespace");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("missing-namespace");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("another-existing");
+    verify(mockWorkspaceService).deleteWorkspace(existingWorkspace1, false);
+    verify(mockWorkspaceService).deleteWorkspace(existingWorkspace2, false);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withDeleteFailure_throwsException() {
+    // Arrange
+    List<String> namespaces = Arrays.asList("namespace1", "namespace2");
+
+    DbWorkspace workspace1 = createMockWorkspace("namespace1");
+    DbWorkspace workspace2 = createMockWorkspace("namespace2");
+
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("namespace1")).thenReturn(workspace1);
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("namespace2")).thenReturn(workspace2);
+
+    doNothing().when(mockWorkspaceService).deleteWorkspace(workspace1, false);
+    doThrow(new RuntimeException("Delete failed"))
+        .when(mockWorkspaceService)
+        .deleteWorkspace(workspace2, false);
+
+    // Act & Assert
+    RuntimeException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            RuntimeException.class, () -> controller.cleanupOrphanedWorkspaces(namespaces));
+
+    assertThat(exception.getMessage()).isEqualTo("Delete failed");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace1");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("namespace2");
+    verify(mockWorkspaceService).deleteWorkspace(workspace1, false);
+    verify(mockWorkspaceService).deleteWorkspace(workspace2, false);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  @Test
+  void cleanupOrphanedWorkspaces_withNotFoundAndSuccessfulDelete_processesAllAndReturnsOk() {
+    // Arrange
+    List<String> namespaces = Arrays.asList("success1", "notfound", "success2");
+
+    DbWorkspace successWorkspace1 = createMockWorkspace("success1");
+    DbWorkspace successWorkspace2 = createMockWorkspace("success2");
+
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("success1")).thenReturn(successWorkspace1);
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("notfound"))
+        .thenThrow(new NotFoundException("Not found"));
+    when(mockWorkspaceService.lookupWorkspaceByNamespace("success2")).thenReturn(successWorkspace2);
+
+    doNothing().when(mockWorkspaceService).deleteWorkspace(successWorkspace1, false);
+    doNothing().when(mockWorkspaceService).deleteWorkspace(successWorkspace2, false);
+
+    // Act
+    ResponseEntity<Void> response = controller.cleanupOrphanedWorkspaces(namespaces);
+
+    // Assert
+    assertValidResponse(response);
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("success1");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("notfound");
+    verify(mockWorkspaceService).lookupWorkspaceByNamespace("success2");
+    verify(mockWorkspaceService).deleteWorkspace(successWorkspace1, false);
+    verify(mockWorkspaceService).deleteWorkspace(successWorkspace2, false);
+    verifyNoMoreInteractions(mockWorkspaceService);
+  }
+
+  private DbWorkspace createMockWorkspace(String namespace) {
+    DbWorkspace workspace = new DbWorkspace();
+    workspace.setWorkspaceNamespace(namespace);
+    return workspace;
+  }
+
+  private void assertValidResponse(ResponseEntity<Void> response) {
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNull();
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -332,7 +332,8 @@ public class WorkspaceDaoTest {
   public void findAllOrphanedWorkspaceNamespaces_empty() {
     workspaceDao.deleteAll();
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -356,7 +357,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).containsExactly(namespace1, namespace2);
   }
@@ -380,7 +382,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
   }
@@ -416,8 +419,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(knownWorkspace1);
     workspaceDao.save(knownWorkspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
-        List.of(knownNamespace1, knownNamespace2));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace1, knownNamespace2));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace1, orphanedNamespace2);
   }
@@ -441,8 +444,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
-        List.of(namespace1, namespace2));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(namespace1, namespace2));
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -472,7 +475,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return the active orphaned workspace, not the deleted one
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
@@ -505,7 +509,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace2);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return one instance of the orphaned namespace due to DISTINCT
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -519,8 +519,7 @@ public class WorkspaceDaoTest {
   public void findAllOrphanedWorkspaceNamespaces_empty() {
     workspaceDao.deleteAll();
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -532,11 +531,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "orphaned-namespace-1";
     String namespace2 = "orphaned-namespace-2";
 
-    DbWorkspace workspace1 =
+    DbWorkspace workspace1 = 
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 =
+    DbWorkspace workspace2 = 
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -544,8 +543,7 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).containsExactly(namespace1, namespace2);
   }
@@ -557,11 +555,11 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace orphanedWorkspace =
+    DbWorkspace orphanedWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace =
+    DbWorkspace knownWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -569,8 +567,7 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
   }
@@ -584,19 +581,19 @@ public class WorkspaceDaoTest {
     String knownNamespace1 = "known-namespace-1";
     String knownNamespace2 = "known-namespace-2";
 
-    DbWorkspace orphanedWorkspace1 =
+    DbWorkspace orphanedWorkspace1 = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 =
+    DbWorkspace orphanedWorkspace2 = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace1 =
+    DbWorkspace knownWorkspace1 = 
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace2 =
+    DbWorkspace knownWorkspace2 = 
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -606,8 +603,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(knownWorkspace1);
     workspaceDao.save(knownWorkspace2);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace1, knownNamespace2));
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
+        List.of(knownNamespace1, knownNamespace2));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace1, orphanedNamespace2);
   }
@@ -619,11 +616,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "namespace-1";
     String namespace2 = "namespace-2";
 
-    DbWorkspace workspace1 =
+    DbWorkspace workspace1 = 
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 =
+    DbWorkspace workspace2 = 
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -631,8 +628,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(namespace1, namespace2));
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
+        List.of(namespace1, namespace2));
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -645,15 +642,15 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace deletedWorkspace =
+    DbWorkspace deletedWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(deletedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    DbWorkspace orphanedWorkspace =
+    DbWorkspace orphanedWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace =
+    DbWorkspace knownWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -662,8 +659,7 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return the active orphaned workspace, not the deleted one
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
@@ -677,17 +673,17 @@ public class WorkspaceDaoTest {
     String knownNamespace = "known-namespace";
 
     // Create multiple workspaces with the same orphaned namespace
-    DbWorkspace orphanedWorkspace1 =
+    DbWorkspace orphanedWorkspace1 = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-1")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 =
+    DbWorkspace orphanedWorkspace2 = 
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-2")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace =
+    DbWorkspace knownWorkspace = 
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -696,8 +692,7 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace2);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces =
-        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return one instance of the orphaned namespace due to DISTINCT
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -519,7 +519,8 @@ public class WorkspaceDaoTest {
   public void findAllOrphanedWorkspaceNamespaces_empty() {
     workspaceDao.deleteAll();
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -531,11 +532,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "orphaned-namespace-1";
     String namespace2 = "orphaned-namespace-2";
 
-    DbWorkspace workspace1 = 
+    DbWorkspace workspace1 =
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 = 
+    DbWorkspace workspace2 =
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -543,7 +544,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(Collections.emptyList());
 
     assertThat(orphanedNamespaces).containsExactly(namespace1, namespace2);
   }
@@ -555,11 +557,11 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace orphanedWorkspace = 
+    DbWorkspace orphanedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -567,7 +569,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
   }
@@ -581,19 +584,19 @@ public class WorkspaceDaoTest {
     String knownNamespace1 = "known-namespace-1";
     String knownNamespace2 = "known-namespace-2";
 
-    DbWorkspace orphanedWorkspace1 = 
+    DbWorkspace orphanedWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 = 
+    DbWorkspace orphanedWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace1 = 
+    DbWorkspace knownWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace2 = 
+    DbWorkspace knownWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -603,8 +606,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(knownWorkspace1);
     workspaceDao.save(knownWorkspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
-        List.of(knownNamespace1, knownNamespace2));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace1, knownNamespace2));
 
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace1, orphanedNamespace2);
   }
@@ -616,11 +619,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "namespace-1";
     String namespace2 = "namespace-2";
 
-    DbWorkspace workspace1 = 
+    DbWorkspace workspace1 =
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 = 
+    DbWorkspace workspace2 =
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -628,8 +631,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(workspace1);
     workspaceDao.save(workspace2);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(
-        List.of(namespace1, namespace2));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(namespace1, namespace2));
 
     assertThat(orphanedNamespaces).isEmpty();
   }
@@ -642,15 +645,15 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace deletedWorkspace = 
+    DbWorkspace deletedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(deletedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    DbWorkspace orphanedWorkspace = 
+    DbWorkspace orphanedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -659,7 +662,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return the active orphaned workspace, not the deleted one
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);
@@ -673,17 +677,17 @@ public class WorkspaceDaoTest {
     String knownNamespace = "known-namespace";
 
     // Create multiple workspaces with the same orphaned namespace
-    DbWorkspace orphanedWorkspace1 = 
+    DbWorkspace orphanedWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-1")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 = 
+    DbWorkspace orphanedWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-2")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -692,7 +696,8 @@ public class WorkspaceDaoTest {
     workspaceDao.save(orphanedWorkspace2);
     workspaceDao.save(knownWorkspace);
 
-    List<String> orphanedNamespaces = workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
+    List<String> orphanedNamespaces =
+        workspaceDao.findAllOrphanedWorkspaceNamespaces(List.of(knownNamespace));
 
     // Should only return one instance of the orphaned namespace due to DISTINCT
     assertThat(orphanedNamespaces).containsExactly(orphanedNamespace);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -329,193 +329,6 @@ public class WorkspaceDaoTest {
   }
 
   @Test
-  public void findAllActiveWorkspaceNamespaces_empty() {
-    workspaceDao.deleteAll();
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    assertThat(namespaces).isEmpty();
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_singleActive() {
-    workspaceDao.deleteAll();
-
-    String namespace = "test-namespace-1";
-    DbWorkspace workspace =
-        createWorkspace()
-            .setWorkspaceNamespace(namespace)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    workspaceDao.save(workspace);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    assertThat(namespaces).containsExactly(namespace);
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_multipleActive() {
-    workspaceDao.deleteAll();
-
-    String namespace1 = "test-namespace-1";
-    String namespace2 = "test-namespace-2";
-    String namespace3 = "test-namespace-3";
-
-    DbWorkspace workspace1 =
-        createWorkspace()
-            .setWorkspaceNamespace(namespace1)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 =
-        createWorkspace()
-            .setWorkspaceNamespace(namespace2)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace3 =
-        createWorkspace()
-            .setWorkspaceNamespace(namespace3)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-
-    workspaceDao.save(workspace1);
-    workspaceDao.save(workspace2);
-    workspaceDao.save(workspace3);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    assertThat(namespaces).containsExactly(namespace1, namespace2, namespace3);
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_excludesDeleted() {
-    workspaceDao.deleteAll();
-
-    String activeNamespace = "active-namespace";
-    String deletedNamespace = "deleted-namespace";
-
-    DbWorkspace activeWorkspace =
-        createWorkspace()
-            .setWorkspaceNamespace(activeNamespace)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace deletedWorkspace =
-        createWorkspace()
-            .setWorkspaceNamespace(deletedNamespace)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-
-    workspaceDao.save(activeWorkspace);
-    workspaceDao.save(deletedWorkspace);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    assertThat(namespaces).containsExactly(activeNamespace);
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_duplicateNamespaces() {
-    workspaceDao.deleteAll();
-
-    String sharedNamespace = "shared-namespace";
-
-    // Create two workspaces with the same namespace but different firecloud names
-    DbWorkspace workspace1 =
-        createWorkspace()
-            .setWorkspaceNamespace(sharedNamespace)
-            .setFirecloudName("firecloud-name-1")
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 =
-        createWorkspace()
-            .setWorkspaceNamespace(sharedNamespace)
-            .setFirecloudName("firecloud-name-2")
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-
-    workspaceDao.save(workspace1);
-    workspaceDao.save(workspace2);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    // Should only return one instance of the shared namespace due to DISTINCT
-    assertThat(namespaces).containsExactly(sharedNamespace);
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_mixedStatusesWithDuplicates() {
-    workspaceDao.deleteAll();
-
-    String activeNamespace1 = "active-namespace-1";
-    String activeNamespace2 = "active-namespace-2";
-    String deletedNamespace = "deleted-namespace";
-    String sharedNamespace = "shared-namespace";
-
-    // Active workspaces
-    DbWorkspace activeWorkspace1 =
-        createWorkspace()
-            .setWorkspaceNamespace(activeNamespace1)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace activeWorkspace2 =
-        createWorkspace()
-            .setWorkspaceNamespace(activeNamespace2)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-
-    // Deleted workspace
-    DbWorkspace deletedWorkspace =
-        createWorkspace()
-            .setWorkspaceNamespace(deletedNamespace)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-
-    // Multiple active workspaces with shared namespace
-    DbWorkspace sharedActiveWorkspace1 =
-        createWorkspace()
-            .setWorkspaceNamespace(sharedNamespace)
-            .setFirecloudName("shared-firecloud-1")
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace sharedActiveWorkspace2 =
-        createWorkspace()
-            .setWorkspaceNamespace(sharedNamespace)
-            .setFirecloudName("shared-firecloud-2")
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-
-    // One deleted workspace with shared namespace
-    DbWorkspace sharedDeletedWorkspace =
-        createWorkspace()
-            .setWorkspaceNamespace(sharedNamespace)
-            .setFirecloudName("shared-firecloud-deleted")
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-
-    workspaceDao.save(activeWorkspace1);
-    workspaceDao.save(activeWorkspace2);
-    workspaceDao.save(deletedWorkspace);
-    workspaceDao.save(sharedActiveWorkspace1);
-    workspaceDao.save(sharedActiveWorkspace2);
-    workspaceDao.save(sharedDeletedWorkspace);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    // Should return distinct namespaces from active workspaces only
-    assertThat(namespaces).containsExactly(activeNamespace1, activeNamespace2, sharedNamespace);
-  }
-
-  @Test
-  public void findAllActiveWorkspaceNamespaces_onlyDeletedWorkspaces() {
-    workspaceDao.deleteAll();
-
-    String deletedNamespace1 = "deleted-namespace-1";
-    String deletedNamespace2 = "deleted-namespace-2";
-
-    DbWorkspace deletedWorkspace1 =
-        createWorkspace()
-            .setWorkspaceNamespace(deletedNamespace1)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    DbWorkspace deletedWorkspace2 =
-        createWorkspace()
-            .setWorkspaceNamespace(deletedNamespace2)
-            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-
-    workspaceDao.save(deletedWorkspace1);
-    workspaceDao.save(deletedWorkspace2);
-
-    List<String> namespaces = workspaceDao.findAllActiveWorkspaceNamespaces();
-
-    assertThat(namespaces).isEmpty();
-  }
-
-  @Test
   public void findAllOrphanedWorkspaceNamespaces_empty() {
     workspaceDao.deleteAll();
 
@@ -531,11 +344,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "orphaned-namespace-1";
     String namespace2 = "orphaned-namespace-2";
 
-    DbWorkspace workspace1 = 
+    DbWorkspace workspace1 =
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 = 
+    DbWorkspace workspace2 =
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -555,11 +368,11 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace orphanedWorkspace = 
+    DbWorkspace orphanedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -581,19 +394,19 @@ public class WorkspaceDaoTest {
     String knownNamespace1 = "known-namespace-1";
     String knownNamespace2 = "known-namespace-2";
 
-    DbWorkspace orphanedWorkspace1 = 
+    DbWorkspace orphanedWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 = 
+    DbWorkspace orphanedWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace1 = 
+    DbWorkspace knownWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace2 = 
+    DbWorkspace knownWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -616,11 +429,11 @@ public class WorkspaceDaoTest {
     String namespace1 = "namespace-1";
     String namespace2 = "namespace-2";
 
-    DbWorkspace workspace1 = 
+    DbWorkspace workspace1 =
         createWorkspace()
             .setWorkspaceNamespace(namespace1)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace workspace2 = 
+    DbWorkspace workspace2 =
         createWorkspace()
             .setWorkspaceNamespace(namespace2)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -642,15 +455,15 @@ public class WorkspaceDaoTest {
     String orphanedNamespace = "orphaned-namespace";
     String knownNamespace = "known-namespace";
 
-    DbWorkspace deletedWorkspace = 
+    DbWorkspace deletedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(deletedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    DbWorkspace orphanedWorkspace = 
+    DbWorkspace orphanedWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
@@ -673,17 +486,17 @@ public class WorkspaceDaoTest {
     String knownNamespace = "known-namespace";
 
     // Create multiple workspaces with the same orphaned namespace
-    DbWorkspace orphanedWorkspace1 = 
+    DbWorkspace orphanedWorkspace1 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-1")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace orphanedWorkspace2 = 
+    DbWorkspace orphanedWorkspace2 =
         createWorkspace()
             .setWorkspaceNamespace(orphanedNamespace)
             .setFirecloudName("firecloud-2")
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
-    DbWorkspace knownWorkspace = 
+    DbWorkspace knownWorkspace =
         createWorkspace()
             .setWorkspaceNamespace(knownNamespace)
             .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceDaoTest.java
@@ -387,6 +387,12 @@ public class WorkspaceDaoTest {
             List.of("namespace-1", "namespace-2"), // namespaces in db
             List.of("namespace-1", "namespace-2"), // externally referenced namespaces
             Collections.emptyList() // expected orphaned
+            ),
+        Arguments.of(
+            "Mixed bag - some orphaned, some externally referenced",
+            List.of("orphaned-1", "orphaned-2", "referenced-1", "referenced-2"), // namespaces in db
+            List.of("referenced-1", "referenced-2"), // externally referenced namespaces
+            List.of("orphaned-1", "orphaned-2") // expected orphaned
             ));
   }
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +58,7 @@ import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.FailedPreconditionException;
 import org.pmiops.workbench.exceptions.ForbiddenException;
+import org.pmiops.workbench.exfiltration.EgressRemediationService;
 import org.pmiops.workbench.exfiltration.ObjectNameLengthServiceImpl;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.google.CloudBillingClient;
@@ -79,6 +81,7 @@ import org.pmiops.workbench.utils.mappers.FirecloudMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -113,6 +116,7 @@ public class WorkspaceServiceTest {
     CohortService.class,
     ConceptSetService.class,
     DataSetService.class,
+    EgressRemediationService.class,
     FeaturedWorkspaceMapper.class,
     IamService.class,
     InitialCreditsService.class,
@@ -138,6 +142,12 @@ public class WorkspaceServiceTest {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     Stopwatch stopwatch() {
       return Stopwatch.createUnstarted();
+    }
+
+    @Bean
+    @Qualifier("objectLengthsEgressService")
+    EgressRemediationService objectLengthsEgressService() {
+      return mock(EgressRemediationService.class);
     }
   }
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/WorkspaceServiceTest.java
@@ -408,7 +408,6 @@ public class WorkspaceServiceTest {
             accessLevel);
     firecloudWorkspaceResponses.add(mockWorkspaceListResponse);
     when(mockFireCloudService.listWorkspaces()).thenReturn(firecloudWorkspaceResponses);
-
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -1,0 +1,155 @@
+package org.pmiops.workbench.workspaces.impersonation;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.pmiops.workbench.FakeClockConfiguration;
+import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
+import org.pmiops.workbench.db.dao.FeaturedWorkspaceDao;
+import org.pmiops.workbench.db.dao.UserDao;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.firecloud.FireCloudService;
+import org.pmiops.workbench.impersonation.ImpersonatedFirecloudService;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
+import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceServiceImpl;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
+import org.pmiops.workbench.model.WorkspaceActiveStatus;
+import org.pmiops.workbench.utils.mappers.FirecloudMapper;
+import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ImpersonatedWorkspaceServiceTest {
+
+  @TestConfiguration
+  @Import({
+    FakeClockConfiguration.class,
+    ImpersonatedWorkspaceServiceImpl.class,
+  })
+  @MockBean({
+    BillingProjectAuditor.class,
+    FeaturedWorkspaceDao.class,
+    FireCloudService.class,
+    FirecloudMapper.class,
+    ImpersonatedFirecloudService.class,
+    InitialCreditsService.class,
+    UserDao.class,
+    WorkspaceMapper.class
+  })
+  static class Configuration {}
+
+  @Autowired private ImpersonatedWorkspaceService impersonatedWorkspaceService;
+  @MockBean private WorkspaceDao workspaceDao;
+
+  private static final String WORKSPACE_NAMESPACE = "test-workspace-namespace";
+  private static final String LAST_MODIFIED_BY = "test-user@example.com";
+
+  @Test
+  public void testCleanupWorkspace_WorkspaceExists_SetsDeletedStatusAndLastModifiedBy() {
+    // Arrange
+    DbWorkspace dbWorkspace = createTestWorkspace();
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(dbWorkspace));
+
+    // Act
+    impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
+
+    // Assert
+    ArgumentCaptor<DbWorkspace> workspaceCaptor = ArgumentCaptor.forClass(DbWorkspace.class);
+    verify(workspaceDao).save(workspaceCaptor.capture());
+
+    DbWorkspace savedWorkspace = workspaceCaptor.getValue();
+    assertThat(savedWorkspace.getLastModifiedBy()).isEqualTo(LAST_MODIFIED_BY);
+    assertThat(savedWorkspace.getWorkspaceActiveStatusEnum())
+        .isEqualTo(WorkspaceActiveStatus.DELETED);
+
+    // Verify that the same workspace object was modified
+    assertThat(savedWorkspace).isSameInstanceAs(dbWorkspace);
+  }
+
+  @Test
+  public void testCleanupWorkspace_WorkspaceDoesNotExist_NoOperationPerformed() {
+    // Arrange
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.empty());
+
+    // Act
+    impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
+
+    // Assert
+    verify(workspaceDao, never()).save(any(DbWorkspace.class));
+  }
+
+  @Test
+  public void testCleanupWorkspace_WorkspaceAlreadyDeleted_NoOperationPerformed() {
+    // Arrange
+    DbWorkspace dbWorkspace = createTestWorkspace();
+    dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
+    dbWorkspace.setLastModifiedBy("previous-user@example.com");
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(dbWorkspace));
+
+    // Act
+    impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
+
+    // Assert - No save should be called since workspace is already deleted
+    verify(workspaceDao, never()).save(any(DbWorkspace.class));
+  }
+
+  @Test
+  public void testCleanupWorkspace_WorkspaceActiveStatus_UpdatesIfNotDeleted() {
+    // Test that only non-deleted workspaces are updated
+    DbWorkspace activeWorkspace = createTestWorkspace();
+    activeWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(activeWorkspace));
+
+    impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
+
+    // Should call save for active workspace
+    verify(workspaceDao).save(activeWorkspace);
+    assertThat(activeWorkspace.getWorkspaceActiveStatusEnum())
+        .isEqualTo(WorkspaceActiveStatus.DELETED);
+    assertThat(activeWorkspace.getLastModifiedBy()).isEqualTo(LAST_MODIFIED_BY);
+  }
+
+  @Test
+  public void testCleanupWorkspace_DaoThrowsException_ExceptionPropagated() {
+    // Arrange
+    DbWorkspace dbWorkspace = createTestWorkspace();
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(dbWorkspace));
+    RuntimeException expectedException = new RuntimeException("Database error");
+    when(workspaceDao.save(any(DbWorkspace.class))).thenThrow(expectedException);
+
+    // Act & Assert
+    RuntimeException thrownException =
+        assertThrows(
+            RuntimeException.class,
+            () -> impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY));
+
+    assertThat(thrownException).isSameInstanceAs(expectedException);
+    assertThat(thrownException.getMessage()).isEqualTo("Database error");
+
+    // Verify that save was attempted
+    verify(workspaceDao).save(any(DbWorkspace.class));
+  }
+
+  private DbWorkspace createTestWorkspace() {
+    DbWorkspace workspace = new DbWorkspace();
+    workspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
+    workspace.setFirecloudName("test-firecloud-name");
+    workspace.setLastModifiedBy("original-user@example.com");
+    workspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
+    return workspace;
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -107,7 +107,8 @@ public class ImpersonatedWorkspaceServiceTest {
 
   @ParameterizedTest
   @MethodSource("noOperationScenarios")
-  public void testCleanupWorkspace_NoOperationPerformed(String scenarioName, Optional<DbWorkspace> workspaceOptional) {
+  public void testCleanupWorkspace_NoOperationPerformed(
+      String scenarioName, Optional<DbWorkspace> workspaceOptional) {
     // Arrange
     when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(workspaceOptional);
 
@@ -121,18 +122,17 @@ public class ImpersonatedWorkspaceServiceTest {
   private static Stream<Arguments> noOperationScenarios() {
     // Workspace does not exist scenario
     Optional<DbWorkspace> emptyOptional = Optional.empty();
-    
+
     // Workspace already deleted scenario
     DbWorkspace deletedWorkspace = new DbWorkspace();
     deletedWorkspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
     deletedWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
     deletedWorkspace.setLastModifiedBy("previous-user@example.com");
     Optional<DbWorkspace> deletedOptional = Optional.of(deletedWorkspace);
-    
+
     return Stream.of(
         Arguments.of("WorkspaceDoesNotExist", emptyOptional),
-        Arguments.of("WorkspaceAlreadyDeleted", deletedOptional)
-    );
+        Arguments.of("WorkspaceAlreadyDeleted", deletedOptional));
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -73,13 +73,15 @@ public class ImpersonatedWorkspaceServiceTest {
       this.lastLogRecord = record;
     }
 
-    /** Implementation of flush is not needed for this test handler. */
     @Override
-    public void flush() {}
+    public void flush() {
+      /* Implementation of flush is not needed for this test handler. */
+    }
 
-    /** Implementation of close is not needed for this test handler. */
     @Override
-    public void close() throws SecurityException {}
+    public void close() throws SecurityException {
+      /* Implementation of close is not needed for this test handler. */
+    }
 
     public LogRecord getLastLogRecord() {
       return lastLogRecord;

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -120,7 +120,8 @@ public class ImpersonatedWorkspaceServiceTest {
 
     // Assert
     verify(workspaceDao, never()).save(any(DbWorkspace.class));
-    verify(featuredWorkspaceDao, never()).deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
+    verify(featuredWorkspaceDao, never())
+        .deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
   }
 
   private static Stream<Arguments> noOperationScenarios() {
@@ -160,7 +161,8 @@ public class ImpersonatedWorkspaceServiceTest {
 
     // Verify that save was attempted but featured workspace cleanup was not called due to exception
     verify(workspaceDao).save(any(DbWorkspace.class));
-    verify(featuredWorkspaceDao, never()).deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
+    verify(featuredWorkspaceDao, never())
+        .deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
   }
 
   @Test
@@ -220,7 +222,8 @@ public class ImpersonatedWorkspaceServiceTest {
 
     // Assert
     verify(workspaceDao, never()).save(any(DbWorkspace.class));
-    verify(featuredWorkspaceDao, never()).deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
+    verify(featuredWorkspaceDao, never())
+        .deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
   }
 
   @Test
@@ -228,14 +231,16 @@ public class ImpersonatedWorkspaceServiceTest {
     // Arrange
     DbWorkspace deletedWorkspace = createTestWorkspace();
     deletedWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED);
-    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(deletedWorkspace));
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE))
+        .thenReturn(Optional.of(deletedWorkspace));
 
     // Act
     impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
 
     // Assert
     verify(workspaceDao, never()).save(any(DbWorkspace.class));
-    verify(featuredWorkspaceDao, never()).deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
+    verify(featuredWorkspaceDao, never())
+        .deleteDbFeaturedWorkspaceByWorkspace(any(DbWorkspace.class));
   }
 
   @Test
@@ -244,7 +249,9 @@ public class ImpersonatedWorkspaceServiceTest {
     DbWorkspace dbWorkspace = createTestWorkspace();
     when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(dbWorkspace));
     RuntimeException expectedException = new RuntimeException("Featured workspace DAO error");
-    doThrow(expectedException).when(featuredWorkspaceDao).deleteDbFeaturedWorkspaceByWorkspace(dbWorkspace);
+    doThrow(expectedException)
+        .when(featuredWorkspaceDao)
+        .deleteDbFeaturedWorkspaceByWorkspace(dbWorkspace);
 
     // Act & Assert
     RuntimeException thrownException =
@@ -257,8 +264,9 @@ public class ImpersonatedWorkspaceServiceTest {
     assertThat(thrownException).isSameInstanceAs(expectedException);
     assertThat(thrownException.getMessage()).isEqualTo("Featured workspace DAO error");
 
-    // Verify that both workspace save and featured workspace cleanup were attempted during the transaction
-    // Note: Due to @Transactional annotation, the workspace save will be rolled back when the 
+    // Verify that both workspace save and featured workspace cleanup were attempted during the
+    // transaction
+    // Note: Due to @Transactional annotation, the workspace save will be rolled back when the
     // featured workspace cleanup fails, but both method calls should still occur
     verify(workspaceDao).save(any(DbWorkspace.class));
     verify(featuredWorkspaceDao).deleteDbFeaturedWorkspaceByWorkspace(dbWorkspace);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -73,9 +73,15 @@ public class ImpersonatedWorkspaceServiceTest {
       this.lastLogRecord = record;
     }
 
+    /**
+     * Implementation of flush is not needed for this test handler.
+     */
     @Override
     public void flush() {}
 
+    /**
+     * Implementation of close is not needed for this test handler.
+     */
     @Override
     public void close() throws SecurityException {}
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -17,11 +17,14 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.pmiops.workbench.FakeClockConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.pmiops.workbench.actionaudit.auditors.BillingProjectAuditor;
 import org.pmiops.workbench.db.dao.FeaturedWorkspaceDao;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -29,43 +32,26 @@ import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.impersonation.ImpersonatedFirecloudService;
-import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceService;
 import org.pmiops.workbench.impersonation.ImpersonatedWorkspaceServiceImpl;
 import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.WorkspaceActiveStatus;
 import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 
-@DataJpaTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@ExtendWith(MockitoExtension.class)
 public class ImpersonatedWorkspaceServiceTest {
 
-  @TestConfiguration
-  @Import({
-    FakeClockConfiguration.class,
-    ImpersonatedWorkspaceServiceImpl.class,
-  })
-  @MockBean({
-    BillingProjectAuditor.class,
-    FeaturedWorkspaceDao.class,
-    FireCloudService.class,
-    FirecloudMapper.class,
-    ImpersonatedFirecloudService.class,
-    InitialCreditsService.class,
-    UserDao.class,
-    WorkspaceMapper.class
-  })
-  static class Configuration {}
+  @Mock private BillingProjectAuditor billingProjectAuditor;
+  @Mock private FeaturedWorkspaceDao featuredWorkspaceDao;
+  @Mock private FireCloudService fireCloudService;
+  @Mock private FirecloudMapper firecloudMapper;
+  @Mock private ImpersonatedFirecloudService impersonatedFirecloudService;
+  @Mock private InitialCreditsService initialCreditsService;
+  @Mock private UserDao userDao;
+  @Mock private WorkspaceDao workspaceDao;
+  @Mock private WorkspaceMapper workspaceMapper;
 
-  @Autowired private ImpersonatedWorkspaceService impersonatedWorkspaceService;
-  @MockBean private WorkspaceDao workspaceDao;
-  @MockBean private FeaturedWorkspaceDao featuredWorkspaceDao;
+  @InjectMocks private ImpersonatedWorkspaceServiceImpl impersonatedWorkspaceService;
 
   private static final String WORKSPACE_NAMESPACE = "test-workspace-namespace";
   private static final String LAST_MODIFIED_BY = "test-user@example.com";

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -73,15 +73,11 @@ public class ImpersonatedWorkspaceServiceTest {
       this.lastLogRecord = record;
     }
 
-    /**
-     * Implementation of flush is not needed for this test handler.
-     */
+    /** Implementation of flush is not needed for this test handler. */
     @Override
     public void flush() {}
 
-    /**
-     * Implementation of close is not needed for this test handler.
-     */
+    /** Implementation of close is not needed for this test handler. */
     @Override
     public void close() throws SecurityException {}
 

--- a/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/impersonation/ImpersonatedWorkspaceServiceTest.java
@@ -7,7 +7,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pmiops.workbench.FakeClockConfiguration;
@@ -57,6 +63,26 @@ public class ImpersonatedWorkspaceServiceTest {
 
   private static final String WORKSPACE_NAMESPACE = "test-workspace-namespace";
   private static final String LAST_MODIFIED_BY = "test-user@example.com";
+
+  // Custom log handler to capture log messages for testing
+  private static class TestLogHandler extends Handler {
+    private LogRecord lastLogRecord;
+
+    @Override
+    public void publish(LogRecord record) {
+      this.lastLogRecord = record;
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+
+    public LogRecord getLastLogRecord() {
+      return lastLogRecord;
+    }
+  }
 
   @Test
   public void testCleanupWorkspace_WorkspaceExists_SetsDeletedStatusAndLastModifiedBy() {
@@ -135,7 +161,9 @@ public class ImpersonatedWorkspaceServiceTest {
     RuntimeException thrownException =
         assertThrows(
             RuntimeException.class,
-            () -> impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY));
+            () ->
+                impersonatedWorkspaceService.cleanupWorkspace(
+                    WORKSPACE_NAMESPACE, LAST_MODIFIED_BY));
 
     assertThat(thrownException).isSameInstanceAs(expectedException);
     assertThat(thrownException.getMessage()).isEqualTo("Database error");
@@ -144,11 +172,59 @@ public class ImpersonatedWorkspaceServiceTest {
     verify(workspaceDao).save(any(DbWorkspace.class));
   }
 
+  @Test
+  public void testCleanupWorkspace_LogsWorkspaceCleanupDetails() {
+    // Arrange
+    DbWorkspace dbWorkspace = createTestWorkspace();
+    String originalUser = "original-user@example.com";
+    Timestamp originalTimestamp = Timestamp.from(Instant.parse("2025-07-20T10:15:30.00Z"));
+
+    dbWorkspace.setLastModifiedBy(originalUser);
+    dbWorkspace.setLastModifiedTime(originalTimestamp);
+
+    when(workspaceDao.getByNamespace(WORKSPACE_NAMESPACE)).thenReturn(Optional.of(dbWorkspace));
+
+    // Set up log capture
+    Logger logger =
+        Logger.getLogger("org.pmiops.workbench.impersonation.ImpersonatedWorkspaceServiceImpl");
+    TestLogHandler testHandler = new TestLogHandler();
+    logger.addHandler(testHandler);
+    logger.setLevel(Level.INFO);
+
+    try {
+      // Act
+      impersonatedWorkspaceService.cleanupWorkspace(WORKSPACE_NAMESPACE, LAST_MODIFIED_BY);
+
+      // Assert
+      LogRecord logRecord = testHandler.getLastLogRecord();
+      assertThat(logRecord).isNotNull();
+      assertThat(logRecord.getLevel()).isEqualTo(Level.INFO);
+
+      String logMessage = logRecord.getMessage();
+      assertThat(logMessage).contains("Workspace (" + WORKSPACE_NAMESPACE + ")");
+      assertThat(logMessage).contains("that was last updated by " + originalUser);
+      assertThat(logMessage).contains("on " + originalTimestamp);
+      assertThat(logMessage).contains("has been cleaned up by " + LAST_MODIFIED_BY);
+
+      // Verify the full expected message format
+      String expectedMessage =
+          String.format(
+              "Workspace (%s), that was last updated by %s on %s, has been cleaned up by %s",
+              WORKSPACE_NAMESPACE, originalUser, originalTimestamp, LAST_MODIFIED_BY);
+      assertThat(logMessage).isEqualTo(expectedMessage);
+
+    } finally {
+      // Clean up
+      logger.removeHandler(testHandler);
+    }
+  }
+
   private DbWorkspace createTestWorkspace() {
     DbWorkspace workspace = new DbWorkspace();
     workspace.setWorkspaceNamespace(WORKSPACE_NAMESPACE);
     workspace.setFirecloudName("test-firecloud-name");
     workspace.setLastModifiedBy("original-user@example.com");
+    workspace.setLastModifiedTime(Timestamp.from(Instant.parse("2025-07-22T09:00:00.00Z")));
     workspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE);
     return workspace;
   }

--- a/api/tools/src/cron/README.md
+++ b/api/tools/src/cron/README.md
@@ -1,3 +1,3 @@
 # Developer Cron Scripts
 This directory contains several scripts that run cron jobs that a normally scheduled.
-This is intended as a convience for developers to run these jobs manually.
+This is intended as a convenience for developers to run these jobs manually.

--- a/api/tools/src/cron/README.md
+++ b/api/tools/src/cron/README.md
@@ -1,3 +1,4 @@
 # Developer Cron Scripts
+
 This directory contains several scripts that run cron jobs that a normally scheduled.
 This is intended as a convenience for developers to run these jobs manually.

--- a/api/tools/src/cron/README.md
+++ b/api/tools/src/cron/README.md
@@ -1,3 +1,3 @@
-## Developer Cron Scripts
+# Developer Cron Scripts
 This directory contains several scripts that run cron jobs that a normally scheduled.
 This is intended as a convience for developers to run these jobs manually.

--- a/api/tools/src/cron/README.md
+++ b/api/tools/src/cron/README.md
@@ -1,3 +1,3 @@
-# Developer Cron Scripts
+## Developer Cron Scripts
 This directory contains several scripts that run cron jobs that a normally scheduled.
 This is intended as a convience for developers to run these jobs manually.

--- a/api/tools/src/cron/README.md
+++ b/api/tools/src/cron/README.md
@@ -1,0 +1,3 @@
+# Developer Cron Scripts
+This directory contains several scripts that run cron jobs that a normally scheduled.
+This is intended as a convience for developers to run these jobs manually.

--- a/api/tools/src/cron/cleanupOrphanedWorkspaces.sh
+++ b/api/tools/src/cron/cleanupOrphanedWorkspaces.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -X GET 'http://localhost:8081/v1/cron/cleanupOrphanedWorkspaces' \
+  --header "X-AppEngine-Cron: true"


### PR DESCRIPTION
### Overview
Sets up a cron job that finds all of the workspaces present in the RWB  but not in Terra. These workspaces are considered orphaned. In batches, these workspaces are set to active_status=1 (deleted).

### Workflow Diagram
<img width="884" height="567" alt="image" src="https://github.com/user-attachments/assets/473ff38b-45b1-4824-b3af-4395e72cc7b4" />

[Lucid Chart Version of Diagram](https://lucid.app/lucidchart/91b8d7ed-2991-44e1-8a44-6d1a77d4b254/edit?viewport_loc=-336%2C-68%2C3442%2C1592%2Cb6gBZmypYXLQ&invitationId=inv_1c2b19fa-f7fa-46ad-b7db-83f71fa79ed5)

### Components
<ins>**config_**</ins> - Configures how many workspaces can be cleaned up in a single cloud task for the specified environment.

<ins>**cron_base.yaml**</ins> - sets up what endpoint(`/v1/cron/cleanupOrphanedWorkspaces`) will be called and when (every day 21:00 CT).

<ins>**queue.yaml**</ins> - Updated this to establish the `cleanupOrphanedWorkspacesQueue` in order to queue the cloud tasks related to cleaning up orphaned workspaces.

<ins>**workbench-api.yaml**</ins> - Sets up two new end points. One for a cron and one for a cloud task:

- connects endpoint (`/v1/cron/cleanupOrphanedWorkspaces`) to controller (OfflineWorkspaceController.java) function (cleanupOrphanedWorkspaces).
- connects endpoint (`/v1/cloudTask/cleanupOrphanedWorkspaces`) to controller (CloudTaskWorkspacesController.java) function (cleanupOrphanedWorkspacesBatch).

<ins>**OfflineWorkspaceController(cleanupOrphanedWorkspaces)**</ins> - Gets all orphaned workspaces from the WorkspaceService and passes them to the TaskQueueService.

<ins>**WorkspaceServiceImpl(getOrphanedWorkspaceNamespacesAsService)**</ins> - Gets all active workspaces from Terra and then finds the orphaned workspaces via WorkspaceDao's `findAllOrphanedWorkspaceNamespaces` function.

<ins>**WorkspaceDao(findAllOrphanedWorkspaceNamespaces)**</ins> - Queries the database to find all active (active_status = 0) workspaces that are not present in the list of workspace namespaces provided.

<ins>**TaskQueueService (groupAndPushCleanupOrphanedWorkspacesTasks)**</ins> - Takes a list of workspace namespaces and splits them up into batches on the `cleanupOrphanedWorkspacesQueue` to be sent to this endpoint `/v1/cloudTask/cleanupOrphanedWorkspaces`

<ins>**CloudTaskWorkspacesController (cleanupOrphanedWorkspacesBatch)**</ins> - For each workspace in a cloud task, calls `ImpersonatedWorkspaceServiceImpl`'s `cleanupWorkspace`.

<ins>**ImpersonatedWorkspaceServiceImpl (cleanupWorkspace)**</ins> - Sets workspace to deleted (active_status=1) and updates last modified information via the `WorkspaceDao`.

### How to Test
In your local environment, insert an workspace to your workspace table without creating it through the application. You could run the following query:
```
INSERT INTO workbench.workspace (name,workspace_namespace,firecloud_name,cdr_version_id,creator_id,creation_time,last_modified_time,version,active_status,billing_migration_status,billing_account_name,disseminate_research_other,google_project,admin_locked,admin_locked_reason,last_modified_by,initial_credits_exhausted,uses_tanagra,is_vwb_workspace) VALUES
	 ('FakeWorkspace','aou-rw-fake','fake',NULL,4,'2025-04-07 19:34:05','2025-04-07 19:34:05',3,1,0,'billingAccounts/fake',NULL,NULL,0,NULL,'Fake User',0,0,0);
```

Once you inserted the fake workspace record, you can run `./api/tools/src/cron/cleanupOrphanedWorkspaces.sh` to start the cleanupOrphanedWorkspaces cron job locally.

If the job runs successfully, the record should get its `active_status` set to 1 (deleted), its `last_modified_time` set to roughly the current time, and its `last_modified_by` value set to "CleanupOrphanedWorkspaces Cron Job".

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [x] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
