### PR TITLE
[no ticket][risk=no] Add memberRoles field to PodDescription schema

### DIFF
--- a/api/src/main/resources/vwb-user-manager.yaml
+++ b/api/src/main/resources/vwb-user-manager.yaml
@@ -1920,6 +1920,9 @@ components:
           $ref: '#/components/schemas/PodEnvironment'
         groupName:
           type: string
+        memberRoles:
+          description: Roles for the specified email (when email query parameter is provided in listPods)
+          $ref: '#/components/schemas/PodRoleList'
         createdBy:
           description: User email of creator
           type: string


### PR DESCRIPTION
## Summary
Add missing `memberRoles` field to `PodDescription` schema to complete the listPods endpoint sync with verily1 user-manager.

## Context
PR #9475 added the `email` query parameter to the listPods endpoint, but was **missing the response field** that gets populated when that parameter is provided.

This PR adds the missing `memberRoles` field to complete the implementation.

## Changes
- Added `memberRoles` field to `PodDescription` schema
  - Type: `PodRoleList` (array of PodRole enum: ADMIN, USER, SUPPORT)
  - Optional field (not in required list)
  - Only populated when `email` query parameter is provided in listPods request
  - Description clarifies it contains roles for the specified email

## Use Case
Enables org admins to query pod access for specific users:

**Request:**
```
GET /api/organizations/v2/{orgId}/pods?email=researcher@example.com
```

**Response:** Each `PodDescription` in the response includes:
```json
{
  "podId": "...",
  "userFacingId": "...",
  "memberRoles": ["USER"],  // <-- NEW FIELD
  ...
}
```

## References
- PR #9475: Added email query parameter (merged)
- Verily1 implementation: https://github.com/verily-src/verily1/blob/main/workbench/user-manager/service/src/main/resources/api/openapi.yml

## Test plan
- [ ] Verify API spec compiles without errors
- [ ] Verify generated client includes the memberRoles field in PodDescription
- [ ] Confirm complete alignment with verily1 user-manager service

🤖 Generated with [Claude Code](https://claude.com/claude-code)