### PR TITLE
[no ticket][risk=no] Add workspace migration fields to reporting

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -681,11 +681,8 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
               .workspaceDemographic(
                   toModelWorkspaceDemographic(getSpecificPopulationsSet(specificPopulationsStr)))
               .migratedVwbWorkspaceId(rs.getString("migrated_vwb_workspace_id"))
-                  .migrationState(
-                          migrationStateStr == null
-                                  ? null
-                                  : MigrationState.valueOf(migrationStateStr)
-                  );
+              .migrationState(
+                  migrationStateStr == null ? null : MigrationState.valueOf(migrationStateStr));
         },
         limit,
         offset);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -610,7 +610,9 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
             + "  w.workspace_id,\n"
             + "  workspace_namespace,\n"
             + "  w.active_status,\n"
-            + "  sp.specific_populations\n"
+            + "  sp.specific_populations,\n"
+            + "  migrated_vwb_workspace_id,\n"
+            + "  migration_state\n"
             + "FROM workspace w\n"
             // some Tanagra workspaces don't have CDR version IDs
             + "  LEFT JOIN cdr_version c ON w.cdr_version_id = c.cdr_version_id\n"
@@ -676,7 +678,9 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                   workspaceActiveStatusFromStorage(rs.getShort("active_status")).toString())
               .focusOnUnderrepresentedPopulations(focusOnUnderrepresentedPopulations)
               .workspaceDemographic(
-                  toModelWorkspaceDemographic(getSpecificPopulationsSet(specificPopulationsStr)));
+                  toModelWorkspaceDemographic(getSpecificPopulationsSet(specificPopulationsStr)))
+              .migratedVwbWorkspaceId(rs.getString("migrated_vwb_workspace_id"))
+              .migrationState(rs.getString("migration_state"));
         },
         limit,
         offset);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -633,6 +633,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
         sql,
         (rs, unused) -> {
           String specificPopulationsStr = rs.getString("specific_populations");
+          String migrationStateStr = rs.getString("migration_state");
           boolean focusOnUnderrepresentedPopulations =
               specificPopulationsStr != null && !specificPopulationsStr.isEmpty();
 
@@ -680,7 +681,11 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
               .workspaceDemographic(
                   toModelWorkspaceDemographic(getSpecificPopulationsSet(specificPopulationsStr)))
               .migratedVwbWorkspaceId(rs.getString("migrated_vwb_workspace_id"))
-              .migrationState(migrationStateFromStorage(rs.getShort("migration_state")));
+                  .migrationState(
+                          migrationStateStr == null
+                                  ? null
+                                  : MigrationState.valueOf(migrationStateStr)
+                  );
         },
         limit,
         offset);

--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -680,7 +680,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
               .workspaceDemographic(
                   toModelWorkspaceDemographic(getSpecificPopulationsSet(specificPopulationsStr)))
               .migratedVwbWorkspaceId(rs.getString("migrated_vwb_workspace_id"))
-              .migrationState(rs.getString("migration_state"));
+              .migrationState(migrationStateFromStorage(rs.getShort("migration_state")));
         },
         limit,
         offset);

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbStorageEnums.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.model.Education;
 import org.pmiops.workbench.model.Ethnicity;
 import org.pmiops.workbench.model.GenderIdentity;
 import org.pmiops.workbench.model.InstitutionalRole;
+import org.pmiops.workbench.model.MigrationState;
 import org.pmiops.workbench.model.OrganizationType;
 import org.pmiops.workbench.model.PrePackagedConceptSetEnum;
 import org.pmiops.workbench.model.Race;
