### PR TITLE
[RW-16024][risk=low] Update Jira search endpoint

### DIFF
--- a/api/src/main/resources/jira.yaml
+++ b/api/src/main/resources/jira.yaml
@@ -176,23 +176,14 @@ paths:
             - write:jira-work
         - { }
       x-atlassian-connect-scope: WRITE
-  "/rest/api/3/search":
+  "/rest/api/3/search/jql":
     post:
       tags:
         - jira
-      summary: Search for issues using JQL (POST)
+      summary: Search for issues using JQL
       description: |-
-        Searches for issues using [JQL](https://confluence.atlassian.com/x/egORLQ).
-
-        There is a [GET](#api-rest-api-3-search-get) version of this resource that can be used for smaller JQL query expressions.
-
-        This operation can be accessed anonymously.
-
-        **[Permissions](#permissions) required:** Issues are included in the response where the user has:
-         *  *Browse projects* [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the issue.
-         *  If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission to view the issue.
-      operationId: searchForIssuesUsingJqlPost
-      parameters: [ ]
+        Searches for issues using [JQL](https://confluence.atlassian.com/x/egORLQ). This is the new, recommended API endpoint.
+      operationId: searchForIssuesUsingJql
       requestBody:
         description: A JSON object containing the search request.
         content:
@@ -456,6 +447,12 @@ components:
           additionalProperties:
             "$ref": "#/components/schemas/JsonTypeBean"
           description: The schema describing the field types in the search results.
+        isLast:
+          type: boolean
+          description: Indicates whether this is the last page of the paginated response.
+        nextPageToken:
+          type: string
+          description: The token for a page to fetch that is not the first page.
       additionalProperties: false
       description: The result of a JQL search.
     IssueBean:
@@ -608,6 +605,15 @@ components:
           type: boolean
           description: Reference fields by their key (rather than ID). The default
             is `false`.
+        nextPageToken:
+          type: string
+          description: The token for a page to fetch that is not the first page.
+        reconcileIssues:
+          type: array
+          description: Strong consistency issue ids to be reconciled with search results.
+          items:
+            type: integer
+            format: int64
       additionalProperties: false
     FieldReferenceData:
       type: object

--- a/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/exfiltration/EgressRemediationServiceTest.java
@@ -505,7 +505,7 @@ public class EgressRemediationServiceTest {
 
   @Test
   public void testRemediateEgressEvent_noJiraTicketWhenJiraDisabled() throws Exception {
-    when(mockJiraApi.searchForIssuesUsingJqlPost(any()))
+    when(mockJiraApi.searchForIssuesUsingJql(any()))
         .thenReturn(new SearchResults().issues(ImmutableList.of()));
     workbenchConfig.egressAlertRemediationPolicy.escalations =
         ImmutableList.of(suspendComputeAfter(1, Duration.ofMinutes(1)));
@@ -519,7 +519,7 @@ public class EgressRemediationServiceTest {
   public void testRemediateEgressEvent_createJiraTicketNoExisting() throws Exception {
     workbenchConfig.egressAlertRemediationPolicy.enableJiraTicketing = true;
 
-    when(mockJiraApi.searchForIssuesUsingJqlPost(any()))
+    when(mockJiraApi.searchForIssuesUsingJql(any()))
         .thenReturn(new SearchResults().issues(ImmutableList.of()));
     when(mockJiraApi.createIssue(any(), any())).thenReturn(new CreatedIssue().key("RW-1234"));
     workbenchConfig.egressAlertRemediationPolicy.escalations =
@@ -555,7 +555,7 @@ public class EgressRemediationServiceTest {
   public void testRemediateEgressEvent_commentExistingJiraTicket() throws Exception {
     workbenchConfig.egressAlertRemediationPolicy.enableJiraTicketing = true;
 
-    when(mockJiraApi.searchForIssuesUsingJqlPost(any()))
+    when(mockJiraApi.searchForIssuesUsingJql(any()))
         .thenReturn(new SearchResults().issues(ImmutableList.of(new IssueBean().id("123"))));
     workbenchConfig.egressAlertRemediationPolicy.escalations =
         ImmutableList.of(suspendComputeAfter(1, Duration.ofMinutes(1)));


### PR DESCRIPTION
The old one that we are using are deprecated and removed
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-post

And it should be replaced by the new one: 
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-post


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
