### PR TITLE
[DT-1034][risk=no] Add VWB workspace admin page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryService.java
@@ -12,9 +12,11 @@ public interface VwbAdminQueryService {
    */
   List<VwbWorkspace> queryVwbWorkspacesByCreator(String email);
 
-  List<VwbWorkspace> queryVwbWorkspacesById(String id);
+  List<VwbWorkspace> queryVwbWorkspacesByUserFacingId(String id);
 
   List<VwbWorkspace> queryVwbWorkspacesByName(String name);
 
   List<VwbWorkspace> queryVwbWorkspacesByShareActivity(String email);
+
+  List<String> queryVwbWorkspaceCollaboratorsByUserFacingId(String id);
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6802,13 +6802,13 @@ paths:
           description: The egress event was successfully handled.
           content: { }
       x-codegen-request-body-name: request
-  /v2/admin/vwb/workspaces/getVwbWorkspaceBySearchParam:
+  /v2/admin/vwb/workspaces:
     get:
       tags:
         - vwbWorkspaceAdmin
       description: Returns all VWB workspaces that match the given search param. Requires
         RESEARCHER_DATA_VIEW authority.
-      operationId: getVwbWorkspaceBySearchParam
+      operationId: getVwbWorkspacesBySearchParam
       parameters:
         - name: searchParamType
           in: query
@@ -6827,6 +6827,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VwbWorkspaceListResponse'
+
+        403:
+          description: User doesn't have the RESEARCHER_DATA_VIEW authority
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v2/admin/vwb/workspaces/{workspaceUserFacingId}:
+    get:
+      tags:
+        - vwbWorkspaceAdmin
+      description: Given a workspace user facing id, returns workspace details. Requires
+        RESEARCHER_DATA_VIEW authority.
+      operationId: getVwbWorkspaceAdminView
+      parameters:
+        - name: workspaceUserFacingId
+          in: path
+          description: The workspace user facing id
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: The details for a VWB workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VwbWorkspaceAdminView'
 
         403:
           description: User doesn't have the RESEARCHER_DATA_VIEW authority
@@ -13671,6 +13699,9 @@ components:
         id:
           type: string
           description: ID of the workspace
+        googleProjectId:
+          type: string
+          description: ID of the workspace
         userFacingId:
           type: string
           description: ID of the workspace displayed to the user
@@ -13694,6 +13725,22 @@ components:
         - WORKSPACE_USER_FACING_ID
         - WORKSPACE_NAME
         - WORKSPACE_SHARED
+    VwbWorkspaceAdminView:
+      type: object
+      properties:
+        workspace:
+          $ref: '#/components/schemas/VwbWorkspace'
+        workspaceDatabaseId:
+          type: integer
+          description: |
+            ID used in the AoU RWB workspace table. Useful for DB queries and Action Audit searches in Stackdriver Logging and BigQuery.
+          format: int64
+        collaborators:
+          type: array
+          description: List of users who own or collaborate on this workspace.
+          items:
+            type: string
+      description: Admin-visible metadata about a VWB workspace.
 
   parameters:
     userId:

--- a/ui/src/app/pages/admin/vwb/admin-vwb-workspace-search.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-workspace-search.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { Column } from 'primereact/column';
+import { DataTable } from 'primereact/datatable';
+
+import { VwbWorkspace, VwbWorkspaceSearchParamType } from 'generated/fetch';
+
+import { Button } from 'app/components/buttons';
+import { styles as headerStyles } from 'app/components/headers';
+import { Error, Select, TextInputWithLabel } from 'app/components/inputs';
+import { SpinnerOverlay } from 'app/components/spinners';
+import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { vwbWorkspaceAdminApi } from 'app/services/swagger-fetch-clients';
+import { useNavigation } from 'app/utils/navigation';
+
+const VwbWorkspaceSearchParamTypeOptions = [
+  {
+    value: VwbWorkspaceSearchParamType.CREATOR,
+    label: 'Workspace Creator',
+  },
+  {
+    value: VwbWorkspaceSearchParamType.USER_FACING_ID,
+    label: 'Workspace User Facing ID',
+  },
+  {
+    value: VwbWorkspaceSearchParamType.NAME,
+    label: 'Workspace Name',
+  },
+  {
+    value: VwbWorkspaceSearchParamType.SHARED,
+    label: 'Workspace Shared By/With',
+  },
+];
+
+const SearchParamTypeLabel = {
+  [VwbWorkspaceSearchParamType.CREATOR]: 'Creator Username',
+  [VwbWorkspaceSearchParamType.USER_FACING_ID]: 'Workspace User Facing ID',
+  [VwbWorkspaceSearchParamType.NAME]: 'Workspace Name',
+  [VwbWorkspaceSearchParamType.SHARED]: 'Collaborator Username',
+};
+
+export const AdminVwbWorkspaceSearch = (
+  spinnerProps: WithSpinnerOverlayProps
+) => {
+  const [searchParam, setSearchParam] = useState('');
+  const [searchParamType, setSearchParamType] =
+    useState<VwbWorkspaceSearchParamType>(VwbWorkspaceSearchParamType.CREATOR);
+  const [vwbWorkspaces, setVwbWorkspaces] = useState<VwbWorkspace[]>(null);
+  const [fetchError, setFetchError] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [navigate] = useNavigation();
+
+  useEffect(() => spinnerProps.hideSpinner(), []);
+
+  const searchVwbWorkspaces = async () => {
+    try {
+      setFetchError(false);
+      setLoading(true);
+      setVwbWorkspaces(null);
+      const response =
+        await vwbWorkspaceAdminApi().getVwbWorkspaceBySearchParam(
+          searchParamType.toString(),
+          searchParam
+        );
+      setVwbWorkspaces(response.items);
+    } catch (error) {
+      console.error(error);
+      setFetchError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ margin: '1.5rem' }}>
+      <h2>Search VWB Workspaces</h2>
+      <div style={headerStyles.formLabel}>Search by</div>
+      <div style={{ width: '22.5rem', marginBottom: '1.5rem' }}>
+        <Select
+          value={searchParamType}
+          options={VwbWorkspaceSearchParamTypeOptions}
+          onChange={setSearchParamType}
+        />
+      </div>
+      <TextInputWithLabel
+        containerStyle={{ display: 'inline-block', marginRight: '1.5rem' }}
+        style={{ width: '22.5rem', margin: '1.5rem' }}
+        labelText={SearchParamTypeLabel[searchParamType]}
+        value={searchParam}
+        onChange={setSearchParam}
+        onKeyDown={(event: KeyboardEvent) => {
+          if (!!searchParam && event.key === 'Enter') {
+            searchVwbWorkspaces();
+          }
+        }}
+      />
+      <Button
+        style={{ height: '2.25rem' }}
+        disabled={!searchParam}
+        onClick={() => searchVwbWorkspaces()}
+      >
+        Get Workspaces
+      </Button>
+      <div style={{ marginTop: '1.5rem' }}>
+        {fetchError && (
+          <Error>
+            Error loading data. Please refresh the page or contact the
+            development team.
+          </Error>
+        )}
+        {loading ? (
+          <SpinnerOverlay />
+        ) : (
+          vwbWorkspaces !== null && (
+            <DataTable
+              paginator
+              rows={10}
+              onRowClick={(row) =>
+                navigate(['admin','vwb', 'workspaces', row.data.userFacingId])
+              }
+              emptyMessage='No workspaces found'
+              loading={loading}
+              value={vwbWorkspaces}
+            >
+              <Column
+                field='userFacingId'
+                header='User Facing ID'
+                headerStyle={{ width: '250px' }}
+              />
+              <Column
+                field='displayName'
+                header='Name'
+                headerStyle={{ width: '250px' }}
+              />
+              <Column field='description' header='Description' />
+              <Column
+                field='createdBy'
+                header='Creator'
+                headerStyle={{ width: '150px' }}
+              />
+              <Column
+                field='creationTime'
+                header='Creation Time'
+                headerStyle={{ width: '150px' }}
+                body={({ creationTime }) =>
+                  new Date(creationTime).toLocaleString()
+                }
+              />
+            </DataTable>
+          )
+        )}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/app/pages/admin/vwb/admin-vwb-workspace-search.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-workspace-search.tsx
@@ -5,13 +5,12 @@ import { DataTable } from 'primereact/datatable';
 
 import { VwbWorkspace, VwbWorkspaceSearchParamType } from 'generated/fetch';
 
-import { Button } from 'app/components/buttons';
+import { Button, StyledRouterLink } from 'app/components/buttons';
 import { styles as headerStyles } from 'app/components/headers';
 import { Error, Select, TextInputWithLabel } from 'app/components/inputs';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { vwbWorkspaceAdminApi } from 'app/services/swagger-fetch-clients';
-import { useNavigation } from 'app/utils/navigation';
 
 const VwbWorkspaceSearchParamTypeOptions = [
   {
@@ -48,7 +47,6 @@ export const AdminVwbWorkspaceSearch = (
   const [vwbWorkspaces, setVwbWorkspaces] = useState<VwbWorkspace[]>(null);
   const [fetchError, setFetchError] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [navigate] = useNavigation();
 
   useEffect(() => spinnerProps.hideSpinner(), []);
 
@@ -58,7 +56,7 @@ export const AdminVwbWorkspaceSearch = (
       setLoading(true);
       setVwbWorkspaces(null);
       const response =
-        await vwbWorkspaceAdminApi().getVwbWorkspaceBySearchParam(
+        await vwbWorkspaceAdminApi().getVwbWorkspacesBySearchParam(
           searchParamType.toString(),
           searchParam
         );
@@ -115,9 +113,6 @@ export const AdminVwbWorkspaceSearch = (
             <DataTable
               paginator
               rows={10}
-              onRowClick={(row) =>
-                navigate(['admin','vwb', 'workspaces', row.data.userFacingId])
-              }
               emptyMessage='No workspaces found'
               loading={loading}
               value={vwbWorkspaces}
@@ -126,6 +121,13 @@ export const AdminVwbWorkspaceSearch = (
                 field='userFacingId'
                 header='User Facing ID'
                 headerStyle={{ width: '250px' }}
+                body={({ userFacingId }) => (
+                  <StyledRouterLink
+                    path={`/admin/vwb/workspaces/${userFacingId}`}
+                  >
+                    {userFacingId}
+                  </StyledRouterLink>
+                )}
               />
               <Column
                 field='displayName'

--- a/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
@@ -1,148 +1,157 @@
-import * as React from 'react';
-import { useEffect, useState } from 'react';
-import { Column } from 'primereact/column';
-import { DataTable } from 'primereact/datatable';
+import React, { useEffect, useState } from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import * as fp from 'lodash/fp';
 
 import { VwbWorkspace, VwbWorkspaceSearchParamType } from 'generated/fetch';
 
-import { Button } from 'app/components/buttons';
-import { styles as headerStyles } from 'app/components/headers';
-import { Error, Select, TextInputWithLabel } from 'app/components/inputs';
+import { Error as ErrorDiv } from 'app/components/inputs';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { WorkspaceInfoField } from 'app/pages/admin/workspace/workspace-info-field';
 import { vwbWorkspaceAdminApi } from 'app/services/swagger-fetch-clients';
+import { MatchParams, profileStore } from 'app/utils/stores';
 
-const VwbWorkspaceSearchParamTypeOptions = [
-  {
-    value: VwbWorkspaceSearchParamType.CREATOR,
-    label: 'Workspace Creator',
-  },
-  {
-    value: VwbWorkspaceSearchParamType.USER_FACING_ID,
-    label: 'Workspace User Facing ID',
-  },
-  {
-    value: VwbWorkspaceSearchParamType.NAME,
-    label: 'Workspace Name',
-  },
-  {
-    value: VwbWorkspaceSearchParamType.SHARED,
-    label: 'Workspace Shared By/With',
-  },
-];
+interface Props
+  extends WithSpinnerOverlayProps,
+    RouteComponentProps<MatchParams> {}
 
-const SearchParamTypeLabel = {
-  [VwbWorkspaceSearchParamType.CREATOR]: 'Creator Username',
-  [VwbWorkspaceSearchParamType.USER_FACING_ID]: 'Workspace User Facing ID',
-  [VwbWorkspaceSearchParamType.NAME]: 'Workspace Name',
-  [VwbWorkspaceSearchParamType.SHARED]: 'Collaborator Username',
-};
+export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
+  const [workspace, setWorkspace] = useState<VwbWorkspace>();
+  const [loadingWorkspace, setLoadingWorkspace] = useState<boolean>(false);
+  const [dataLoadError, setDataLoadError] = useState<Response>();
 
-export const AdminVwbWorkspace = (spinnerProps: WithSpinnerOverlayProps) => {
-  const [searchParam, setSearchParam] = useState('');
-  const [searchParamType, setSearchParamType] =
-    useState<VwbWorkspaceSearchParamType>(VwbWorkspaceSearchParamType.CREATOR);
-  const [vwbWorkspaces, setVwbWorkspaces] = useState<VwbWorkspace[]>(null);
-  const [fetchError, setFetchError] = useState(false);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => spinnerProps.hideSpinner(), []);
-
-  const searchVwbWorkspaces = async () => {
-    try {
-      setFetchError(false);
-      setLoading(true);
-      setVwbWorkspaces(null);
-      const response =
-        await vwbWorkspaceAdminApi().getVwbWorkspaceBySearchParam(
-          searchParamType.toString(),
-          searchParam
-        );
-      setVwbWorkspaces(response.items);
-    } catch (error) {
-      console.error(error);
-      setFetchError(true);
-    } finally {
-      setLoading(false);
+  const handleDataLoadError = async (error) => {
+    if (error instanceof Response) {
+      console.log('error', error, await error.json());
+      setDataLoadError(error);
     }
   };
 
+  const populateWorkspaceDetails = async () => {
+    const { ufid } = props.match.params;
+    setLoadingWorkspace(true);
+
+    vwbWorkspaceAdminApi()
+      .getVwbWorkspaceBySearchParam(
+        VwbWorkspaceSearchParamType.USER_FACING_ID,
+        ufid
+      )
+      .then((resp) => {
+        setWorkspace(resp.items[0]);
+      })
+      .catch((error) => handleDataLoadError(error))
+      .finally(() => setLoadingWorkspace(false));
+  };
+
+  useEffect(() => {
+    console.log(props.match);
+    props.hideSpinner();
+  }, []);
+
+  useEffect(() => {
+    if (props.match.params.ufid) {
+      populateWorkspaceDetails();
+    }
+  }, [props.match.params.ufid]);
+
+  const { profile } = profileStore.get();
+
   return (
     <div style={{ margin: '1.5rem' }}>
-      <h2>Search VWB Workspaces</h2>
-      <div style={headerStyles.formLabel}>Search by</div>
-      <div style={{ width: '22.5rem', marginBottom: '1.5rem' }}>
-        <Select
-          value={searchParamType}
-          options={VwbWorkspaceSearchParamTypeOptions}
-          onChange={setSearchParamType}
-        />
-      </div>
-      <TextInputWithLabel
-        containerStyle={{ display: 'inline-block', marginRight: '1.5rem' }}
-        style={{ width: '22.5rem', margin: '1.5rem' }}
-        labelText={SearchParamTypeLabel[searchParamType]}
-        value={searchParam}
-        onChange={setSearchParam}
-        onKeyDown={(event: KeyboardEvent) => {
-          if (!!searchParam && event.key === 'Enter') {
-            searchVwbWorkspaces();
-          }
-        }}
-      />
-      <Button
-        style={{ height: '2.25rem' }}
-        disabled={!searchParam}
-        onClick={() => searchVwbWorkspaces()}
-      >
-        Get Workspaces
-      </Button>
-      <div style={{ marginTop: '1.5rem' }}>
-        {fetchError && (
-          <Error>
-            Error loading data. Please refresh the page or contact the
-            development team.
-          </Error>
-        )}
-        {loading ? (
-          <SpinnerOverlay />
-        ) : (
-          vwbWorkspaces !== null && (
-            <DataTable
-              paginator
-              rows={10}
-              emptyMessage='No workspaces found'
-              loading={loading}
-              value={vwbWorkspaces}
-            >
-              <Column
-                field='userFacingId'
-                header='User Facing ID'
-                headerStyle={{ width: '250px' }}
-              />
-              <Column
-                field='displayName'
-                header='Name'
-                headerStyle={{ width: '250px' }}
-              />
-              <Column field='description' header='Description' />
-              <Column
-                field='createdBy'
-                header='Creator'
-                headerStyle={{ width: '150px' }}
-              />
-              <Column
-                field='creationTime'
-                header='Creation Time'
-                headerStyle={{ width: '150px' }}
-                body={({ creationTime }) =>
-                  new Date(creationTime).toLocaleString()
-                }
-              />
-            </DataTable>
-          )
-        )}
-      </div>
+      {dataLoadError && (
+        <ErrorDiv>
+          Error loading data. Please refresh the page or contact the development
+          team.
+        </ErrorDiv>
+      )}
+      {loadingWorkspace && <SpinnerOverlay />}
+      {workspace && (
+        <div>
+          <h3>Basic Information</h3>
+          <div className='basic-info' style={{ marginTop: '1.5rem' }}>
+            {/*<WorkspaceInfoField labelText='Active Status'>*/}
+            {/*  {activeStatus}*/}
+            {/*</WorkspaceInfoField>*/}
+            {/*<WorkspaceInfoField labelText='Billing Account Type'>*/}
+            {/*  {isUsingInitialCredits(workspace)*/}
+            {/*    ? `Initial credits (${workspace.creatorUser.userName})`*/}
+            {/*    : 'User provided'}*/}
+            {/*</WorkspaceInfoField>*/}
+            {/*{isUsingInitialCredits(workspace) && (*/}
+            {/*  <WorkspaceInfoField labelText='Initial Credits Billing Status'>*/}
+            {/*    {workspace.initialCredits?.exhausted*/}
+            {/*      ? 'Exhausted'*/}
+            {/*      : 'Not Exhausted'}*/}
+            {/*    ,{' '}*/}
+            {/*    {workspace.initialCredits?.expirationEpochMillis <= Date.now()*/}
+            {/*      ? 'Expired'*/}
+            {/*      : 'Not Expired'}*/}
+            {/*  </WorkspaceInfoField>*/}
+            {/*)}*/}
+            <WorkspaceInfoField labelText='Workspace Name'>
+              {workspace.displayName}
+            </WorkspaceInfoField>
+            <WorkspaceInfoField labelText='User Facing ID'>
+              {workspace.userFacingId}
+            </WorkspaceInfoField>
+            <WorkspaceInfoField labelText='Creator'>
+              {workspace.createdBy}
+            </WorkspaceInfoField>
+            {/*<WorkspaceInfoField labelText='Google Project Id'>*/}
+            {/*  {workspace.googleProject}*/}
+            {/*</WorkspaceInfoField>*/}
+            <WorkspaceInfoField labelText='Creation Time'>
+              {new Date(workspace.creationTime).toDateString()}
+            </WorkspaceInfoField>
+          </div>
+          {/*<Accordion>*/}
+          {/*  <AccordionTab header='Research Purpose'>*/}
+          {/*    <ResearchPurposeSection*/}
+          {/*      {...{researchPurpose}}*/}
+          {/*      showAIAN={*/}
+          {/*        cdrVersion &&*/}
+          {/*        showAIANResearchPurpose(cdrVersion.publicReleaseNumber)*/}
+          {/*      }*/}
+          {/*    />*/}
+          {/*  </AccordionTab>*/}
+          {/*</Accordion>*/}
+          {/*{activeStatus === WorkspaceActiveStatus.ACTIVE && (*/}
+          {/*  <>*/}
+          {/*    <Collaborators*/}
+          {/*      {...{collaborators}}*/}
+          {/*      creator={workspace.creatorUser.userName}*/}
+          {/*    />*/}
+          {/*    <CohortBuilder {...{workspaceObjects}} />*/}
+          {/*    <CloudStorageObjects*/}
+          {/*      {...{cloudStorage}}*/}
+          {/*      workspaceNamespace={workspace.namespace}*/}
+          {/*    />*/}
+          {/*    {cloudStorageTraffic?.receivedBytes && (*/}
+          {/*      <CloudStorageTrafficChart {...{cloudStorageTraffic}} />*/}
+          {/*    )}*/}
+          {/*    <h2>Cloud Environments</h2>*/}
+          {/*    <CloudEnvironmentsTable*/}
+          {/*      {...{runtimes, userApps}}*/}
+          {/*      workspaceNamespace={workspace.namespace}*/}
+          {/*      onDelete={populateFederatedWorkspaceInformation}*/}
+          {/*    />*/}
+          {/*    <h2>Egress event history</h2>*/}
+          {/*    {renderIfAuthorized(*/}
+          {/*      profile,*/}
+          {/*      AuthorityGuardedAction.EGRESS_EVENTS,*/}
+          {/*      () => (*/}
+          {/*        <EgressEventsTable*/}
+          {/*          displayPageSize={10}*/}
+          {/*          sourceWorkspaceNamespace={workspace.namespace}*/}
+          {/*        />*/}
+          {/*      )*/}
+          {/*    )}*/}
+          {/*    <h2>Disks</h2>*/}
+          {/*    <DisksTable sourceWorkspaceNamespace={workspace.namespace}/>*/}
+          {/*  </>*/}
+          {/*)}*/}
+        </div>
+      )}
     </div>
   );
-};
+});

--- a/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
@@ -2,21 +2,22 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import * as fp from 'lodash/fp';
 
-import { VwbWorkspace, VwbWorkspaceSearchParamType } from 'generated/fetch';
+import { VwbWorkspaceAdminView } from 'generated/fetch';
 
 import { Error as ErrorDiv } from 'app/components/inputs';
 import { SpinnerOverlay } from 'app/components/spinners';
 import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
 import { WorkspaceInfoField } from 'app/pages/admin/workspace/workspace-info-field';
 import { vwbWorkspaceAdminApi } from 'app/services/swagger-fetch-clients';
-import { MatchParams, profileStore } from 'app/utils/stores';
+import { MatchParams } from 'app/utils/stores';
 
 interface Props
   extends WithSpinnerOverlayProps,
     RouteComponentProps<MatchParams> {}
 
 export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
-  const [workspace, setWorkspace] = useState<VwbWorkspace>();
+  const [workspaceDetails, setWorkspaceDetails] =
+    useState<VwbWorkspaceAdminView>();
   const [loadingWorkspace, setLoadingWorkspace] = useState<boolean>(false);
   const [dataLoadError, setDataLoadError] = useState<Response>();
 
@@ -32,29 +33,21 @@ export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
     setLoadingWorkspace(true);
 
     vwbWorkspaceAdminApi()
-      .getVwbWorkspaceBySearchParam(
-        VwbWorkspaceSearchParamType.USER_FACING_ID,
-        ufid
-      )
-      .then((resp) => {
-        setWorkspace(resp.items[0]);
-      })
+      .getVwbWorkspaceAdminView(ufid)
+      .then(setWorkspaceDetails)
       .catch((error) => handleDataLoadError(error))
       .finally(() => setLoadingWorkspace(false));
   };
 
   useEffect(() => {
-    console.log(props.match);
     props.hideSpinner();
   }, []);
 
   useEffect(() => {
-    if (props.match.params.ufid) {
-      populateWorkspaceDetails();
-    }
+    populateWorkspaceDetails();
   }, [props.match.params.ufid]);
 
-  const { profile } = profileStore.get();
+  const { collaborators, workspace } = workspaceDetails || {};
 
   return (
     <div style={{ margin: '1.5rem' }}>
@@ -69,87 +62,36 @@ export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
         <div>
           <h3>Basic Information</h3>
           <div className='basic-info' style={{ marginTop: '1.5rem' }}>
-            {/*<WorkspaceInfoField labelText='Active Status'>*/}
-            {/*  {activeStatus}*/}
-            {/*</WorkspaceInfoField>*/}
-            {/*<WorkspaceInfoField labelText='Billing Account Type'>*/}
-            {/*  {isUsingInitialCredits(workspace)*/}
-            {/*    ? `Initial credits (${workspace.creatorUser.userName})`*/}
-            {/*    : 'User provided'}*/}
-            {/*</WorkspaceInfoField>*/}
-            {/*{isUsingInitialCredits(workspace) && (*/}
-            {/*  <WorkspaceInfoField labelText='Initial Credits Billing Status'>*/}
-            {/*    {workspace.initialCredits?.exhausted*/}
-            {/*      ? 'Exhausted'*/}
-            {/*      : 'Not Exhausted'}*/}
-            {/*    ,{' '}*/}
-            {/*    {workspace.initialCredits?.expirationEpochMillis <= Date.now()*/}
-            {/*      ? 'Expired'*/}
-            {/*      : 'Not Expired'}*/}
-            {/*  </WorkspaceInfoField>*/}
-            {/*)}*/}
-            <WorkspaceInfoField labelText='Workspace Name'>
-              {workspace.displayName}
+            <WorkspaceInfoField labelText='Google Project Id'>
+              {workspace.googleProjectId}
+            </WorkspaceInfoField>
+            <WorkspaceInfoField labelText='Workspace ID'>
+              {workspace.id}
             </WorkspaceInfoField>
             <WorkspaceInfoField labelText='User Facing ID'>
               {workspace.userFacingId}
             </WorkspaceInfoField>
+            <WorkspaceInfoField labelText='Workspace Name'>
+              {workspace.displayName}
+            </WorkspaceInfoField>
             <WorkspaceInfoField labelText='Creator'>
               {workspace.createdBy}
             </WorkspaceInfoField>
-            {/*<WorkspaceInfoField labelText='Google Project Id'>*/}
-            {/*  {workspace.googleProject}*/}
-            {/*</WorkspaceInfoField>*/}
             <WorkspaceInfoField labelText='Creation Time'>
               {new Date(workspace.creationTime).toDateString()}
             </WorkspaceInfoField>
+            <WorkspaceInfoField labelText='Description'>
+              {workspace.description}
+            </WorkspaceInfoField>
+            <h3>Collaborators</h3>
+            <div className='collaborators' style={{ marginTop: '1.5rem' }}>
+              {collaborators.map((collaborator, c) => (
+                <div key={c} style={{ marginBottom: '1rem' }}>
+                  {collaborator}
+                </div>
+              ))}
+            </div>
           </div>
-          {/*<Accordion>*/}
-          {/*  <AccordionTab header='Research Purpose'>*/}
-          {/*    <ResearchPurposeSection*/}
-          {/*      {...{researchPurpose}}*/}
-          {/*      showAIAN={*/}
-          {/*        cdrVersion &&*/}
-          {/*        showAIANResearchPurpose(cdrVersion.publicReleaseNumber)*/}
-          {/*      }*/}
-          {/*    />*/}
-          {/*  </AccordionTab>*/}
-          {/*</Accordion>*/}
-          {/*{activeStatus === WorkspaceActiveStatus.ACTIVE && (*/}
-          {/*  <>*/}
-          {/*    <Collaborators*/}
-          {/*      {...{collaborators}}*/}
-          {/*      creator={workspace.creatorUser.userName}*/}
-          {/*    />*/}
-          {/*    <CohortBuilder {...{workspaceObjects}} />*/}
-          {/*    <CloudStorageObjects*/}
-          {/*      {...{cloudStorage}}*/}
-          {/*      workspaceNamespace={workspace.namespace}*/}
-          {/*    />*/}
-          {/*    {cloudStorageTraffic?.receivedBytes && (*/}
-          {/*      <CloudStorageTrafficChart {...{cloudStorageTraffic}} />*/}
-          {/*    )}*/}
-          {/*    <h2>Cloud Environments</h2>*/}
-          {/*    <CloudEnvironmentsTable*/}
-          {/*      {...{runtimes, userApps}}*/}
-          {/*      workspaceNamespace={workspace.namespace}*/}
-          {/*      onDelete={populateFederatedWorkspaceInformation}*/}
-          {/*    />*/}
-          {/*    <h2>Egress event history</h2>*/}
-          {/*    {renderIfAuthorized(*/}
-          {/*      profile,*/}
-          {/*      AuthorityGuardedAction.EGRESS_EVENTS,*/}
-          {/*      () => (*/}
-          {/*        <EgressEventsTable*/}
-          {/*          displayPageSize={10}*/}
-          {/*          sourceWorkspaceNamespace={workspace.namespace}*/}
-          {/*        />*/}
-          {/*      )*/}
-          {/*    )}*/}
-          {/*    <h2>Disks</h2>*/}
-          {/*    <DisksTable sourceWorkspaceNamespace={workspace.namespace}/>*/}
-          {/*  </>*/}
-          {/*)}*/}
         </div>
       )}
     </div>

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -26,6 +26,7 @@ import { AdminUserProfile } from 'app/pages/admin/user/admin-user-profile';
 import { AdminUserTable } from 'app/pages/admin/user/admin-user-table';
 import { UserAudit } from 'app/pages/admin/user-audit';
 import { AdminVwbWorkspace } from 'app/pages/admin/vwb/admin-vwb-workspace';
+import { AdminVwbWorkspaceSearch } from 'app/pages/admin/vwb/admin-vwb-workspace-search';
 import { AdminWorkspace } from 'app/pages/admin/workspace/admin-workspace';
 import { AdminWorkspaceSearch } from 'app/pages/admin/workspace/admin-workspace-search';
 import { DemographicSurvey } from 'app/pages/demographic-survey';
@@ -125,6 +126,10 @@ const WorkspaceAdminPage = fp.flow(
   withRouteData,
   withRoutingSpinner
 )(AdminWorkspace);
+const VwbWorkspaceAdminSearchPage = fp.flow(
+  withRouteData,
+  withRoutingSpinner
+)(AdminVwbWorkspaceSearch);
 const VwbWorkspaceAdminPage = fp.flow(
   withRouteData,
   withRoutingSpinner
@@ -290,6 +295,15 @@ export const SignedInRoutes = () => {
       <AppRoute
         exact
         path='/admin/vwb/workspaces'
+        guards={[authorityGuard(AuthorityGuardedAction.WORKSPACE_ADMIN)]}
+      >
+        <VwbWorkspaceAdminSearchPage
+          routeData={{ title: 'VWB Workspace Admin', minimizeChrome: true }}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
+        path='/admin/vwb/workspaces/:ufid'
         guards={[authorityGuard(AuthorityGuardedAction.WORKSPACE_ADMIN)]}
       >
         <VwbWorkspaceAdminPage

--- a/ui/src/app/utils/stores.tsx
+++ b/ui/src/app/utils/stores.tsx
@@ -241,6 +241,7 @@ export interface MatchParams {
   ns?: string;
   pid?: string;
   sparkConsolePath?: string;
+  ufid?: string;
   username?: string;
   usernameWithoutGsuiteDomain?: string;
   terraName?: string;


### PR DESCRIPTION
- Renamed VWB ws search component  `admin-vwb-workspace.tsx` -> `admin-vwb-workspace-search.tsx` 
- Added new `admin-vwb-workspace.tsx` component for detailed admin view. Clicking on the user facing id in the search results table will navigate to the detailed view
- Added `getVwbWorkspaceAdminView` endpoint to retrieve workspace details

https://github.com/user-attachments/assets/10331791-9324-4cc9-9074-f1ef5efe9cf9

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