@@ -573,6 +574,14 @@ public final class DbStorageEnums {
           .put(TierAccessStatus.ENABLED, (short) 1)
           .build();
 
+  private static final BiMap<MigrationState, Short> CLIENT_TO_STORAGE_MIGRATION_STATE =
+      ImmutableBiMap.<MigrationState, Short>builder()
+          .put(MigrationState.NOT_STARTED, (short) 0)
+          .put(MigrationState.STARTING, (short) 1)
+          .put(MigrationState.FINISHED, (short) 2)
+          .put(MigrationState.FAILED, (short) 3)
+          .build();
+
   public static Race raceFromStorage(Short race) {
     return CLIENT_TO_STORAGE_RACE.inverse().get(race);
   }
@@ -627,5 +636,13 @@ public final class DbStorageEnums {
 
   public static TierAccessStatus tierAccessStatusFromStorage(Short tierAccessStatus) {
     return CLIENT_TO_STORAGE_TIER_ACCESS_STATUS.inverse().get(tierAccessStatus);
+  }
+
+  public static Short migrationStateToStorage(MigrationState migrationState) {
+    return CLIENT_TO_STORAGE_MIGRATION_STATE.get(migrationState);
+  }
+
+  public static MigrationState migrationStateFromStorage(Short migrationState) {
+    return CLIENT_TO_STORAGE_MIGRATION_STATE.inverse().get(migrationState);
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -56,7 +56,7 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   ACTIVE_STATUS("active_status", ReportingWorkspace::getActiveStatus),
   MIGRATED_VWB_WORKSPACE_ID(
       "migrated_vwb_workspace_id", ReportingWorkspace::getMigratedVwbWorkspaceId),
-  MIGRATION_STATE("migration_state", ReportingWorkspace::getMigrationState),
+  MIGRATION_STATE("migration_state", w -> enumToString(w.getMigrationState())),
   FOCUS_ON_UNDER_REPRESENTED_POPULATIONS(
       "focus_on_under_represented_populations",
       ReportingWorkspace::isFocusOnUnderrepresentedPopulations),

--- a/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
+++ b/api/src/main/java/org/pmiops/workbench/reporting/insertion/WorkspaceColumnValueExtractor.java
@@ -54,6 +54,9 @@ public enum WorkspaceColumnValueExtractor implements ColumnValueExtractor<Report
   WORKSPACE_ID("workspace_id", ReportingWorkspace::getWorkspaceId),
   WORKSPACE_NAMESPACE("workspace_namespace", ReportingWorkspace::getWorkspaceNamespace),
   ACTIVE_STATUS("active_status", ReportingWorkspace::getActiveStatus),
+  MIGRATED_VWB_WORKSPACE_ID(
+      "migrated_vwb_workspace_id", ReportingWorkspace::getMigratedVwbWorkspaceId),
+  MIGRATION_STATE("migration_state", ReportingWorkspace::getMigrationState),
   FOCUS_ON_UNDER_REPRESENTED_POPULATIONS(
       "focus_on_under_represented_populations",
       ReportingWorkspace::isFocusOnUnderrepresentedPopulations),

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -8014,7 +8014,7 @@ components:
           socialBehavioral: false
     MigrationState:
       type: string
-      description: Tracks the lifecycle (NOT_STARTED, STARTING, FINISHED, FAILED)
+      description: Indicates the status of the workspace migration (NOT_STARTED, STARTING, FINISHED, FAILED).
       enum:
         - NOT_STARTED
         - STARTING
@@ -13353,9 +13353,7 @@ components:
           description: |-
             Id of the RW 2.0 workspace created during migration
         migrationState:
-          type: string
-          description: |-
-            Indicates the status of the workspace migration. It can be "NOT_STARTED", "STARTING" or "FINISHED".
+          $ref: '#/components/schemas/MigrationState'
         focusOnUnderrepresentedPopulations:
           type: boolean
           description: |-

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -13348,6 +13348,14 @@ components:
           type: string
           description: |-
             Indicates the status of the workspace. It can be either "Active" or "Deleted".
+        migratedVwbWorkspaceId:
+          type: string
+          description: |-
+            Id of the RW 2.0 workspace created during migration
+        migrationState:
+          type: string
+          description: |-
+            Indicates the status of the workspace migration. It can be "NOT_STARTED", "STARTING" or "FINISHED".
         focusOnUnderrepresentedPopulations:
           type: boolean
           description: |-

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -67,7 +67,7 @@ public class ReportingTestUtils {
       FeaturedWorkspaceCategory.COMMUNITY.toString();
   public static final String WORKSPACE__ACTIVE_STATUS = "Active";
   public static final String WORKSPACE__MIGRATED_VWB_WORKSPACE_ID = "12345";
-  public static final String WORKSPACE__MIGRATION_STATE = "NOT_STARTED";
+  public static final MigrationState WORKSPACE__MIGRATION_STATE = MigrationState.NOT_STARTED;
   public static final Boolean WORKSPACE__FOCUS_ON_UNDER_REPRESENTED_POPULATIONS = true;
   public static final WorkspaceDemographic WORKSPACE__WORKSPACE_DEMOGRAPHIC =
       new WorkspaceDemographic()

--- a/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
+++ b/api/src/test/java/org/pmiops/workbench/testconfig/ReportingTestUtils.java
@@ -66,6 +66,8 @@ public class ReportingTestUtils {
   public static final String WORKSPACE__FEATURED_WORKSPACE_CATEGORY =
       FeaturedWorkspaceCategory.COMMUNITY.toString();
   public static final String WORKSPACE__ACTIVE_STATUS = "Active";
+  public static final String WORKSPACE__MIGRATED_VWB_WORKSPACE_ID = "12345";
+  public static final String WORKSPACE__MIGRATION_STATE = "NOT_STARTED";
   public static final Boolean WORKSPACE__FOCUS_ON_UNDER_REPRESENTED_POPULATIONS = true;
   public static final WorkspaceDemographic WORKSPACE__WORKSPACE_DEMOGRAPHIC =
       new WorkspaceDemographic()
@@ -153,6 +155,8 @@ public class ReportingTestUtils {
         .workspaceId(WORKSPACE__WORKSPACE_ID)
         .workspaceNamespace(WORKSPACE__WORKSPACE_NAMESPACE)
         .activeStatus(WORKSPACE__ACTIVE_STATUS)
+        .migratedVwbWorkspaceId(WORKSPACE__MIGRATED_VWB_WORKSPACE_ID)
+        .migrationState(WORKSPACE__MIGRATION_STATE)
         .focusOnUnderrepresentedPopulations(WORKSPACE__FOCUS_ON_UNDER_REPRESENTED_POPULATIONS)
         .workspaceDemographic(WORKSPACE__WORKSPACE_DEMOGRAPHIC);
   }


### PR DESCRIPTION
Update reporting service to add `migrated_vwb_workspace_id` and `migration_state` columns