### PR TITLE
[WIP][RW-15653][risk=no] Use workspace user cache when checking for unshared Leonardo resources

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -5,21 +5,10 @@ import static org.pmiops.workbench.utils.LogFormatters.formatDurationPretty;
 import com.google.common.base.Stopwatch;
 import jakarta.inject.Provider;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
-import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.disks.DiskAdminService;
-import org.pmiops.workbench.exceptions.WorkbenchException;
-import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
-import org.pmiops.workbench.leonardo.LeonardoApiClient;
-import org.pmiops.workbench.leonardo.LeonardoStatusUtils;
+import org.pmiops.workbench.environments.EnvironmentsAdminService;
 import org.pmiops.workbench.model.Disk;
-import org.pmiops.workbench.model.UserAppEnvironment;
-import org.pmiops.workbench.model.UserRole;
-import org.pmiops.workbench.workspaces.WorkspaceService;
-import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,23 +19,17 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
       Logger.getLogger(CloudTaskEnvironmentsController.class.getName());
 
   private final DiskAdminService diskAdminService;
-  private final LeonardoApiClient leonardoApiClient;
+  private final EnvironmentsAdminService environmentsAdminService;
   private final Provider<Stopwatch> stopwatchProvider;
-  private final WorkspaceService workspaceService;
-  private final WorkspaceUserCacheService workspaceUserCacheService;
 
   @Autowired
   public CloudTaskEnvironmentsController(
       DiskAdminService diskAdminService,
-      LeonardoApiClient leonardoApiClient,
-      Provider<Stopwatch> stopwatchProvider,
-      WorkspaceService workspaceService,
-      WorkspaceUserCacheService workspaceUserCacheService) {
+      EnvironmentsAdminService environmentsAdminService,
+      Provider<Stopwatch> stopwatchProvider) {
     this.diskAdminService = diskAdminService;
-    this.leonardoApiClient = leonardoApiClient;
+    this.environmentsAdminService = environmentsAdminService;
     this.stopwatchProvider = stopwatchProvider;
-    this.workspaceService = workspaceService;
-    this.workspaceUserCacheService = workspaceUserCacheService;
   }
 
   @Override
@@ -57,20 +40,12 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             "Deleting unshared environments for %d workspaces.", workspaceNamespaces.size()));
 
     var stopwatch = stopwatchProvider.get().start();
-    long failedUserRoles =
-        workspaceService.lookupWorkspacesByNamespace(workspaceNamespaces).stream()
-            .filter(
-                ws -> {
-                  boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
-                  return !successfulGetFirecloudUserRoles;
-                })
-            .count();
+    var failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(workspaceNamespaces);
     var elapsed = stopwatch.stop().elapsed();
     LOGGER.info(
         String.format(
             "Attempted to delete unshared environments for %d workspaces (%d failures) in %s.",
-            workspaceNamespaces.size(), failedUserRoles, formatDurationPretty(elapsed)));
-
+            workspaceNamespaces.size(), failures, formatDurationPretty(elapsed)));
     return ResponseEntity.ok().build();
   }
 
@@ -87,215 +62,5 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             persistentDiskBatch.size(), formatDurationPretty(elapsed)));
 
     return ResponseEntity.ok().build();
