### PR TITLE
[no ticket][risk=no] Fix wondershaper on Dataproc by detecting network interface

### DIFF
--- a/api/src/main/webapp/static/start_notebook_runtime.sh
+++ b/api/src/main/webapp/static/start_notebook_runtime.sh
@@ -9,7 +9,7 @@ set -x
 # server and its path is passed in as jupyterStartUserScriptUri during notebook
 # runtime creation. This runs after initialize_notebook_runtime.sh on creation.
 
+IFACE=$(ip route show default | awk '{print $5}' | head -1)
 pushd /usr/local/share/wondershaper
-wondershaper -a "eth0" -u 16384 # kilobits; 16Mib/s (2MiB/s)
-
+wondershaper -a "$IFACE" -u 16384 # kilobits; 16Mib/s (2MiB/s)
 popd


### PR DESCRIPTION
## Summary
- Wondershaper egress limiting (2 MiB/s) has been **silently broken on Dataproc since May 2025** when the `terra-jupyter-aou` image was bumped from `2.2.13` → `2.2.16`, moving AOU from Dataproc 2.1 to 2.2
- **Root cause**: The Jupyter container on Dataproc uses `network_mode: host`, so it sees the host VM's network interfaces. Dataproc 2.2 (Ubuntu 22) uses `ens4` as the default interface, not `eth0`. The hardcoded `wondershaper -a "eth0"` targets a non-existent interface and fails silently (no `set -e` in the script)
- **Fix**: Detect the default network interface dynamically via `ip route show default`. This returns `eth0` on GCE (bridge networking) and `ens4` on Dataproc (host networking), so it works for both
- **Why it wasn't caught**: The script uses `set -x` (trace) but not `set -e` (exit on error), so wondershaper failures are logged but don't halt startup

### Related
- Leonardo PR [DataBiosphere/leonardo#4839](https://github.com/DataBiosphere/leonardo/pull/4839) — Dataproc 2.1 → 2.2 upgrade (merged 2025-05-06)
- Workbench PR [#9269](https://github.com/all-of-us/workbench/pull/9269) — image bump to `2.2.16` in prod (merged 2025-05-13)

## Test plan
- [ ] SSH into a Dataproc master node, verify `ip route show default` returns `ens4`
- [ ] Create a new Dataproc runtime, check startup logs for successful wondershaper output
- [ ] Run speed test on Dataproc to confirm egress is limited to ~2 MiB/s
- [ ] Verify GCE runtimes still work (interface resolves to `eth0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)