### PR TITLE
[RW-15766][risk=no] Pull in fix for inconsistent v7 genomic extraction

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -51,10 +51,10 @@
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 15,
+      "methodRepoVersion": 16,
       "methodLogicalVersion": 3
     },
     "cdrv8plus": {

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -50,7 +50,7 @@
     "minExtractionScatterTasks": 350,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-preprod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,

--- a/api/config/config_preprod.json
+++ b/api/config/config_preprod.json
@@ -53,7 +53,7 @@
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-preprod",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 5,
+      "methodRepoVersion": 6,
       "methodLogicalVersion": 3
     },
     "cdrv8plus": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -54,7 +54,7 @@
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-prod",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 4,
+      "methodRepoVersion": 7,
       "methodLogicalVersion": 3
     },
     "cdrv8plus": {

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -51,7 +51,7 @@
     "minExtractionScatterTasks": 350,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-prod",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 4,

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -54,7 +54,7 @@
       "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-stable",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 5,
+      "methodRepoVersion": 6,
       "methodLogicalVersion": 3
     }
   },

--- a/api/config/config_stable.json
+++ b/api/config/config_stable.json
@@ -51,7 +51,7 @@
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-stable",
       "methodName": "GvsExtractCohortFromSampleNames",
       "methodRepoVersion": 5,

--- a/api/config/config_staging.json
+++ b/api/config/config_staging.json
@@ -51,10 +51,10 @@
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-staging",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 5,
+      "methodRepoVersion": 6,
       "methodLogicalVersion": 3
     }
   },

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -51,10 +51,10 @@
     "minExtractionScatterTasks": 20,
     "extractionScatterTasksPerSample": 4,
     "legacyVersions": {
-      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-4.2.0.0-533-g9c2aa67-SNAPSHOT-local.jar",
+      "gatkJarUri": "gs:\/\/all-of-us-workbench-test-genomics\/wgs\/gatk-package-after_master_merge-247-g5128841-SNAPSHOT-local.jar",
       "methodNamespace": "aouwgscohortextraction-test",
       "methodName": "GvsExtractCohortFromSampleNames",
-      "methodRepoVersion": 15,
+      "methodRepoVersion": 16,
       "methodLogicalVersion": 3
     },
     "cdrv8plus": {

--- a/api/genomics/docs/updating_extraction_wdl.md
+++ b/api/genomics/docs/updating_extraction_wdl.md
@@ -25,8 +25,8 @@
 ### Merging
 1. Create a PR with your GATK branch
 2. Get it reviewed by the Variants team and merge it
-3. Upload the new snapshot to all environments using the `--all-projects` parameter of `create-terra-method-snapshot`
-   1. `./project.rb create-terra-method-snapshot --source-git-repo broadinstitute/gatk --source-git-path scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl --source-git-ref ah_var_store —method-name GvsExtractCohortFromSampleNames —all-projects`
+3. Upload the new snapshot to all environments `create-terra-method-snapshot` (the `--all-projects` parameter no longer works so each environment will need to be uploaded separately)
+   1. `./project.rb create-terra-method-snapshot --source-git-repo broadinstitute/gatk --source-git-path scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl --source-git-ref ah_var_store --method-name GvsExtractCohortFromSampleNames --project [project-id]`
       1. The `--source-git-ref` should match the branch that your changes were merged into
       2. The `--method-name` parameter can be anything but our convention has been to use the WDL workflow's name.
    2. Update the config_*.json files. The version number for each environment will be in the output of the previous step.

--- a/api/genomics/docs/updating_extraction_wdl.md
+++ b/api/genomics/docs/updating_extraction_wdl.md
@@ -26,7 +26,8 @@
 1. Create a PR with your GATK branch
 2. Get it reviewed by the Variants team and merge it
 3. Upload the new snapshot to all environments `create-terra-method-snapshot` (the `--all-projects` parameter no longer works so each environment will need to be uploaded separately)
-   1. `./project.rb create-terra-method-snapshot --source-git-repo broadinstitute/gatk --source-git-path scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl --source-git-ref ah_var_store --method-name GvsExtractCohortFromSampleNames --project [project-id]`
+   1. `./project.rb create-terra-method-snapshot --source-git-repo broadinstitute/gatk --source-git-path scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl --source-git-ref gvs_0.6.4 --method-namespace aouwgscohortextraction-{env} --method-name GvsExtractCohortFromSampleNames --project [project-id]`
       1. The `--source-git-ref` should match the branch that your changes were merged into
       2. The `--method-name` parameter can be anything but our convention has been to use the WDL workflow's name.
+      3. `--project` and `--method-namespace` will need to be updated with the appropriate values from the environment-specific config.
    2. Update the config_*.json files. The version number for each environment will be in the output of the previous step.

--- a/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
+++ b/api/src/main/java/org/pmiops/workbench/genomics/GenomicExtractionService.java
@@ -358,21 +358,18 @@ public class GenomicExtractionService {
 
     if (useLegacyWorkflow) {
       // Added in https://github.com/broadinstitute/gatk/pull/7698
-      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".extraction_uuid", "\"" + extractionUuid + "\"");
-      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".cohort_table_prefix", "\"" + extractionUuid + "\"");
       maybeInputs.put(
           EXTRACT_WORKFLOW_NAME + ".gatk_override",
           "\"" + cohortExtractionConfig.legacyVersions.gatkJarUri + "\"");
-      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".scatter_count", Integer.toString(scatterCount));
-    } else {
-      // Added Nov 2024 for v8
-      // replaces extraction_uuid and cohort_table_prefix which are now set to this value
-      maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".call_set_identifier", "\"" + extractionUuid + "\"");
-      // added Jan 2025: new parameter name for scatter count override in v8
-      maybeInputs.put(
-          EXTRACT_WORKFLOW_NAME + ".extract_scatter_count_override",
-          Integer.toString(scatterCount));
     }
+
+    // Added Nov 2024 for v8 and incorporated into v7 Aug 2025
+    // replaces extraction_uuid and cohort_table_prefix which are now set to this value
+    maybeInputs.put(EXTRACT_WORKFLOW_NAME + ".call_set_identifier", "\"" + extractionUuid + "\"");
+    // added Jan 2025: new parameter name for scatter count override in v8
+    // added to v7 in Aug 2025
+    maybeInputs.put(
+        EXTRACT_WORKFLOW_NAME + ".extract_scatter_count_override", Integer.toString(scatterCount));
 
     Blob personIdsFile =
         extractionServiceAccountCloudStorageClientProvider


### PR DESCRIPTION
Ticket: [RW-15766](https://precisionmedicineinitiative.atlassian.net/browse/RW-15766)
* The Variants team fixed the cause of the inconsistent extractions. I published the updated code to the Terra method repo and updated the version numbers in our config accordingly.
* Using the new method required minor updates to the submission inputs.
* Tested by running a genomic extraction successfully against this version.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