-  }
-
-  /**
-   * Delete runtimes, apps, and disks in the given workspace that are not owned by any user with
-   * access to the workspace. In most cases, we have nothing to delete. If we find any potential
-   * resources to delete, we refetch the current workspace ACL before deleting in case the cache is
-   * stale. We delete runtimes and apps before disks, since deleting a runtime or app will also
-   * delete its associated disk.
-   *
-   * <p>The overall flow is: 1. Get workspace users out of cache 2. Fetch runtimes and apps from
-   * Leonardo 3. Find runtime and app deletion candidates 4. If we have any runtime or app
-   * candidates, refetch current workspace users 5. Confirm that runtime or app candidates should
-   * still be deleted based on current ACL 6. Delete runtime or app candidates 7. Fetch disks from
-   * Leonardo 8. Find disk deletion candidates 9. If we have any disk candidates, and we didn't
-   * refetch workspace current users, do so now 10. If we have any disk candidates, and we did
-   * refetch workspace current users, use those 11. Confirm that disk candidates should still be
-   * deleted based on current ACL 12. Delete candidates
-   *
-   * @param dbWorkspace the workspace to check for unshared environments and disks
-   * @return true if we were able to get current users from Rawls, false if that call failed
-   */
-  private boolean deleteUnshared(DbWorkspace dbWorkspace) {
-    // this call often fails on Test.  TODO: investigate.
-
-    // get users out of cache
-    var cachedUsers = workspaceUserCacheService.getWorkspaceUsers(dbWorkspace.getWorkspaceId());
-
-    // check for runtimes and apps to delete
-    var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
-    var deletableRuntimes =
-        runtimes.stream().filter(LeonardoStatusUtils::canDeleteRuntime).toList();
-    var possibleRuntimesToDelete =
-        deletableRuntimes.stream()
-            .filter(runtime -> !cachedUsers.contains(runtime.getAuditInfo().getCreator()))
-            .toList();
-
-    var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
-    var deletableApps = apps.stream().filter(LeonardoStatusUtils::canDeleteApp).toList();
-    var possibleAppsToDelete =
-        deletableApps.stream().filter(app -> !cachedUsers.contains(app.getCreator())).toList();
-
-    // if we have any apps or runtimes to delete, refetch current users before trying to delete
-    final Set<String> currentUsers;
-    if (!possibleRuntimesToDelete.isEmpty() || !possibleAppsToDelete.isEmpty()) {
-      try {
-        currentUsers = getCurrentUsers(dbWorkspace);
-      } catch (WorkbenchException e) {
-        return false;
-      }
-
-      // maybe delete runtimes and apps
-      maybeDeleteRuntimes(dbWorkspace, deletableRuntimes, currentUsers, runtimes.size());
-      maybeDeleteApps(dbWorkspace, deletableApps, currentUsers, apps.size());
-    } else {
-      currentUsers = null;
-    }
-
-    return deleteUnsharedDisks(dbWorkspace, cachedUsers, currentUsers);
-  }
-
-  private void maybeDeleteRuntimes(
-      DbWorkspace dbWorkspace,
-      List<LeonardoListRuntimeResponse> deletableRuntimes,
-      Set<String> currentUsers,
-      Integer totalRuntimes) {
-    var runtimesToDelete =
-        deletableRuntimes.stream()
-            .filter(runtime -> !currentUsers.contains(runtime.getAuditInfo().getCreator()))
-            .toList();
-
-    if (!runtimesToDelete.isEmpty()) {
-      LOGGER.info(
-          String.format(
-              "Deleting %d runtimes for workspace %s/%s (ID %d) out of %d total",
-              runtimesToDelete.size(),
-              dbWorkspace.getWorkspaceNamespace(),
-              dbWorkspace.getFirecloudName(),
-              dbWorkspace.getWorkspaceId(),
-              totalRuntimes));
-      runtimesToDelete.forEach(
-          runtime -> {
-            try {
-              leonardoApiClient.deleteRuntimeAsService(
-                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /* deleteDisk */ true);
-            } catch (WorkbenchException e) {
-              LOGGER.warning(
-                  String.format(
-                      "Failed to delete runtime %s in project %s: %s",
-                      runtime.getRuntimeName(), dbWorkspace.getGoogleProject(), e.getMessage()));
-            }
-          });
-    }
-  }
-
-  private void maybeDeleteApps(
-      DbWorkspace dbWorkspace,
-      List<UserAppEnvironment> deletableApps,
-      Set<String> currentUsers,
-      Integer totalApps) {
-    var appsToDelete =
-        deletableApps.stream().filter(app -> !currentUsers.contains(app.getCreator())).toList();
-
-    if (!appsToDelete.isEmpty()) {
-      LOGGER.info(
-          String.format(
-              "Deleting %d apps for workspace %s/%s (ID %d) out of %d total",
-              appsToDelete.size(),
-              dbWorkspace.getWorkspaceNamespace(),
-              dbWorkspace.getFirecloudName(),
-              dbWorkspace.getWorkspaceId(),
-              totalApps));
-      appsToDelete.forEach(
-          app -> {
-            try {
-              leonardoApiClient.deleteAppAsService(
-                  app.getAppName(), dbWorkspace, /* deleteDisk */ true);
-            } catch (WorkbenchException e) {
-              LOGGER.warning(
-                  String.format(
-                      "Failed to delete app %s in project %s: %s",
-                      app.getAppName(), dbWorkspace.getGoogleProject(), e.getMessage()));
-            }
-          });
-    }
-  }
-
-  private boolean deleteUnsharedDisks(
-      DbWorkspace dbWorkspace, Set<String> cachedUsers, Set<String> currentUsers) {
-    // check for disks to delete
-    // (check disks after runtime and app deletion, because these will delete their associated
-    // disks)
-    var disks = leonardoApiClient.listDisksByProjectAsService(dbWorkspace.getGoogleProject());
-    var deletableDisks = disks.stream().filter(LeonardoStatusUtils::canDeleteDisk).toList();
-    var potentialDisksToDelete =
-        deletableDisks.stream()
-            .filter(disk -> !cachedUsers.contains(disk.getAuditInfo().getCreator()))
-            .toList();
-
-    // if we have any to delete, and we haven't refetched current users, do so now
-    // if we have any to delete, and we've already refetched current users, then use that
-    if (!potentialDisksToDelete.isEmpty()) {
-      final Set<String> diskCurrentUsers;
-      if (currentUsers == null) {
-        try {
-          diskCurrentUsers = getCurrentUsers(dbWorkspace);
-        } catch (WorkbenchException e) {
-          return false;
-        }
-      } else {
-        diskCurrentUsers = currentUsers;
-      }
-
-      maybeDeleteDisks(dbWorkspace, deletableDisks, diskCurrentUsers, disks.size());
-    }
-
-    return true;
-  }
-
-  private void maybeDeleteDisks(
-      DbWorkspace dbWorkspace,
-      List<ListPersistentDiskResponse> deletableDisks,
-      Set<String> currentUsers,
-      Integer totalDisks) {
-    var disksToDelete =
-        deletableDisks.stream()
-            .filter(disk -> !currentUsers.contains(disk.getAuditInfo().getCreator()))
-            .toList();
-
-    if (!disksToDelete.isEmpty()) {
-      LOGGER.info(
-          String.format(
-              "Deleting %d disks for workspace %s/%s (ID %d) out of %d total",
-              disksToDelete.size(),
-              dbWorkspace.getWorkspaceNamespace(),
-              dbWorkspace.getFirecloudName(),
-              dbWorkspace.getWorkspaceId(),
-              totalDisks));
-      disksToDelete.forEach(
-          disk -> {
-            try {
-              leonardoApiClient.deletePersistentDiskAsService(
-                  dbWorkspace.getGoogleProject(), disk.getName());
-            } catch (WorkbenchException e) {
-              LOGGER.warning(
-                  String.format(
-                      "Failed to delete disk %s in project %s: %s",
-                      disk.getName(), dbWorkspace.getGoogleProject(), e.getMessage()));
-            }
-          });
-    }
-  }
-
-  private Set<String> getCurrentUsers(DbWorkspace dbWorkspace) {
-    try {
-      return workspaceService
-          .getFirecloudUserRoles(
-              dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
-          .stream()
-          .map(UserRole::getEmail)
-          .collect(Collectors.toSet());
-    } catch (WorkbenchException e) {
-      LOGGER.warning(
-          String.format(
-              "Failed to get user roles for workspace %s/%s (ID %d): %s",
-              dbWorkspace.getWorkspaceNamespace(),
-              dbWorkspace.getFirecloudName(),
-              dbWorkspace.getWorkspaceId(),
-              e.getMessage()));
-      throw e;
-    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -40,7 +40,8 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             "Deleting unshared environments for %d workspaces.", workspaceNamespaces.size()));
 
     var stopwatch = stopwatchProvider.get().start();
-    var failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(workspaceNamespaces);
+    var failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(workspaceNamespaces);
     var elapsed = stopwatch.stop().elapsed();
     LOGGER.info(
         String.format(

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskEnvironmentsController.java
@@ -5,16 +5,21 @@ import static org.pmiops.workbench.utils.LogFormatters.formatDurationPretty;
 import com.google.common.base.Stopwatch;
 import jakarta.inject.Provider;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.disks.DiskAdminService;
 import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
 import org.pmiops.workbench.leonardo.LeonardoApiClient;
 import org.pmiops.workbench.leonardo.LeonardoStatusUtils;
 import org.pmiops.workbench.model.Disk;
+import org.pmiops.workbench.model.UserAppEnvironment;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,17 +33,20 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
   private final LeonardoApiClient leonardoApiClient;
   private final Provider<Stopwatch> stopwatchProvider;
   private final WorkspaceService workspaceService;
+  private final WorkspaceUserCacheService workspaceUserCacheService;
 
   @Autowired
   public CloudTaskEnvironmentsController(
       DiskAdminService diskAdminService,
       LeonardoApiClient leonardoApiClient,
       Provider<Stopwatch> stopwatchProvider,
-      WorkspaceService workspaceService) {
+      WorkspaceService workspaceService,
+      WorkspaceUserCacheService workspaceUserCacheService) {
     this.diskAdminService = diskAdminService;
     this.leonardoApiClient = leonardoApiClient;
     this.stopwatchProvider = stopwatchProvider;
     this.workspaceService = workspaceService;
+    this.workspaceUserCacheService = workspaceUserCacheService;
   }
 
   @Override
@@ -81,39 +89,72 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
     return ResponseEntity.ok().build();
   }
 
-  // return success value of getFirecloudUserRoles()
+  /**
+   * Delete runtimes, apps, and disks in the given workspace that are not owned by any user with
+   * access to the workspace. In most cases, we have nothing to delete. If we find any potential
+   * resources to delete, we refetch the current workspace ACL before deleting in case the cache is
+   * stale. We delete runtimes and apps before disks, since deleting a runtime or app will also
+   * delete its associated disk.
+   *
+   * <p>The overall flow is: 1. Get workspace users out of cache 2. Fetch runtimes and apps from
+   * Leonardo 3. Find runtime and app deletion candidates 4. If we have any runtime or app
+   * candidates, refetch current workspace users 5. Confirm that runtime or app candidates should
+   * still be deleted based on current ACL 6. Delete runtime or app candidates 7. Fetch disks from
+   * Leonardo 8. Find disk deletion candidates 9. If we have any disk candidates, and we didn't
+   * refetch workspace current users, do so now 10. If we have any disk candidates, and we did
+   * refetch workspace current users, use those 11. Confirm that disk candidates should still be
+   * deleted based on current ACL 12. Delete candidates
+   *
+   * @param dbWorkspace the workspace to check for unshared environments and disks
+   * @return true if we were able to get current users from Rawls, false if that call failed
+   */
   private boolean deleteUnshared(DbWorkspace dbWorkspace) {
     // this call often fails on Test.  TODO: investigate.
-    final List<UserRole> userRoles;
-    try {
-      userRoles =
-          workspaceService.getFirecloudUserRoles(
-              dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
-    } catch (WorkbenchException e) {
-      LOGGER.warning(
-          String.format(
-              "Failed to get user roles for workspace %s/%s (ID %d): %s",
-              dbWorkspace.getWorkspaceNamespace(),
-              dbWorkspace.getFirecloudName(),
-              dbWorkspace.getWorkspaceId(),
-              e.getMessage()));
-      return false;
-    }
 
-    var currentUsers = userRoles.stream().map(UserRole::getEmail).collect(Collectors.toSet());
+    // get users out of cache
+    var cachedUsers = workspaceUserCacheService.getWorkspaceUsers(dbWorkspace.getWorkspaceId());
 
+    // check for runtimes and apps to delete
     var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
-    var runtimesToDelete =
-        runtimes.stream()
-            .filter(LeonardoStatusUtils::canDeleteRuntime)
-            .filter(runtime -> !currentUsers.contains(runtime.getAuditInfo().getCreator()))
+    var deletableRuntimes =
+        runtimes.stream().filter(LeonardoStatusUtils::canDeleteRuntime).toList();
+    var possibleRuntimesToDelete =
+        deletableRuntimes.stream()
+            .filter(runtime -> !cachedUsers.contains(runtime.getAuditInfo().getCreator()))
             .toList();
 
     var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
-    var appsToDelete =
-        apps.stream()
-            .filter(LeonardoStatusUtils::canDeleteApp)
-            .filter(app -> !currentUsers.contains(app.getCreator()))
+    var deletableApps = apps.stream().filter(LeonardoStatusUtils::canDeleteApp).toList();
+    var possibleAppsToDelete =
+        deletableApps.stream().filter(app -> !cachedUsers.contains(app.getCreator())).toList();
+
+    // if we have any apps or runtimes to delete, refetch current users before trying to delete
+    final Set<String> currentUsers;
+    if (!possibleRuntimesToDelete.isEmpty() || !possibleAppsToDelete.isEmpty()) {
+      try {
+        currentUsers = getCurrentUsers(dbWorkspace);
+      } catch (WorkbenchException e) {
+        return false;
+      }
+
+      // maybe delete runtimes and apps
+      maybeDeleteRuntimes(dbWorkspace, deletableRuntimes, currentUsers, runtimes.size());
+      maybeDeleteApps(dbWorkspace, deletableApps, currentUsers, apps.size());
+    } else {
+      currentUsers = null;
+    }
+
+    return deleteUnsharedDisks(dbWorkspace, cachedUsers, currentUsers);
+  }
+
+  private void maybeDeleteRuntimes(
+      DbWorkspace dbWorkspace,
+      List<LeonardoListRuntimeResponse> deletableRuntimes,
+      Set<String> currentUsers,
+      Integer totalRuntimes) {
+    var runtimesToDelete =
+        deletableRuntimes.stream()
+            .filter(runtime -> !currentUsers.contains(runtime.getAuditInfo().getCreator()))
             .toList();
 
     if (!runtimesToDelete.isEmpty()) {
@@ -124,13 +165,12 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               dbWorkspace.getWorkspaceNamespace(),
               dbWorkspace.getFirecloudName(),
               dbWorkspace.getWorkspaceId(),
-              runtimes.size()));
+              totalRuntimes));
       runtimesToDelete.forEach(
           runtime -> {
             try {
               leonardoApiClient.deleteRuntimeAsService(
-                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /*
-             deleteDisk */ true);
+                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /* deleteDisk */ true);
             } catch (WorkbenchException e) {
               LOGGER.warning(
                   String.format(
@@ -139,6 +179,15 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             }
           });
     }
+  }
+
+  private void maybeDeleteApps(
+      DbWorkspace dbWorkspace,
+      List<UserAppEnvironment> deletableApps,
+      Set<String> currentUsers,
+      Integer totalApps) {
+    var appsToDelete =
+        deletableApps.stream().filter(app -> !currentUsers.contains(app.getCreator())).toList();
 
     if (!appsToDelete.isEmpty()) {
       LOGGER.info(
@@ -148,7 +197,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               dbWorkspace.getWorkspaceNamespace(),
               dbWorkspace.getFirecloudName(),
               dbWorkspace.getWorkspaceId(),
-              apps.size()));
+              totalApps));
       appsToDelete.forEach(
           app -> {
             try {
@@ -162,13 +211,47 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             }
           });
     }
