### PR TITLE
[no ticket][risk=no] Fix VWB admin AoD and group principal parsing

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/VwbGroupAdminController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/VwbGroupAdminController.java
@@ -95,7 +95,7 @@ public class VwbGroupAdminController implements VwbGroupAdminApiDelegate {
         request.getRole(),
         request.getReason());
     GroupRole role = GroupRole.valueOf(request.getRole().name());
-    vwbUserManagerClient.addUserToGroup(groupName, request.getEmail(), role);
+    vwbUserManagerClient.addUserToGroup(groupName, request.getEmail(), role, request.getReason());
     return ResponseEntity.noContent().build();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/RetryHandler.java
@@ -40,7 +40,11 @@ public abstract class RetryHandler<E extends Exception> {
       // would cause a ClassCastException in the bridge method before convertException is reached.
       throw exception;
     } catch (Exception exception) {
-      throw convertException((E) exception);
+      try {
+        throw convertException((E) exception);
+      } catch (ClassCastException cce) {
+        throw new ServerErrorException(exception);
+      }
     }
   }
 

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -71,28 +71,33 @@ public class VwbUserManagerClient {
 
   /** Adds a user into VWB user group. */
   public void addUserToGroup(String groupName, String email) {
-    addUserToGroup(groupName, email, GroupRole.MEMBER);
+    addUserToGroup(groupName, email, GroupRole.MEMBER, null);
   }
 
   /** Adds a user into VWB user group with a specified role. */
-  public void addUserToGroup(String groupName, String email, GroupRole role) {
+  public void addUserToGroup(String groupName, String email, GroupRole role, String reason) {
     logger.info("Adding user in VWB group {}, with email {}, role {}", groupName, email, role);
-    updateGroupMembership(groupName, email, SetAccessOperation.GRANT, role);
+    updateGroupMembership(groupName, email, SetAccessOperation.GRANT, role, reason);
   }
 
   /** Removes a user from VWB user group. */
   public void removeUserFromGroup(String groupName, String email) {
     logger.info("Removing user from VWB group {}, with email {}", groupName, email);
-    updateGroupMembership(groupName, email, SetAccessOperation.REVOKE, GroupRole.MEMBER);
+    updateGroupMembership(groupName, email, SetAccessOperation.REVOKE, GroupRole.MEMBER, null);
   }
 
   private void updateGroupMembership(
-      String groupName, String email, SetAccessOperation operation, GroupRole role) {
+      String groupName,
+      String email,
+      SetAccessOperation operation,
+      GroupRole role,
+      String reason) {
     String organizationId = workbenchConfigProvider.get().vwb.organizationId;
     SetAccessRequest setAccessRequest =
         new SetAccessRequest()
             .role(role)
             .operation(operation)
+            .reason(reason)
             .principal(new Principal().userPrincipal(new PrincipalUser().email(email)));
     vwbUserManagerRetryHandler.run(
         context -> {

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -87,11 +87,7 @@ public class VwbUserManagerClient {
   }
 
   private void updateGroupMembership(
-      String groupName,
-      String email,
-      SetAccessOperation operation,
-      GroupRole role,
-      String reason) {
+      String groupName, String email, SetAccessOperation operation, GroupRole role, String reason) {
     String organizationId = workbenchConfigProvider.get().vwb.organizationId;
     SetAccessRequest setAccessRequest =
         new SetAccessRequest()

--- a/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/usermanager/VwbUserManagerClient.java
@@ -212,11 +212,28 @@ public class VwbUserManagerClient {
 
     vwbUserManagerRetryHandler.run(
         context -> {
-          workspaceApiProvider
-              .get()
-              .workspaceAccessOnDemand(accessOnDemandRequest, workspaceIdentifier);
+          try {
+            workspaceApiProvider
+                .get()
+                .workspaceAccessOnDemand(accessOnDemandRequest, workspaceIdentifier);
+          } catch (ApiException e) {
+            if (isAlreadyOwnerException(e)) {
+              logger.info(
+                  String.format(
+                      "Skipping AoD for userFacingId=%s: service account is already an OWNER",
+                      userFacingId));
+            } else {
+              throw e;
+            }
+          }
           return null;
         });
+  }
+
+  private boolean isAlreadyOwnerException(ApiException e) {
+    return e.getCode() == 400
+        && e.getResponseBody() != null
+        && e.getResponseBody().contains("already an OWNER");
   }
 
   public PodDescriptionList listUserPods(String orgId) {

--- a/api/src/main/resources/vwb-user-manager.yaml
+++ b/api/src/main/resources/vwb-user-manager.yaml
@@ -2163,6 +2163,8 @@ components:
           $ref: '#/components/schemas/GroupRole'
         expiration:
           $ref: '#/components/schemas/ExpirationDays'
+        reason:
+          type: string
 
     UserActiveState:
       type: string

--- a/api/src/main/resources/vwb-user-manager.yaml
+++ b/api/src/main/resources/vwb-user-manager.yaml
@@ -2100,7 +2100,6 @@ components:
       properties:
         organizationId:
           type: string
-          format: uuid
         groupName:
           type: string
 

--- a/api/src/test/java/org/pmiops/workbench/api/VwbGroupAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/VwbGroupAdminControllerTest.java
@@ -202,7 +202,8 @@ public class VwbGroupAdminControllerTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     verify(mockVwbUserManagerClient)
-        .addUserToGroup("test-group", "newuser@verily.com", GroupRole.MEMBER);
+        .addUserToGroup(
+            "test-group", "newuser@verily.com", GroupRole.MEMBER, "Needs access for testing");
   }
 
   @Test
@@ -217,7 +218,8 @@ public class VwbGroupAdminControllerTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     verify(mockVwbUserManagerClient)
-        .addUserToGroup("test-group", "admin@verily.com", GroupRole.ADMIN);
+        .addUserToGroup(
+            "test-group", "admin@verily.com", GroupRole.ADMIN, "Admin access required");
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/api/VwbGroupAdminControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/VwbGroupAdminControllerTest.java
@@ -218,8 +218,7 @@ public class VwbGroupAdminControllerTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     verify(mockVwbUserManagerClient)
-        .addUserToGroup(
-            "test-group", "admin@verily.com", GroupRole.ADMIN, "Admin access required");
+        .addUserToGroup("test-group", "admin@verily.com", GroupRole.ADMIN, "Admin access required");
   }
 
   @Test

--- a/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
@@ -109,13 +109,15 @@ export const AdminVwbGroups = (spinnerProps: WithSpinnerOverlayProps) => {
       loadMembers(selectedGroup.groupName);
     } catch (error) {
       console.error(error);
-      const errorMessage =
-        error instanceof Response
-          ? await error
-              .json()
-              .then((body) => body?.message)
-              .catch(() => null)
-          : null;
+      let errorMessage = null;
+      if (error instanceof Response) {
+        try {
+          const body = await error.json();
+          errorMessage = body?.message;
+        } catch {
+          // ignore parse errors
+        }
+      }
       setAddMemberError(
         errorMessage ||
           'Failed to add member. Please check the email and try again.'

--- a/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
@@ -111,10 +111,14 @@ export const AdminVwbGroups = (spinnerProps: WithSpinnerOverlayProps) => {
       console.error(error);
       const errorMessage =
         error instanceof Response
-          ? await error.json().then((body) => body?.message).catch(() => null)
+          ? await error
+              .json()
+              .then((body) => body?.message)
+              .catch(() => null)
           : null;
       setAddMemberError(
-        errorMessage || 'Failed to add member. Please check the email and try again.'
+        errorMessage ||
+          'Failed to add member. Please check the email and try again.'
       );
     } finally {
       setAddMemberLoading(false);

--- a/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-groups.tsx
@@ -109,8 +109,12 @@ export const AdminVwbGroups = (spinnerProps: WithSpinnerOverlayProps) => {
       loadMembers(selectedGroup.groupName);
     } catch (error) {
       console.error(error);
+      const errorMessage =
+        error instanceof Response
+          ? await error.json().then((body) => body?.message).catch(() => null)
+          : null;
       setAddMemberError(
-        'Failed to add member. Please check the email and try again.'
+        errorMessage || 'Failed to add member. Please check the email and try again.'
       );
     } finally {
       setAddMemberLoading(false);

--- a/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
+++ b/ui/src/app/pages/admin/vwb/admin-vwb-workspace.tsx
@@ -525,14 +525,14 @@ export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
                   <div
                     style={{ paddingLeft: '0.75rem', paddingRight: '0.75rem' }}
                   >
-                    {getCommandText(workspace.id)}
+                    {getCommandText(workspace.userFacingId)}
                   </div>
                   <FontAwesomeIcon
                     icon={faCopy}
                     style={{ marginRight: '0.6rem', cursor: 'pointer' }}
                     onClick={() =>
                       navigator.clipboard.writeText(
-                        getCommandText(workspace.id)
+                        getCommandText(workspace.userFacingId)
                       )
                     }
                     title='Copy CLI Command'
@@ -544,7 +544,7 @@ export const AdminVwbWorkspace = fp.flow(withRouter)((props: Props) => {
                 style={{ marginLeft: '0.5rem', height: '2.25rem' }}
                 onClick={() => {
                   window.open(
-                    `${environment.vwbUiUrl}/workspaces/${workspace.id}`,
+                    `${environment.vwbUiUrl}/workspaces/${workspace.userFacingId}`,
                     '_blank',
                     'noopener noreferrer'
                   );


### PR DESCRIPTION
## Summary
- Skip AoD (Access on Demand) when the service account is already an OWNER of the workspace, instead of propagating a 400 error from the VWB User Manager API
- Fix `PrincipalWorkbenchGroup.organizationId` type from `uuid` to `string` to match the upstream VWB spec — the field can contain UFIDs (e.g. `~aou-prod`), not just UUIDs, which caused Gson deserialization failures

## Test plan
- [ ] Verify AoD succeeds on workspaces where the service account is not yet an owner
- [ ] Verify AoD no longer errors on workspaces where the service account is already an owner
- [ ] Verify group listing no longer fails with `JsonSyntaxException` on `~aou-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)