### PR TITLE
[DT-1037][risk=no] Add workspace activity to VWB admin page

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/VwbWorkspaceAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/VwbWorkspaceAdminController.java
@@ -1,11 +1,13 @@
 package org.pmiops.workbench.api;
 
+import java.util.List;
 import java.util.Optional;
 import org.pmiops.workbench.annotations.AuthorityRequired;
 import org.pmiops.workbench.exceptions.BadRequestException;
 import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.model.Authority;
 import org.pmiops.workbench.model.VwbWorkspaceAdminView;
+import org.pmiops.workbench.model.VwbWorkspaceAuditLog;
 import org.pmiops.workbench.model.VwbWorkspaceListResponse;
 import org.pmiops.workbench.model.VwbWorkspaceSearchParamType;
 import org.pmiops.workbench.vwb.admin.VwbAdminQueryService;
@@ -67,6 +69,12 @@ public class VwbWorkspaceAdminController implements VwbWorkspaceAdminApiDelegate
                                     "Workspace User Facing Id %s was not found", userFacingId))))
             .collaborators(
                 vwbAdminQueryService.queryVwbWorkspaceCollaboratorsByUserFacingId(userFacingId)));
+  }
+
+  @Override
+  @AuthorityRequired({Authority.RESEARCHER_DATA_VIEW})
+  public ResponseEntity<List<VwbWorkspaceAuditLog>> getVwbWorkspaceAuditLogs(String workspaceId) {
+    return ResponseEntity.ok(vwbAdminQueryService.queryVwbWorkspaceActivity(workspaceId));
   }
 
   protected VwbWorkspaceSearchParamType validateSearchParamType(String param) {

--- a/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryService.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryService.java
@@ -3,6 +3,7 @@ package org.pmiops.workbench.vwb.admin;
 import java.util.List;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.VwbWorkspace;
+import org.pmiops.workbench.model.VwbWorkspaceAuditLog;
 
 public interface VwbAdminQueryService {
 
@@ -20,4 +21,6 @@ public interface VwbAdminQueryService {
   List<VwbWorkspace> queryVwbWorkspacesByShareActivity(String email);
 
   List<UserRole> queryVwbWorkspaceCollaboratorsByUserFacingId(String id);
+
+  List<VwbWorkspaceAuditLog> queryVwbWorkspaceActivity(String workspaceId);
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryServiceImpl.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.VwbConfig;
 import org.pmiops.workbench.model.UserRole;
 import org.pmiops.workbench.model.VwbWorkspace;
+import org.pmiops.workbench.model.VwbWorkspaceAuditLog;
 import org.pmiops.workbench.model.WorkspaceAccessLevel;
 import org.pmiops.workbench.utils.FieldValues;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,6 +82,18 @@ public class VwbAdminQueryServiceImpl implements VwbAdminQueryService {
           + " wal.change_type='GRANT_WORKSPACE_ROLE' \n"
           + "AND \n"
           + " (wal.change_subject_id=@SEARCH_PARAM OR wal.actor_email=@SEARCH_PARAM) ";
+
+  private static final String AUDIT_QUERY =
+      "SELECT \n"
+          + " change_type, \n"
+          + " change_date, \n"
+          + " actor_email, \n"
+          + " workspace_id, \n"
+          + "FROM \n"
+          + " %s \n"
+          + "WHERE \n"
+          + " change_subject_id=@WORKSPACE_ID "
+          + "ORDER BY change_date ASC ";
 
   @Autowired
   public VwbAdminQueryServiceImpl(
@@ -183,6 +196,23 @@ public class VwbAdminQueryServiceImpl implements VwbAdminQueryService {
         .collect(Collectors.toList());
   }
 
+  @Override
+  public List<VwbWorkspaceAuditLog> queryVwbWorkspaceActivity(String workspaceId) {
+
+    final String queryString =
+        String.format(AUDIT_QUERY, getTableName(VWB_WORKSPACE_ACTIVITY_LOG_TABLE));
+
+    final QueryJobConfiguration queryJobConfiguration =
+        QueryJobConfiguration.newBuilder(queryString)
+            .addNamedParameter("WORKSPACE_ID", QueryParameterValue.string(workspaceId))
+            .build();
+
+    final TableResult result = bigQueryService.executeQuery(queryJobConfiguration);
+    return StreamSupport.stream(result.iterateAll().spliterator(), false)
+        .map(this::fieldValueListToVwbWorkspaceAuditLog)
+        .collect(Collectors.toList());
+  }
+
   private String getTableName(String table) {
     final VwbConfig vwbConfig = workbenchConfigProvider.get().vwb;
     return String.format(
@@ -219,5 +249,16 @@ public class VwbAdminQueryServiceImpl implements VwbAdminQueryService {
         .ifPresent(userRole::setRole);
     FieldValues.getString(row, "user_email").ifPresent(userRole::setEmail);
     return userRole;
+  }
+
+  private VwbWorkspaceAuditLog fieldValueListToVwbWorkspaceAuditLog(FieldValueList row) {
+    VwbWorkspaceAuditLog auditLog = new VwbWorkspaceAuditLog();
+    FieldValues.getString(row, "workspace_id").ifPresent(auditLog::setWorkspaceId);
+    FieldValues.getString(row, "change_type").ifPresent(auditLog::setChangeType);
+    FieldValues.getDateTime(row, "change_date")
+        .map(OffsetDateTime::toString)
+        .ifPresent(auditLog::setChangeTime);
+    FieldValues.getString(row, "actor_email").ifPresent(auditLog::setActorEmail);
+    return auditLog;
   }
 }

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -6862,6 +6862,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /v2/admin/vwb/workspaces/{workspaceId}/audit:
+    get:
+      tags:
+        - vwbWorkspaceAdmin
+      description: Returns all VWB workspaces audit logs for the given workspace. Requires
+        RESEARCHER_DATA_VIEW authority.
+      operationId: getVwbWorkspaceAuditLogs
+      parameters:
+        - name: workspaceId
+          in: path
+          description: The workspace id
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: A list of VWB workspace audit logs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VwbWorkspaceAuditLog'
+
+        403:
+          description: User doesn't have the RESEARCHER_DATA_VIEW authority
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
     ArchivalStatus:
@@ -13748,6 +13778,21 @@ components:
           items:
             $ref: '#/components/schemas/UserRole'
       description: Admin-visible metadata about a VWB workspace.
+    VwbWorkspaceAuditLog:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+          description: ID of the workspace
+        changeType:
+          type: string
+          description: Type of change made to the workspace
+        actorEmail:
+          type: string
+          description: Username of the user that made the workspace change
+        changeTime:
+          type: string
+          description: Timestamp the workspace was changed
 
   parameters:
     userId:


### PR DESCRIPTION
Add table to VWB workspace admin page that displays events captured in the `wsm_workspace_activity_logs` table. This feature will modified with more detail and likely moved to a separate audit page as more data becomes available.

<img width="3016" height="2366" alt="localhost_4200_admin_vwb_workspaces_sam-test" src="https://github.com/user-attachments/assets/a3ea1bd3-700c-4921-90c0-a2a097005fab" />