+  }
 
-    // check disks after runtime and app deletion, because these will delete their associated disks
-
+  private boolean deleteUnsharedDisks(
+      DbWorkspace dbWorkspace, Set<String> cachedUsers, Set<String> currentUsers) {
+    // check for disks to delete
+    // (check disks after runtime and app deletion, because these will delete their associated
+    // disks)
     var disks = leonardoApiClient.listDisksByProjectAsService(dbWorkspace.getGoogleProject());
+    var deletableDisks = disks.stream().filter(LeonardoStatusUtils::canDeleteDisk).toList();
+    var potentialDisksToDelete =
+        deletableDisks.stream()
+            .filter(disk -> !cachedUsers.contains(disk.getAuditInfo().getCreator()))
+            .toList();
+
+    // if we have any to delete, and we haven't refetched current users, do so now
+    // if we have any to delete, and we've already refetched current users, then use that
+    if (!potentialDisksToDelete.isEmpty()) {
+      final Set<String> diskCurrentUsers;
+      if (currentUsers == null) {
+        try {
+          diskCurrentUsers = getCurrentUsers(dbWorkspace);
+        } catch (WorkbenchException e) {
+          return false;
+        }
+      } else {
+        diskCurrentUsers = currentUsers;
+      }
+
+      maybeDeleteDisks(dbWorkspace, deletableDisks, diskCurrentUsers, disks.size());
+    }
+
+    return true;
+  }
+
+  private void maybeDeleteDisks(
+      DbWorkspace dbWorkspace,
+      List<ListPersistentDiskResponse> deletableDisks,
+      Set<String> currentUsers,
+      Integer totalDisks) {
     var disksToDelete =
-        disks.stream()
-            .filter(LeonardoStatusUtils::canDeleteDisk)
+        deletableDisks.stream()
             .filter(disk -> !currentUsers.contains(disk.getAuditInfo().getCreator()))
             .toList();
 
@@ -180,7 +263,7 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
               dbWorkspace.getWorkspaceNamespace(),
               dbWorkspace.getFirecloudName(),
               dbWorkspace.getWorkspaceId(),
-              disks.size()));
+              totalDisks));
       disksToDelete.forEach(
           disk -> {
             try {
@@ -194,6 +277,25 @@ public class CloudTaskEnvironmentsController implements CloudTaskEnvironmentsApi
             }
           });
     }
