### PR TITLE
[risk=no][no-ticket] Remove dependency check due to issues with the tool. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1302,8 +1302,6 @@ workflows:
           <<: *filter-release-tags
       - api-bigquery-test:
           <<: *filter-release-tags
-      - api-deps-check:
-          <<: *filter-release-tags
       - api-integration-test:
           <<: *filter-release-tags
       - deploy-to-staging:
@@ -1312,7 +1310,6 @@ workflows:
             - api-local-test
             - api-unit-test
             - api-bigquery-test
-            - api-deps-check
             - api-integration-test
             - ui-unit-test
       - puppeteer-env-setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,16 +612,6 @@ jobs:
                 working_directory: ~/workbench/api
                 command: ./project.rb run-local-api-tests
 
-  api-deps-check:
-    executor: workbench-executor
-    steps:
-      - run-api-test:
-          additional_steps:
-            - run:
-                name: Scan dependencies for vulnerabilities
-                working_directory: ~/workbench/api
-                command: ./gradlew dependencyCheckAnalyze --info
-
   api-integration-test:
     executor: workbench-executor
     steps:


### PR DESCRIPTION
We have Snyk configured which reports new vulnerabilities so we don't need this tool. See issues documented in:
https://github.com/dependency-check/dependency-check-gradle/issues/467

This caused failures in our build for the past few days.
https://app.circleci.com/pipelines/github/all-of-us/workbench/38566/workflows/c67cec56-f5b9-4217-9ccc-452ed761ddff


<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
