### PR TITLE
[no ticket][risk=no] Force active support load for jira-ruby

### DIFF
--- a/deploy/libproject/jirarelease.rb
+++ b/deploy/libproject/jirarelease.rb
@@ -8,6 +8,7 @@
 
 require "open3"
 require "jira-ruby"
+require "active_support/core_ext/object"
 
 require_relative "../../aou-utils/utils/common"
 


### PR DESCRIPTION
Fix attempt for this release deploy failure: https://app.circleci.com/pipelines/github/all-of-us/workbench/39215/workflows/5704cbc5-82fb-47dd-92d0-ed6a04e915fc/jobs/441008
```
/var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/http_error.rb:11:in `initialize': undefined method `presence' for "Not Found":String (NoMethodError)
Did you mean?  presence_in
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/request_client.rb:13:in `exception'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/request_client.rb:13:in `raise'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/request_client.rb:13:in `request'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/client.rb:306:in `request'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/client.rb:279:in `get'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/base.rb:334:in `fetch'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/base.rb:107:in `find'
        from /var/lib/gems/3.0.0/gems/jira-ruby-2.3.0/lib/jira/base_factory.rb:31:in `block (2 levels) in delegate_to_target_class'
        from /home/circleci/workbench/deploy/libproject/jirarelease.rb:111:in `create_ticket'
        from /home/circleci/workbench/deploy/libproject/deploy.rb:314:in `deploy'
        from /home/circleci/workbench/api/libproject/devstart.rb:2624:in `block in <top (required)>'
        from /home/circleci/workbench/aou-utils/utils/common.rb:83:in `handle_or_die'
        from /home/circleci/workbench/aou-utils/workbench.rb:48:in `handle_argv_or_die'
        from ./project.rb:6:in `<main>'
```

Fix found in this pr: https://github.com/sumoheavy/jira-ruby/pull/435