-    return true;
+  }
+
+  private Set<String> getCurrentUsers(DbWorkspace dbWorkspace) {
+    try {
+      return workspaceService
+          .getFirecloudUserRoles(
+              dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
+          .stream()
+          .map(UserRole::getEmail)
+          .collect(Collectors.toSet());
+    } catch (WorkbenchException e) {
+      LOGGER.warning(
+          String.format(
+              "Failed to get user roles for workspace %s/%s (ID %d): %s",
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              e.getMessage()));
+      throw e;
+    }
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceUserCacheDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceUserCacheDao.java
@@ -5,6 +5,7 @@ import org.pmiops.workbench.db.model.DbWorkspaceUserCache;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Cache of workspace access control lists. This cache is NOT to be used for any authorization. This
@@ -21,4 +22,8 @@ public interface WorkspaceUserCacheDao extends CrudRepository<DbWorkspaceUserCac
           "delete from workspace_user_cache where exists (select 1 from workspace where workspace.workspace_id = workspace_user_cache.workspace_id and workspace.active_status = 1)",
       nativeQuery = true)
   void deleteAllInactiveWorkspaces();
+
+  @Query(
+      "select u.username from DbWorkspaceUserCache wuc join DbUser u on wuc.userId = u.userId where wuc.workspaceId = :workspaceId")
+  Set<String> findAllUsersByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminService.java
@@ -1,0 +1,7 @@
+package org.pmiops.workbench.environments;
+
+import java.util.List;
+
+public interface EnvironmentsAdminService {
+  long deleteUnsharedWorkspaceEnvironmentsBatch(List<String> workspaceNamespaces);
+}

--- a/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceImpl.java
@@ -1,0 +1,314 @@
+package org.pmiops.workbench.environments;
+
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.leonardo.LeonardoStatusUtils;
+import org.pmiops.workbench.model.UserAppEnvironment;
+import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnvironmentsAdminServiceImpl implements EnvironmentsAdminService {
+  private static final Logger LOGGER =
+      Logger.getLogger(EnvironmentsAdminServiceImpl.class.getName());
+
+  private final WorkspaceService workspaceService;
+  private final LeonardoApiClient leonardoApiClient;
+  private final WorkspaceUserCacheService workspaceUserCacheService;
+
+  @Autowired
+  public EnvironmentsAdminServiceImpl(
+      WorkspaceService workspaceService,
+      LeonardoApiClient leonardoApiClient,
+      WorkspaceUserCacheService workspaceUserCacheService
+      ) {
+    this.workspaceService = workspaceService;
+    this.leonardoApiClient = leonardoApiClient;
+    this.workspaceUserCacheService = workspaceUserCacheService;
+  }
+
+  /** * Delete unshared environments (runtimes, apps, and disks) in the given workspaces. This method
+   * will return the number of workspaces that failed to fetch workspace ACLs.
+   *
+   * @param workspaceNamespaces the namespaces of the workspaces to check for unshared environments
+   * @return the number of workspaces that failed to fetch workspace ACLs
+   */
+  @Override
+  public long deleteUnsharedWorkspaceEnvironmentsBatch(List<String> workspaceNamespaces) {
+    return workspaceService.lookupWorkspacesByNamespace(workspaceNamespaces).stream()
+            .filter(
+                ws -> {
+                  boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
+                  return !successfulGetFirecloudUserRoles;
+                })
+            .count();
+  }
+
+  /**
+   * Delete runtimes, apps, and disks in the given workspace that are not owned by any user with
+   * access to the workspace. In most cases, we have nothing to delete. If we find any potential
+   * resources to delete, we refetch the current workspace ACL before deleting in case the cache is
+   * stale. We delete runtimes and apps before disks, since deleting a runtime or app will also
+   * delete its associated disk.
+   *
+   * <p>The overall flow is: 1. Get workspace users out of cache 2. Fetch runtimes and apps from
+   * Leonardo 3. Find runtime and app deletion candidates 4. If we have any runtime or app
+   * candidates, refetch current workspace users 5. Confirm that runtime or app candidates should
+   * still be deleted based on current ACL 6. Delete runtime or app candidates 7. Fetch disks from
+   * Leonardo 8. Find disk deletion candidates 9. If we have any disk candidates, and we didn't
+   * refetch workspace current users, do so now 10. If we have any disk candidates, and we did
+   * refetch workspace current users, use those 11. Confirm that disk candidates should still be
+   * deleted based on current ACL 12. Delete candidates
+   *
+   * @param dbWorkspace the workspace to check for unshared environments and disks
+   * @return true if we were able to get current users from Rawls, false if that call failed
+   */
+  private boolean deleteUnshared(DbWorkspace dbWorkspace) {
+    // this call often fails on Test.  TODO: investigate.
+
+    // get users out of cache
+    var cachedUsers = workspaceUserCacheService.getWorkspaceUsers(dbWorkspace.getWorkspaceId());
+
+    // check for runtimes and apps to delete
+    var runtimes = leonardoApiClient.listRuntimesByProjectAsService(dbWorkspace.getGoogleProject());
+    var deletableRuntimes =
+        runtimes.stream().filter(LeonardoStatusUtils::canDeleteRuntime).toList();
+    var possibleRuntimesToDelete =
+        deletableRuntimes.stream()
+            .filter(runtime -> !cachedUsers.contains(runtime.getAuditInfo().getCreator()))
+            .toList();
+
+    var apps = leonardoApiClient.listAppsInProjectAsService(dbWorkspace.getGoogleProject());
+    var deletableApps = apps.stream().filter(LeonardoStatusUtils::canDeleteApp).toList();
+    var possibleAppsToDelete =
+        deletableApps.stream().filter(app -> !cachedUsers.contains(app.getCreator())).toList();
+
+    // if we have any apps or runtimes to delete, refetch current users before trying to delete
+    final Set<String> currentUsers;
+    if (!possibleRuntimesToDelete.isEmpty() || !possibleAppsToDelete.isEmpty()) {
+      try {
+        currentUsers = getCurrentUsers(dbWorkspace);
+      } catch (WorkbenchException e) {
+        return false;
+      }
+
+      // maybe delete runtimes and apps
+      maybeDeleteRuntimes(dbWorkspace, deletableRuntimes, currentUsers, runtimes.size());
+      maybeDeleteApps(dbWorkspace, deletableApps, currentUsers, apps.size());
+    } else {
+      currentUsers = null;
+    }
+
+    return deleteUnsharedDisks(dbWorkspace, cachedUsers, currentUsers);
+  }
+
+  /**
+   * Given a list of deletable runtimes and the current users with access to the workspace, delete
+   * any runtimes not owned by a current user.
+   *
+   * @param dbWorkspace workspace the runtimes are in
+   * @param deletableRuntimes all runtimes in the workspace that are in a deletable state
+   * @param currentUsers the current users with access to the workspace
+   * @param totalRuntimes the total number of runtimes in the workspace
+   */
+  private void maybeDeleteRuntimes(
+      DbWorkspace dbWorkspace,
+      List<LeonardoListRuntimeResponse> deletableRuntimes,
+      Set<String> currentUsers,
+      Integer totalRuntimes) {
+    var runtimesToDelete =
+        deletableRuntimes.stream()
+            .filter(runtime -> !currentUsers.contains(runtime.getAuditInfo().getCreator()))
+            .toList();
+
+    if (!runtimesToDelete.isEmpty()) {
+      LOGGER.info(
+          String.format(
+              "Deleting %d runtimes for workspace %s/%s (ID %d) out of %d total",
+              runtimesToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              totalRuntimes));
+      runtimesToDelete.forEach(
+          runtime -> {
+            try {
+              leonardoApiClient.deleteRuntimeAsService(
+                  dbWorkspace.getGoogleProject(), runtime.getRuntimeName(), /* deleteDisk */ true);
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete runtime %s in project %s: %s",
+                      runtime.getRuntimeName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
+          });
+    }
+  }
+
+  /**
+   * Given a list of deletable apps and the current users with access to the workspace, delete
+   * any apps not owned by a current user.
+   *
+   * @param dbWorkspace workspace the apps are in
+   * @param deletableApps all apps in the workspace that are in a deletable state
+   * @param currentUsers the current users with access to the workspace
+   * @param totalApps the total number of apps in the workspace
+   */
+  private void maybeDeleteApps(
+      DbWorkspace dbWorkspace,
+      List<UserAppEnvironment> deletableApps,
+      Set<String> currentUsers,
+      Integer totalApps) {
+    var appsToDelete =
+        deletableApps.stream().filter(app -> !currentUsers.contains(app.getCreator())).toList();
+
+    if (!appsToDelete.isEmpty()) {
+      LOGGER.info(
+          String.format(
+              "Deleting %d apps for workspace %s/%s (ID %d) out of %d total",
+              appsToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              totalApps));
+      appsToDelete.forEach(
+          app -> {
+            try {
+              leonardoApiClient.deleteAppAsService(
+                  app.getAppName(), dbWorkspace, /* deleteDisk */ true);
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete app %s in project %s: %s",
+                      app.getAppName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
+          });
+    }
+  }
+
+  /**
+   * Check for unshared disks in the given workspace and delete any that are not owned by a current
+   * user. If we have any disks to delete, and we haven't already refetched current users, do so
+   * now.
+   *
+   * @param dbWorkspace the workspace to check for unshared disks
+   * @param cachedUsers the users with access to the workspace according to the workspace user cache
+   * @param currentUsers the users with access to the workspace according to a live call to Rawls,
+   *     or null if we haven't made that call yet
+   * @return true if we were able to get current users from Rawls if needed, false if that call
+   *     failed
+   */
+  private boolean deleteUnsharedDisks(
+      DbWorkspace dbWorkspace, Set<String> cachedUsers, @Nullable Set<String> currentUsers) {
+    // check for disks to delete
+    // (check disks after runtime and app deletion, because these will delete their associated
+    // disks)
+    var disks = leonardoApiClient.listDisksByProjectAsService(dbWorkspace.getGoogleProject());
+    var deletableDisks = disks.stream().filter(LeonardoStatusUtils::canDeleteDisk).toList();
+    var potentialDisksToDelete =
+        deletableDisks.stream()
+            .filter(disk -> !cachedUsers.contains(disk.getAuditInfo().getCreator()))
+            .toList();
+
+    // if we have any to delete, and we haven't refetched current users, do so now
+    // if we have any to delete, and we've already refetched current users, then use that
+    if (!potentialDisksToDelete.isEmpty()) {
+      final Set<String> diskCurrentUsers;
+      if (currentUsers == null) {
+        try {
+          diskCurrentUsers = getCurrentUsers(dbWorkspace);
+        } catch (WorkbenchException e) {
+          return false;
+        }
+      } else {
+        diskCurrentUsers = currentUsers;
+      }
+
+      maybeDeleteDisks(dbWorkspace, deletableDisks, diskCurrentUsers, disks.size());
+    }
+
+    return true;
+  }
+
+  /**
+   * Given a list of deletable disks and the current users with access to the workspace, delete any
+   * disks not owned by a current user.
+   *
+   * @param dbWorkspace workspace the disks are in
+   * @param deletableDisks all disks in the workspace that are in a deletable state
+   * @param currentUsers the current users with access to the workspace
+   * @param totalDisks the total number of disks in the workspace
+   */
+  private void maybeDeleteDisks(
+      DbWorkspace dbWorkspace,
+      List<ListPersistentDiskResponse> deletableDisks,
+      Set<String> currentUsers,
+      Integer totalDisks) {
+    var disksToDelete =
+        deletableDisks.stream()
+            .filter(disk -> !currentUsers.contains(disk.getAuditInfo().getCreator()))
+            .toList();
+
+    if (!disksToDelete.isEmpty()) {
+      LOGGER.info(
+          String.format(
+              "Deleting %d disks for workspace %s/%s (ID %d) out of %d total",
+              disksToDelete.size(),
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              totalDisks));
+      disksToDelete.forEach(
+          disk -> {
+            try {
+              leonardoApiClient.deletePersistentDiskAsService(
+                  dbWorkspace.getGoogleProject(), disk.getName());
+            } catch (WorkbenchException e) {
+              LOGGER.warning(
+                  String.format(
+                      "Failed to delete disk %s in project %s: %s",
+                      disk.getName(), dbWorkspace.getGoogleProject(), e.getMessage()));
+            }
+          });
+    }
+  }
+
+  /**
+   * Make a live call to Rawls to get the current users with access to the workspace. Called when
+   * the workspace user cache indicates that there may be resources to delete as we need to get
+   * fresh ACLs before deleting anything.
+   * @param dbWorkspace the workspace to get current users for
+   * @return the set of usernames for users with access to the workspace
+   */
+  private Set<String> getCurrentUsers(DbWorkspace dbWorkspace) {
+    try {
+      return workspaceService
+          .getFirecloudUserRoles(
+              dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName())
+          .stream()
+          .map(UserRole::getEmail)
+          .collect(Collectors.toSet());
+    } catch (WorkbenchException e) {
+      LOGGER.warning(
+          String.format(
+              "Failed to get user roles for workspace %s/%s (ID %d): %s",
+              dbWorkspace.getWorkspaceNamespace(),
+              dbWorkspace.getFirecloudName(),
+              dbWorkspace.getWorkspaceId(),
+              e.getMessage()));
+      throw e;
+    }
+  }
+}

--- a/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceImpl.java
@@ -1,6 +1,5 @@
 package org.pmiops.workbench.environments;
 
-
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
@@ -32,14 +31,14 @@ public class EnvironmentsAdminServiceImpl implements EnvironmentsAdminService {
   public EnvironmentsAdminServiceImpl(
       WorkspaceService workspaceService,
       LeonardoApiClient leonardoApiClient,
-      WorkspaceUserCacheService workspaceUserCacheService
-      ) {
+      WorkspaceUserCacheService workspaceUserCacheService) {
     this.workspaceService = workspaceService;
     this.leonardoApiClient = leonardoApiClient;
     this.workspaceUserCacheService = workspaceUserCacheService;
   }
 
-  /** * Delete unshared environments (runtimes, apps, and disks) in the given workspaces. This method
+  /**
+   * * Delete unshared environments (runtimes, apps, and disks) in the given workspaces. This method
    * will return the number of workspaces that failed to fetch workspace ACLs.
    *
    * @param workspaceNamespaces the namespaces of the workspaces to check for unshared environments
@@ -48,12 +47,12 @@ public class EnvironmentsAdminServiceImpl implements EnvironmentsAdminService {
   @Override
   public long deleteUnsharedWorkspaceEnvironmentsBatch(List<String> workspaceNamespaces) {
     return workspaceService.lookupWorkspacesByNamespace(workspaceNamespaces).stream()
-            .filter(
-                ws -> {
-                  boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
-                  return !successfulGetFirecloudUserRoles;
-                })
-            .count();
+        .filter(
+            ws -> {
+              boolean successfulGetFirecloudUserRoles = deleteUnshared(ws);
+              return !successfulGetFirecloudUserRoles;
+            })
+        .count();
   }
 
   /**
@@ -158,8 +157,8 @@ public class EnvironmentsAdminServiceImpl implements EnvironmentsAdminService {
   }
 
   /**
-   * Given a list of deletable apps and the current users with access to the workspace, delete
-   * any apps not owned by a current user.
+   * Given a list of deletable apps and the current users with access to the workspace, delete any
+   * apps not owned by a current user.
    *
    * @param dbWorkspace workspace the apps are in
    * @param deletableApps all apps in the workspace that are in a deletable state
@@ -289,6 +288,7 @@ public class EnvironmentsAdminServiceImpl implements EnvironmentsAdminService {
    * Make a live call to Rawls to get the current users with access to the workspace. Called when
    * the workspace user cache indicates that there may be resources to delete as we need to get
    * fresh ACLs before deleting anything.
+   *
    * @param dbWorkspace the workspace to get current users for
    * @return the set of usernames for users with access to the workspace
    */

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceUserCacheService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceUserCacheService.java
@@ -2,6 +2,7 @@ package org.pmiops.workbench.workspaces;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.pmiops.workbench.db.model.DbWorkspace;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
 
@@ -12,4 +13,6 @@ public interface WorkspaceUserCacheService {
       Map<Long, Map<String, RawlsWorkspaceAccessEntry>> newEntriesByWorkspaceId);
 
   void removeInactiveWorkspaces();
+
+  Set<String> getWorkspaceUsers(Long workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceUserCacheServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceUserCacheServiceImpl.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.pmiops.workbench.db.dao.UserDao;
@@ -78,5 +79,10 @@ public class WorkspaceUserCacheServiceImpl implements WorkspaceUserCacheService 
   @Transactional
   public void removeInactiveWorkspaces() {
     workspaceUserCacheDao.deleteAllInactiveWorkspaces();
+  }
+
+  @Override
+  public Set<String> getWorkspaceUsers(Long workspaceId) {
+    return workspaceUserCacheDao.findAllUsersByWorkspaceId(workspaceId);
   }
 }

--- a/api/src/test/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceTest.java
@@ -1,0 +1,459 @@
+package org.pmiops.workbench.environments;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.AuditInfo;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.DiskStatus;
+import org.broadinstitute.dsde.workbench.client.leonardo.model.ListPersistentDiskResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.db.model.DbWorkspace;
+import org.pmiops.workbench.exceptions.WorkbenchException;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoAuditInfo;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoListRuntimeResponse;
+import org.pmiops.workbench.legacy_leonardo_client.model.LeonardoRuntimeStatus;
+import org.pmiops.workbench.leonardo.LeonardoApiClient;
+import org.pmiops.workbench.model.AppStatus;
+import org.pmiops.workbench.model.UserAppEnvironment;
+import org.pmiops.workbench.model.UserRole;
+import org.pmiops.workbench.workspaces.WorkspaceService;
+import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
+
+@ExtendWith(MockitoExtension.class)
+public class EnvironmentsAdminServiceTest {
+
+  @Mock private WorkspaceService mockWorkspaceService;
+  @Mock private LeonardoApiClient mockLeonardoApiClient;
+  @Mock private WorkspaceUserCacheService mockWorkspaceUserCacheService;
+
+  private EnvironmentsAdminServiceImpl environmentsAdminService;
+
+  private static final String USER_EMAIL_1 = "user1@example.com";
+  private static final String USER_EMAIL_2 = "user2@example.com";
+  private static final String CREATOR_EMAIL = "creator@example.com";
+
+  @BeforeEach
+  void setUp() {
+    environmentsAdminService = new EnvironmentsAdminServiceImpl(
+        mockWorkspaceService, mockLeonardoApiClient, mockWorkspaceUserCacheService);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_noResources() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1, USER_EMAIL_2));
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService).lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace()));
+    verify(mockWorkspaceService, never()).getFirecloudUserRoles(any(), any());
+    verifyNoDeleteCalls();
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_withFailures() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+        List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject())).thenReturn(List.of(
+        createMockRuntime("runtime-1", CREATOR_EMAIL)));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName())).thenThrow(new WorkbenchException("Failed to get user roles"));
+
+    Long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(1, failures);
+    verifyNoDeleteCalls();
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_noWorkspacesFound() {
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of("nonexistent-namespace")))
+        .thenReturn(Collections.emptyList());
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of("nonexistent-namespace"));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService).lookupWorkspacesByNamespace(List.of("nonexistent-namespace"));
+    verifyNoDeleteCalls();
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_multipleWorkspaces() {
+    DbWorkspace workspace1 = createMockWorkspace();
+    DbWorkspace workspace2 = createMockWorkspace();
+    workspace2.setWorkspaceId(456L);
+    workspace2.setWorkspaceNamespace("another-namespace");
+    workspace2.setFirecloudName("another-name");
+    workspace2.setGoogleProject("another-project");
+
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+        List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace1, workspace2));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace1.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace2.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_2));
+
+    var runtime1 = createMockRuntime("runtime-1", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace1.getGoogleProject()))
+        .thenReturn(List.of(createMockRuntime("runtime-1", CREATOR_EMAIL)));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace1.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    var runtime2 = createMockRuntime("runtime-2", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace2.getGoogleProject()))
+        .thenReturn(List.of(createMockRuntime("runtime-2", CREATOR_EMAIL)));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace2.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace1.getWorkspaceNamespace(),
+        workspace1.getFirecloudName()))
+        .thenReturn(List.of(new UserRole().email(USER_EMAIL_1)));
+
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace2.getWorkspaceNamespace(),
+        workspace2.getFirecloudName()))
+        .thenReturn(List.of(new UserRole().email(USER_EMAIL_2)));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace1.getGoogleProject(), runtime1.getRuntimeName(), true);
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace2.getGoogleProject(), runtime2.getRuntimeName(), true);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_creatorsStillHaveAccess() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1, USER_EMAIL_2));
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(createMockRuntime("runtime-1", USER_EMAIL_1)));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(createMockApp("app-1", USER_EMAIL_2)));
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(createMockDisk("disk-1", USER_EMAIL_1)));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService, never()).getFirecloudUserRoles(any(), any());
+    verifyNoDeleteCalls();
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedRuntimes() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    LeonardoListRuntimeResponse runtime = createMockRuntime("runtime-1", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(runtime));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedApps() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    UserAppEnvironment app = createMockApp("app-1", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(app));
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient).deleteAppAsService(app.getAppName(), workspace, true);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedDisks() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    ListPersistentDiskResponse disk = createMockDisk("disk-1", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(disk));
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockWorkspaceService, times(1)).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_reusesCurrentUsersForDisks() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    LeonardoListRuntimeResponse runtime = createMockRuntime("runtime-1", CREATOR_EMAIL);
+    ListPersistentDiskResponse disk = createMockDisk("disk-1", CREATOR_EMAIL);
+
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(runtime));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(disk));
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    // Should only call getCurrentUsers once (for runtime/app phase, then reuse for disks)
+    verify(mockWorkspaceService, times(1)).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
+    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesRuntimeDeletionFailure() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    LeonardoListRuntimeResponse runtimeFailure = createMockRuntime("runtime-failure", CREATOR_EMAIL);
+    LeonardoListRuntimeResponse runtimeSuccess = createMockRuntime("runtime-success", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(runtimeFailure, runtimeSuccess));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    doThrow(new WorkbenchException("Deletion failed"))
+        .when(mockLeonardoApiClient).deleteRuntimeAsService(any(), eq(runtimeFailure.getRuntimeName()), anyBoolean());
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtimeFailure.getRuntimeName(), true);
+    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtimeSuccess.getRuntimeName(), true);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesAppDeletionFailure() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    UserAppEnvironment appFailure = createMockApp("app-failure", CREATOR_EMAIL);
+    UserAppEnvironment appSuccess = createMockApp("app-success", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(appFailure, appSuccess));
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    doThrow(new WorkbenchException("Deletion failed"))
+        .when(mockLeonardoApiClient).deleteAppAsService(appFailure.getAppName(), workspace, true);
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockLeonardoApiClient).deleteAppAsService(appFailure.getAppName(), workspace, true);
+    verify(mockLeonardoApiClient).deleteAppAsService(appSuccess.getAppName(), workspace, true);
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesDiskDeletionFailure() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+
+    ListPersistentDiskResponse diskFailure = createMockDisk("disk-failure", CREATOR_EMAIL);
+    ListPersistentDiskResponse diskSuccess = createMockDisk("disk-success", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(diskFailure, diskSuccess));
+
+    UserRole userRole = new UserRole().email(USER_EMAIL_1);
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(userRole));
+
+    doThrow(new WorkbenchException("Deletion failed"))
+        .when(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
+
+    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    assertEquals(0, failures);
+    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
+    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskSuccess.getName());
+  }
+
+  @Test
+  void testDeleteUnsharedWorkspaceEnvironmentsBatch_usesCurrentWorkspaceUsersToDelete() {
+    DbWorkspace workspace = createMockWorkspace();
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+        .thenReturn(List.of(workspace));
+
+    when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
+        .thenReturn(Set.of(USER_EMAIL_1));
+    // Simulate a stale cache and CREATOR_EMAIL does actually have access
+    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(List.of(new UserRole().email(USER_EMAIL_1), new UserRole().email(CREATOR_EMAIL)));
+
+    var runtime = createMockRuntime("runtime-1", CREATOR_EMAIL);
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(runtime));
+    when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+    when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(Collections.emptyList());
+
+    environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+        List.of(workspace.getWorkspaceNamespace()));
+
+    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verifyNoDeleteCalls();
+  }
+
+  private void verifyNoDeleteCalls() {
+    verify(mockLeonardoApiClient, never()).deleteRuntimeAsService(any(), any(), anyBoolean());
+    verify(mockLeonardoApiClient, never()).deleteAppAsService(any(), any(), anyBoolean());
+    verify(mockLeonardoApiClient, never()).deletePersistentDiskAsService(any(), any());
+  }
+
+  private DbWorkspace createMockWorkspace() {
+    DbWorkspace workspace = new DbWorkspace();
+    workspace.setWorkspaceId(123L);
+    workspace.setWorkspaceNamespace("test-namespace");
+    workspace.setFirecloudName("test-workspace");
+    workspace.setGoogleProject("test-project");
+    return workspace;
+  }
+
+  private LeonardoListRuntimeResponse createMockRuntime(String name, String creator) {
+    return new LeonardoListRuntimeResponse().runtimeName(name).auditInfo(new LeonardoAuditInfo().creator(creator)).status(LeonardoRuntimeStatus.RUNNING);
+  }
+
+  private UserAppEnvironment createMockApp(String name, String creator) {
+    return new UserAppEnvironment().appName(name).creator(creator).status(AppStatus.RUNNING);
+  }
+
+  private ListPersistentDiskResponse createMockDisk(String name, String creator) {
+    return new ListPersistentDiskResponse().name(name).auditInfo(new AuditInfo().creator(creator)).status(DiskStatus.READY);
+  }
+}

