### PR TITLE
[risk=no][no-ticket] If user credits are exhausted or expired, unlink the billing account after creat…

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskVwbController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskVwbController.java
@@ -5,25 +5,33 @@ import java.util.Optional;
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
 import org.pmiops.workbench.model.CreateVwbPodTaskRequest;
 import org.pmiops.workbench.user.VwbUserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class CloudTaskVwbController implements CloudTaskVwbApiDelegate {
 
+  private static final Logger log = LoggerFactory.getLogger(CloudTaskVwbController.class.getName());
+
   private final VwbUserService vwbUserService;
   private final UserService userService;
   private final Provider<WorkbenchConfig> workbenchConfigProvider;
+  private final InitialCreditsService initialCreditsService;
 
   public CloudTaskVwbController(
       VwbUserService vwbUserService,
       UserService userService,
-      Provider<WorkbenchConfig> workbenchConfigProvider) {
+      Provider<WorkbenchConfig> workbenchConfigProvider,
+      InitialCreditsService initialCreditsService) {
     this.vwbUserService = vwbUserService;
     this.userService = userService;
     this.workbenchConfigProvider = workbenchConfigProvider;
+    this.initialCreditsService = initialCreditsService;
   }
 
   @Override
@@ -33,9 +41,20 @@ public class CloudTaskVwbController implements CloudTaskVwbApiDelegate {
     }
     Optional<DbUser> dbUser = userService.getByUsername(body.getUserName());
     // If the user exists and the user does not have a pod, create a pod for the user
-    if (dbUser.isPresent() && dbUser.get().getVwbUserPod() == null) {
-      vwbUserService.createInitialCreditsPodForUser(dbUser.get());
-      return ResponseEntity.ok().build();
+    if (dbUser.isPresent()) {
+      DbUser user = dbUser.get();
+      if (user.getVwbUserPod() == null) {
+        vwbUserService.createInitialCreditsPodForUser(user);
+        // If the user has run out of initial credits, unlink the billing account to prevent further
+        // spending
+        if (initialCreditsService.hasUserRunOutOfInitialCredits(user)) {
+          log.info(
+              "User has run out of initial credits, unlinking billing account for user: "
+                  + user.getUsername());
+          vwbUserService.unlinkBillingAccountForUserPod(user);
+        }
+        return ResponseEntity.ok().build();
+      }
     }
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/api/CloudTaskVwbController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/CloudTaskVwbController.java
@@ -47,8 +47,9 @@ public class CloudTaskVwbController implements CloudTaskVwbApiDelegate {
         vwbUserService.createInitialCreditsPodForUser(user);
         // If the user has run out of initial credits, unlink the billing account to prevent further
         // spending
-        if (initialCreditsService.hasUserRunOutOfInitialCredits(user)) {
-          log.info(
+        if (initialCreditsService.hasUserRunOutOfInitialCredits(user)
+            || initialCreditsService.areUserCreditsExpired(user)) {
+          log.debug(
               "User has run out of initial credits, unlinking billing account for user: "
                   + user.getUsername());
           vwbUserService.unlinkBillingAccountForUserPod(user);

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -480,6 +480,12 @@ public class InitialCreditsService {
                 .plus(billingConfig.initialCreditsExtensionPeriodDays, DAYS));
   }
 
+  public boolean hasUserRunOutOfInitialCredits(DbUser user) {
+    double usage = Optional.ofNullable(getCachedInitialCreditsUsage(user)).orElse(0.0);
+    double limit = getUserInitialCreditsLimit(user);
+    return usage >= limit;
+  }
+
   private void checkExpiration(DbUser user) {
     DbUserInitialCreditsExpiration userInitialCreditsExpiration =
         user.getUserInitialCreditsExpiration();

--- a/api/src/test/java/org/pmiops/workbench/api/CloudTaskVwbControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/CloudTaskVwbControllerTest.java
@@ -1,0 +1,166 @@
+package org.pmiops.workbench.api;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.inject.Provider;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.db.dao.UserService;
+import org.pmiops.workbench.db.model.DbUser;
+import org.pmiops.workbench.db.model.DbVwbUserPod;
+import org.pmiops.workbench.initialcredits.InitialCreditsService;
+import org.pmiops.workbench.model.CreateVwbPodTaskRequest;
+import org.pmiops.workbench.user.VwbUserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class CloudTaskVwbControllerTest {
+
+  @Mock private VwbUserService mockVwbUserService;
+  @Mock private UserService mockUserService;
+  @Mock private Provider<WorkbenchConfig> mockWorkbenchConfigProvider;
+  @Mock private InitialCreditsService mockInitialCreditsService;
+  @Mock private WorkbenchConfig mockWorkbenchConfig;
+  @Mock private WorkbenchConfig.FeatureFlagsConfig mockFeatureFlags;
+
+  private CloudTaskVwbController controller;
+  private static final String TEST_USERNAME = "test-user@example.com";
+
+  @BeforeEach
+  void setUp() {
+    controller =
+        new CloudTaskVwbController(
+            mockVwbUserService,
+            mockUserService,
+            mockWorkbenchConfigProvider,
+            mockInitialCreditsService);
+
+    when(mockWorkbenchConfigProvider.get()).thenReturn(mockWorkbenchConfig);
+    mockWorkbenchConfig.featureFlags = mockFeatureFlags;
+  }
+
+  @Test
+  void processCreateVwbPodTask_whenFeatureFlagDisabled_returnsBadRequest() {
+    // Arrange
+    mockFeatureFlags.enableVWBUserAndPodCreation = false;
+    CreateVwbPodTaskRequest request = new CreateVwbPodTaskRequest();
+    request.setUserName(TEST_USERNAME);
+
+    // Act
+    ResponseEntity<Void> response = controller.processCreateVwbPodTask(request);
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    verifyNoInteractions(mockUserService, mockVwbUserService, mockInitialCreditsService);
+  }
+
+  @Test
+  void processCreateVwbPodTask_whenUserNotFound_returnsNoContent() {
+    // Arrange
+    mockFeatureFlags.enableVWBUserAndPodCreation = true;
+    CreateVwbPodTaskRequest request = new CreateVwbPodTaskRequest();
+    request.setUserName(TEST_USERNAME);
+
+    when(mockUserService.getByUsername(TEST_USERNAME)).thenReturn(Optional.empty());
+
+    // Act
+    ResponseEntity<Void> response = controller.processCreateVwbPodTask(request);
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(mockUserService).getByUsername(TEST_USERNAME);
+    verifyNoInteractions(mockVwbUserService, mockInitialCreditsService);
+  }
+
+  @Test
+  void processCreateVwbPodTask_whenUserExistsButAlreadyHasPod_returnsNoContent() {
+    // Arrange
+    mockFeatureFlags.enableVWBUserAndPodCreation = true;
+    CreateVwbPodTaskRequest request = new CreateVwbPodTaskRequest();
+    request.setUserName(TEST_USERNAME);
+
+    DbUser existingUser = new DbUser();
+    existingUser.setUsername(TEST_USERNAME);
+
+    DbVwbUserPod dbVwbUserPod1 =
+        new DbVwbUserPod()
+            .setVwbUserPodId(1L)
+            .setUser(existingUser)
+            .setVwbPodId("pod1")
+            .setInitialCreditsActive(true);
+
+    existingUser.setVwbUserPod(dbVwbUserPod1);
+
+    when(mockUserService.getByUsername(TEST_USERNAME)).thenReturn(Optional.of(existingUser));
+
+    // Act
+    ResponseEntity<Void> response = controller.processCreateVwbPodTask(request);
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(mockUserService).getByUsername(TEST_USERNAME);
+    verifyNoInteractions(mockVwbUserService, mockInitialCreditsService);
+  }
+
+  @Test
+  void processCreateVwbPodTask_whenUserExistsWithoutPod_createsPodAndReturnsOk() {
+    // Arrange
+    mockFeatureFlags.enableVWBUserAndPodCreation = true;
+    CreateVwbPodTaskRequest request = new CreateVwbPodTaskRequest();
+    request.setUserName(TEST_USERNAME);
+
+    DbUser user = new DbUser();
+    user.setUsername(TEST_USERNAME);
+    user.setVwbUserPod(null);
+
+    when(mockUserService.getByUsername(TEST_USERNAME)).thenReturn(Optional.of(user));
+    when(mockInitialCreditsService.hasUserRunOutOfInitialCredits(user)).thenReturn(false);
+
+    // Act
+    ResponseEntity<Void> response = controller.processCreateVwbPodTask(request);
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(mockUserService).getByUsername(TEST_USERNAME);
+    verify(mockVwbUserService).createInitialCreditsPodForUser(user);
+    verify(mockInitialCreditsService).hasUserRunOutOfInitialCredits(user);
+    verify(mockVwbUserService, never()).unlinkBillingAccountForUserPod(any());
+  }
+
+  @Test
+  void
+      processCreateVwbPodTask_whenUserExistsWithoutPodAndCreditsExhausted_createsPodUnlinksBillingAndReturnsOk() {
+    // Arrange
+    mockFeatureFlags.enableVWBUserAndPodCreation = true;
+    CreateVwbPodTaskRequest request = new CreateVwbPodTaskRequest();
+    request.setUserName(TEST_USERNAME);
+
+    DbUser user = new DbUser();
+    user.setUsername(TEST_USERNAME);
+    user.setVwbUserPod(null);
+
+    when(mockUserService.getByUsername(TEST_USERNAME)).thenReturn(Optional.of(user));
+    when(mockInitialCreditsService.hasUserRunOutOfInitialCredits(user)).thenReturn(true);
+
+    // Act
+    ResponseEntity<Void> response = controller.processCreateVwbPodTask(request);
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(mockUserService).getByUsername(TEST_USERNAME);
+    verify(mockVwbUserService).createInitialCreditsPodForUser(user);
+    verify(mockInitialCreditsService).hasUserRunOutOfInitialCredits(user);
+    verify(mockVwbUserService).unlinkBillingAccountForUserPod(user);
+  }
+}


### PR DESCRIPTION
…ing the pod

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