--- a/api/src/test/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/environments/EnvironmentsAdminServiceTest.java
@@ -48,14 +48,16 @@ public class EnvironmentsAdminServiceTest {
 
   @BeforeEach
   void setUp() {
-    environmentsAdminService = new EnvironmentsAdminServiceImpl(
-        mockWorkspaceService, mockLeonardoApiClient, mockWorkspaceUserCacheService);
+    environmentsAdminService =
+        new EnvironmentsAdminServiceImpl(
+            mockWorkspaceService, mockLeonardoApiClient, mockWorkspaceUserCacheService);
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_noResources() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -68,11 +70,13 @@ public class EnvironmentsAdminServiceTest {
     when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
         .thenReturn(Collections.emptyList());
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockWorkspaceService).lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace()));
+    verify(mockWorkspaceService)
+        .lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace()));
     verify(mockWorkspaceService, never()).getFirecloudUserRoles(any(), any());
     verifyNoDeleteCalls();
   }
@@ -81,21 +85,24 @@ public class EnvironmentsAdminServiceTest {
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_withFailures() {
     DbWorkspace workspace = createMockWorkspace();
     when(mockWorkspaceService.lookupWorkspacesByNamespace(
-        List.of(workspace.getWorkspaceNamespace())))
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
         .thenReturn(Set.of(USER_EMAIL_1));
 
-    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject())).thenReturn(List.of(
-        createMockRuntime("runtime-1", CREATOR_EMAIL)));
+    when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
+        .thenReturn(List.of(createMockRuntime("runtime-1", CREATOR_EMAIL)));
     when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
         .thenReturn(Collections.emptyList());
 
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName())).thenThrow(new WorkbenchException("Failed to get user roles"));
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenThrow(new WorkbenchException("Failed to get user roles"));
 
-    Long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    Long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(1, failures);
     verifyNoDeleteCalls();
@@ -106,8 +113,9 @@ public class EnvironmentsAdminServiceTest {
     when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of("nonexistent-namespace")))
         .thenReturn(Collections.emptyList());
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of("nonexistent-namespace"));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of("nonexistent-namespace"));
 
     assertEquals(0, failures);
     verify(mockWorkspaceService).lookupWorkspacesByNamespace(List.of("nonexistent-namespace"));
@@ -124,7 +132,7 @@ public class EnvironmentsAdminServiceTest {
     workspace2.setGoogleProject("another-project");
 
     when(mockWorkspaceService.lookupWorkspacesByNamespace(
-        List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace())))
+            List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace1, workspace2));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace1.getWorkspaceId()))
@@ -144,26 +152,30 @@ public class EnvironmentsAdminServiceTest {
     when(mockLeonardoApiClient.listAppsInProjectAsService(workspace2.getGoogleProject()))
         .thenReturn(Collections.emptyList());
 
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace1.getWorkspaceNamespace(),
-        workspace1.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace1.getWorkspaceNamespace(), workspace1.getFirecloudName()))
         .thenReturn(List.of(new UserRole().email(USER_EMAIL_1)));
 
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace2.getWorkspaceNamespace(),
-        workspace2.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace2.getWorkspaceNamespace(), workspace2.getFirecloudName()))
         .thenReturn(List.of(new UserRole().email(USER_EMAIL_2)));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace1.getWorkspaceNamespace(), workspace2.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace1.getGoogleProject(), runtime1.getRuntimeName(), true);
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace2.getGoogleProject(), runtime2.getRuntimeName(), true);
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(workspace1.getGoogleProject(), runtime1.getRuntimeName(), true);
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(workspace2.getGoogleProject(), runtime2.getRuntimeName(), true);
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_creatorsStillHaveAccess() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -176,8 +188,9 @@ public class EnvironmentsAdminServiceTest {
     when(mockLeonardoApiClient.listDisksByProjectAsService(workspace.getGoogleProject()))
         .thenReturn(List.of(createMockDisk("disk-1", USER_EMAIL_1)));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
     verify(mockWorkspaceService, never()).getFirecloudUserRoles(any(), any());
@@ -187,7 +200,8 @@ public class EnvironmentsAdminServiceTest {
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedRuntimes() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -202,21 +216,26 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(Collections.emptyList());
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedApps() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -231,21 +250,25 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(Collections.emptyList());
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
     verify(mockLeonardoApiClient).deleteAppAsService(app.getAppName(), workspace, true);
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_deletesUnsharedDisks() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -260,21 +283,26 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(List.of(disk));
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockWorkspaceService, times(1)).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
-    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
+    verify(mockWorkspaceService, times(1))
+        .getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient)
+        .deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_reusesCurrentUsersForDisks() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -291,30 +319,38 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(List.of(disk));
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
     // Should only call getCurrentUsers once (for runtime/app phase, then reuse for disks)
-    verify(mockWorkspaceService, times(1)).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
-    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
+    verify(mockWorkspaceService, times(1))
+        .getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(workspace.getGoogleProject(), runtime.getRuntimeName(), true);
+    verify(mockLeonardoApiClient)
+        .deletePersistentDiskAsService(workspace.getGoogleProject(), disk.getName());
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesRuntimeDeletionFailure() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
         .thenReturn(Set.of(USER_EMAIL_1));
 
-    LeonardoListRuntimeResponse runtimeFailure = createMockRuntime("runtime-failure", CREATOR_EMAIL);
-    LeonardoListRuntimeResponse runtimeSuccess = createMockRuntime("runtime-success", CREATOR_EMAIL);
+    LeonardoListRuntimeResponse runtimeFailure =
+        createMockRuntime("runtime-failure", CREATOR_EMAIL);
+    LeonardoListRuntimeResponse runtimeSuccess =
+        createMockRuntime("runtime-success", CREATOR_EMAIL);
     when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
         .thenReturn(List.of(runtimeFailure, runtimeSuccess));
     when(mockLeonardoApiClient.listAppsInProjectAsService(workspace.getGoogleProject()))
@@ -323,24 +359,32 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(Collections.emptyList());
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
     doThrow(new WorkbenchException("Deletion failed"))
-        .when(mockLeonardoApiClient).deleteRuntimeAsService(any(), eq(runtimeFailure.getRuntimeName()), anyBoolean());
+        .when(mockLeonardoApiClient)
+        .deleteRuntimeAsService(any(), eq(runtimeFailure.getRuntimeName()), anyBoolean());
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtimeFailure.getRuntimeName(), true);
-    verify(mockLeonardoApiClient).deleteRuntimeAsService(workspace.getGoogleProject(), runtimeSuccess.getRuntimeName(), true);
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(
+            workspace.getGoogleProject(), runtimeFailure.getRuntimeName(), true);
+    verify(mockLeonardoApiClient)
+        .deleteRuntimeAsService(
+            workspace.getGoogleProject(), runtimeSuccess.getRuntimeName(), true);
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesAppDeletionFailure() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -356,14 +400,17 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(Collections.emptyList());
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
     doThrow(new WorkbenchException("Deletion failed"))
-        .when(mockLeonardoApiClient).deleteAppAsService(appFailure.getAppName(), workspace, true);
+        .when(mockLeonardoApiClient)
+        .deleteAppAsService(appFailure.getAppName(), workspace, true);
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
     verify(mockLeonardoApiClient).deleteAppAsService(appFailure.getAppName(), workspace, true);
@@ -373,7 +420,8 @@ public class EnvironmentsAdminServiceTest {
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_handlesDiskDeletionFailure() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
@@ -389,31 +437,39 @@ public class EnvironmentsAdminServiceTest {
         .thenReturn(List.of(diskFailure, diskSuccess));
 
     UserRole userRole = new UserRole().email(USER_EMAIL_1);
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
         .thenReturn(List.of(userRole));
 
     doThrow(new WorkbenchException("Deletion failed"))
-        .when(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
+        .when(mockLeonardoApiClient)
+        .deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
 
-    long failures = environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
-        List.of(workspace.getWorkspaceNamespace()));
+    long failures =
+        environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
+            List.of(workspace.getWorkspaceNamespace()));
 
     assertEquals(0, failures);
-    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
-    verify(mockLeonardoApiClient).deletePersistentDiskAsService(workspace.getGoogleProject(), diskSuccess.getName());
+    verify(mockLeonardoApiClient)
+        .deletePersistentDiskAsService(workspace.getGoogleProject(), diskFailure.getName());
+    verify(mockLeonardoApiClient)
+        .deletePersistentDiskAsService(workspace.getGoogleProject(), diskSuccess.getName());
   }
 
   @Test
   void testDeleteUnsharedWorkspaceEnvironmentsBatch_usesCurrentWorkspaceUsersToDelete() {
     DbWorkspace workspace = createMockWorkspace();
-    when(mockWorkspaceService.lookupWorkspacesByNamespace(List.of(workspace.getWorkspaceNamespace())))
+    when(mockWorkspaceService.lookupWorkspacesByNamespace(
+            List.of(workspace.getWorkspaceNamespace())))
         .thenReturn(List.of(workspace));
 
     when(mockWorkspaceUserCacheService.getWorkspaceUsers(workspace.getWorkspaceId()))
         .thenReturn(Set.of(USER_EMAIL_1));
     // Simulate a stale cache and CREATOR_EMAIL does actually have access
-    when(mockWorkspaceService.getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
-        .thenReturn(List.of(new UserRole().email(USER_EMAIL_1), new UserRole().email(CREATOR_EMAIL)));
+    when(mockWorkspaceService.getFirecloudUserRoles(
+            workspace.getWorkspaceNamespace(), workspace.getFirecloudName()))
+        .thenReturn(
+            List.of(new UserRole().email(USER_EMAIL_1), new UserRole().email(CREATOR_EMAIL)));
 
     var runtime = createMockRuntime("runtime-1", CREATOR_EMAIL);
     when(mockLeonardoApiClient.listRuntimesByProjectAsService(workspace.getGoogleProject()))
@@ -426,7 +482,8 @@ public class EnvironmentsAdminServiceTest {
     environmentsAdminService.deleteUnsharedWorkspaceEnvironmentsBatch(
         List.of(workspace.getWorkspaceNamespace()));
 
-    verify(mockWorkspaceService).getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
+    verify(mockWorkspaceService)
+        .getFirecloudUserRoles(workspace.getWorkspaceNamespace(), workspace.getFirecloudName());
     verifyNoDeleteCalls();
   }
 
@@ -446,7 +503,10 @@ public class EnvironmentsAdminServiceTest {
   }
 
   private LeonardoListRuntimeResponse createMockRuntime(String name, String creator) {
-    return new LeonardoListRuntimeResponse().runtimeName(name).auditInfo(new LeonardoAuditInfo().creator(creator)).status(LeonardoRuntimeStatus.RUNNING);
+    return new LeonardoListRuntimeResponse()
+        .runtimeName(name)
+        .auditInfo(new LeonardoAuditInfo().creator(creator))
+        .status(LeonardoRuntimeStatus.RUNNING);
   }
 
   private UserAppEnvironment createMockApp(String name, String creator) {
@@ -454,6 +514,9 @@ public class EnvironmentsAdminServiceTest {
   }
 
   private ListPersistentDiskResponse createMockDisk(String name, String creator) {
-    return new ListPersistentDiskResponse().name(name).auditInfo(new AuditInfo().creator(creator)).status(DiskStatus.READY);
+    return new ListPersistentDiskResponse()
+        .name(name)
+        .auditInfo(new AuditInfo().creator(creator))
+        .status(DiskStatus.READY);
   }
 }


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
