### PR TITLE
[DT-1121][DT-1113][risk=no] Allow v7 migrations, filter user pods

### DIFF
--- a/api/config/config_local.json
+++ b/api/config/config_local.json
@@ -222,16 +222,17 @@
       "logProjectId": "workbench-bq-log-sink",
       "bigQueryDataset": "workbench_monitoring_org_logs_dev"
     },
-    "cdrVersionIdsForMigration": [9, 10],
-    "dataCollectionsForMigration": {
-      "controlled": {
-        "workspaceId": "7d7b32f1-3481-4e60-b496-4b6175833f3f",
-        "resourceId": "dd0c734b-ed8f-4842-8367-bcd9882a654f"
-      },
-      "registered": {
+    "cdrVersionsForMigration": [
+      {
+        "cdrVersionId": 9,
         "workspaceId": "505eb5d3-5b17-42d2-82ed-d3c223ed9e02",
         "resourceId": "101f0ba2-742b-400e-9cee-9f9fc56e5837"
+      },
+      {
+        "cdrVersionId": 10,
+        "workspaceId": "7d7b32f1-3481-4e60-b496-4b6175833f3f",
+        "resourceId": "dd0c734b-ed8f-4842-8367-bcd9882a654f"
       }
-    }
+    ]
   }
 }

--- a/api/config/config_prod.json
+++ b/api/config/config_prod.json
@@ -226,16 +226,27 @@
       "logProjectId": "workbench-bq-log-sink",
       "bigQueryDataset": "workbench_monitoring_org_logs_prod"
     },
-    "cdrVersionIdsForMigration": [13, 14],
-    "dataCollectionsForMigration": {
-      "controlled": {
-        "workspaceId": "3d83ef80-77d7-43e8-a479-52946619b769",
-        "resourceId": "e761c0c3-8741-45f0-944c-d15e4cffb5ae"
+    "cdrVersionsForMigration": [
+      {
+        "cdrVersionId": 11,
+        "workspaceId": "698c6700-afbe-454a-b73a-c675e629336c",
+        "resourceId": "4b26807c-ac70-47cb-aa03-920570e8e1cc"
       },
-      "registered": {
+      {
+        "cdrVersionId": 12,
+        "workspaceId": "3d83ef80-77d7-43e8-a479-52946619b769",
+        "resourceId": "f3681964-4d49-4ba8-9cea-5e4f40198c8f"
+      },
+      {
+        "cdrVersionId": 13,
         "workspaceId": "698c6700-afbe-454a-b73a-c675e629336c",
         "resourceId": "0ee225d5-acc5-4a50-830e-6c062beb95fb"
+      },
+      {
+        "cdrVersionId": 14,
+        "workspaceId": "3d83ef80-77d7-43e8-a479-52946619b769",
+        "resourceId": "e761c0c3-8741-45f0-944c-d15e4cffb5ae"
       }
-    }
+    ]
   }
 }

--- a/api/config/config_test.json
+++ b/api/config/config_test.json
@@ -241,16 +241,17 @@
       "logProjectId": "workbench-bq-log-sink",
       "bigQueryDataset": "workbench_monitoring_org_logs_dev"
     },
-    "cdrVersionIdsForMigration": [7, 9],
-    "dataCollectionsForMigration": {
-      "controlled": {
-        "workspaceId": "7d7b32f1-3481-4e60-b496-4b6175833f3f",
-        "resourceId": "dd0c734b-ed8f-4842-8367-bcd9882a654f"
-      },
-      "registered": {
+    "cdrVersionsForMigration": [
+      {
+        "cdrVersionId": 7,
         "workspaceId": "505eb5d3-5b17-42d2-82ed-d3c223ed9e02",
         "resourceId": "101f0ba2-742b-400e-9cee-9f9fc56e5837"
+      },
+      {
+        "cdrVersionId": 9,
+        "workspaceId": "7d7b32f1-3481-4e60-b496-4b6175833f3f",
+        "resourceId": "dd0c734b-ed8f-4842-8367-bcd9882a654f"
       }
-    }
+    ]
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfig.java
@@ -5,8 +5,6 @@ import static org.pmiops.workbench.utils.BillingUtils.fullBillingAccountName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.pmiops.workbench.config.WorkbenchConfig.VwbConfig.DataCollectionsForMigration;
-import org.pmiops.workbench.config.WorkbenchConfig.VwbConfig.DcAccessTier;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig.CDRv8PlusConfig;
 import org.pmiops.workbench.config.WorkbenchConfig.WgsCohortExtractionConfig.LegacyWorkflowConfig;
 
@@ -81,10 +79,7 @@ public class WorkbenchConfig {
     config.termsOfService = new TermsOfServiceConfig();
     config.artifactRegistry = new ArtifactRegistryConfig();
     config.vwb = new VwbConfig();
-    config.vwb.cdrVersionIdsForMigration = List.of();
-    config.vwb.dataCollectionsForMigration = new DataCollectionsForMigration();
-    config.vwb.dataCollectionsForMigration.controlled = new DcAccessTier();
-    config.vwb.dataCollectionsForMigration.registered = new DcAccessTier();
+    config.vwb.cdrVersionsForMigration = List.of();
     return config;
   }
 
@@ -539,18 +534,13 @@ public class WorkbenchConfig {
     }
 
     public AdminBigQuery adminBigQuery;
-    public List<Integer> cdrVersionIdsForMigration;
 
-    public static class DcAccessTier {
+    public static class CdrVersionForMigration {
+      public Integer cdrVersionId;
       public String workspaceId;
       public String resourceId;
     }
 
-    public static class DataCollectionsForMigration {
-      public DcAccessTier controlled;
-      public DcAccessTier registered;
-    }
-
-    public DataCollectionsForMigration dataCollectionsForMigration;
+    public List<CdrVersionForMigration> cdrVersionsForMigration;
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/config/WorkbenchConfigMapper.java
@@ -82,6 +82,6 @@ public interface WorkbenchConfigMapper {
   @Mapping(
       target = "enableVWBHomepageBanner",
       source = "config.featureFlags.enableVWBHomepageBanner")
-  @Mapping(target = "cdrVersionIdsForMigration", source = "config.vwb.cdrVersionIdsForMigration")
+  @Mapping(target = "cdrVersionsForMigration", source = "config.vwb.cdrVersionsForMigration")
   ConfigResponse toModel(WorkbenchConfig config, List<DbAccessModule> accessModules);
 }

--- a/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/VwbUserService.java
@@ -233,9 +233,10 @@ public class VwbUserService {
     return podList.getResults().stream()
         .filter(
             p ->
-                (p.getDescription() != null && p.getDescription().contains(userEmail))
-                    || userEmail.equals(p.getCreatedBy())
-                    || podIdsFromBq.contains(p.getPodId().toString()))
+                ((p.getDescription() != null && p.getDescription().contains(userEmail))
+                        || userEmail.equals(p.getCreatedBy())
+                        || podIdsFromBq.contains(p.getPodId().toString()))
+                    && p.getEnvironmentData().getEnvironmentDataGcp().getBillingAccountId() != null)
         .toList();
   }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -420,22 +420,42 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
           Level.INFO,
           preprodWorkspace.getWorkspaceNamespace() + ": Workspace created: " + vwbWorkspace);
 
+      // Manually map preprod cdrs to data collection ids from config since preprod cdrVersionIds
+      // will not match prod
       long cdrVersionId = preprodWorkspace.getCdrVersionId();
-      CdrVersionForMigration cdrVersionForMigration =
-          workbenchConfigProvider.get().vwb.cdrVersionsForMigration.stream()
-              .filter(c -> c.cdrVersionId == cdrVersionId)
-              .findFirst()
-              .orElse(null);
-      if (cdrVersionForMigration == null) {
-        throw new RuntimeException(
-            preprodWorkspace.getWorkspaceNamespace() + ": CDR version not available for migration");
-      }
+      String dataCollectionWsid;
+      String dataCollectionResourceId =
+          switch (Long.toString(cdrVersionId)) {
+            case "10", "12" -> {
+              dataCollectionWsid =
+                  workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(0).workspaceId;
+              yield workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(0).resourceId;
+            }
+            case "11", "13" -> {
+              dataCollectionWsid =
+                  workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(1).workspaceId;
+              yield workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(1).resourceId;
+            }
+            case "14" -> {
+              dataCollectionWsid =
+                  workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(2).workspaceId;
+              yield workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(2).resourceId;
+            }
+            case "15" -> {
+              dataCollectionWsid =
+                  workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(3).workspaceId;
+              yield workbenchConfigProvider.get().vwb.cdrVersionsForMigration.get(3).resourceId;
+            }
+            default -> throw new RuntimeException(
+                preprodWorkspace.getWorkspaceNamespace()
+                    + ": Preprod CDR version not available for migration");
+          };
 
       logger.log(Level.INFO, preprodWorkspace.getWorkspaceNamespace() + ": Starting BQ clone");
       wsmClient.cloneBQDataset(
           workspaceId,
-          cdrVersionForMigration.workspaceId,
-          UUID.fromString(cdrVersionForMigration.resourceId),
+          dataCollectionWsid,
+          UUID.fromString(dataCollectionResourceId),
           UUID.randomUUID().toString());
 
       logger.log(Level.INFO, preprodWorkspace.getWorkspaceNamespace() + ": BQ clone complete");

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.VwbConfig.CdrVersionForMigration;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbUser;
@@ -231,23 +232,14 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
       wsmClient.updateWorkspaceProperties(properties, workspaceId.toString());
       logger.log(Level.INFO, namespace + ": Workspace created: " + vwbWorkspace);
 
-      String accessTier = dbWorkspace.getCdrVersion().getAccessTier().getShortName();
-      String dataCollectionWsid;
-      String dataCollectionResourceId;
-
-      // Get data collection id from access tier
-      if (accessTier.equals("registered")) {
-        dataCollectionWsid =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.registered.workspaceId;
-        dataCollectionResourceId =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.registered.resourceId;
-      } else if (accessTier.equals("controlled")) {
-        dataCollectionWsid =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.controlled.workspaceId;
-        dataCollectionResourceId =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.controlled.resourceId;
-      } else {
-        throw new RuntimeException(namespace + ": Workspace migration failed, invalid access tier");
+      long cdrVersionId = dbWorkspace.getCdrVersion().getCdrVersionId();
+      CdrVersionForMigration cdrVersionForMigration =
+          workbenchConfigProvider.get().vwb.cdrVersionsForMigration.stream()
+              .filter(c -> c.cdrVersionId == cdrVersionId)
+              .findFirst()
+              .orElse(null);
+      if (cdrVersionForMigration == null) {
+        throw new RuntimeException(namespace + ": CDR version not available for migration");
       }
 
       // Attach data collection
@@ -255,8 +247,8 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
         logger.log(Level.INFO, namespace + ": Starting BQ clone");
         wsmClient.cloneBQDataset(
             workspaceId,
-            dataCollectionWsid,
-            UUID.fromString(dataCollectionResourceId),
+            cdrVersionForMigration.workspaceId,
+            UUID.fromString(cdrVersionForMigration.resourceId),
             UUID.randomUUID().toString());
 
         logger.log(Level.INFO, namespace + ": BQ clone complete");
@@ -428,29 +420,22 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
           Level.INFO,
           preprodWorkspace.getWorkspaceNamespace() + ": Workspace created: " + vwbWorkspace);
 
-      String accessTier = preprodWorkspace.getAccessTierShortName();
-      String dataCollectionWsid;
-      String dataCollectionResourceId;
-
-      if (accessTier.equals("registered")) {
-        dataCollectionWsid =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.registered.workspaceId;
-        dataCollectionResourceId =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.registered.resourceId;
-      } else if (accessTier.equals("controlled")) {
-        dataCollectionWsid =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.controlled.workspaceId;
-        dataCollectionResourceId =
-            workbenchConfigProvider.get().vwb.dataCollectionsForMigration.controlled.resourceId;
-      } else {
-        throw new RuntimeException("Workspace migration failed, invalid access tier");
+      long cdrVersionId = preprodWorkspace.getCdrVersionId();
+      CdrVersionForMigration cdrVersionForMigration =
+          workbenchConfigProvider.get().vwb.cdrVersionsForMigration.stream()
+              .filter(c -> c.cdrVersionId == cdrVersionId)
+              .findFirst()
+              .orElse(null);
+      if (cdrVersionForMigration == null) {
+        throw new RuntimeException(
+            preprodWorkspace.getWorkspaceNamespace() + ": CDR version not available for migration");
       }
 
       logger.log(Level.INFO, preprodWorkspace.getWorkspaceNamespace() + ": Starting BQ clone");
       wsmClient.cloneBQDataset(
           workspaceId,
-          dataCollectionWsid,
-          UUID.fromString(dataCollectionResourceId),
+          cdrVersionForMigration.workspaceId,
+          UUID.fromString(cdrVersionForMigration.resourceId),
           UUID.randomUUID().toString());
 
       logger.log(Level.INFO, preprodWorkspace.getWorkspaceNamespace() + ": BQ clone complete");

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -7853,11 +7853,23 @@ components:
           type: boolean
           default: false
           description: If true, will display the "Migrate to Verily Workbench" button on workspace pages.
-        cdrVersionIdsForMigration:
+        cdrVersionsForMigration:
           type: array
           items:
-            type: integer
-          description: cdrVersionIds that are available for VWB migration.
+            $ref: '#/components/schemas/CdrVersionForMigration'
+    CdrVersionForMigration:
+      required:
+      - cdrVersion
+      - workspaceId
+      - resourceId
+      type: object
+      properties:
+        cdrVersionId:
+          type: integer
+        workspaceId:
+          type: string
+        resourceId:
+          type: string
     AccessModuleConfig:
       required:
       - expirable

--- a/api/src/test/java/org/pmiops/workbench/user/VwbUserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/VwbUserServiceTest.java
@@ -23,6 +23,8 @@ import org.pmiops.workbench.vwb.user.ApiException;
 import org.pmiops.workbench.vwb.user.model.OrganizationMember;
 import org.pmiops.workbench.vwb.user.model.PodDescription;
 import org.pmiops.workbench.vwb.user.model.PodDescriptionList;
+import org.pmiops.workbench.vwb.user.model.PodEnvironment;
+import org.pmiops.workbench.vwb.user.model.PodEnvironmentDataGcp;
 import org.pmiops.workbench.vwb.user.model.PodRole;
 import org.pmiops.workbench.vwb.user.model.UserDescription;
 import org.pmiops.workbench.vwb.usermanager.VwbUserManagerClient;
@@ -154,7 +156,14 @@ class VwbUserServiceTest {
     stubGetUserPods(email);
 
     UUID podId = UUID.randomUUID();
-    PodDescription pod = new PodDescription().podId(podId).description("Pod for " + email);
+    PodDescription pod =
+        new PodDescription()
+            .podId(podId)
+            .description("Pod for " + email)
+            .environmentData(
+                new PodEnvironment()
+                    .environmentDataGcp(
+                        new PodEnvironmentDataGcp().billingAccountId("test-billing")));
     when(vwbUserManagerClient.listUserPods("test-org-id"))
         .thenReturn(new PodDescriptionList().results(List.of(pod)));
     when(vwbAdminQueryService.queryPodIdsByUserEmail(email)).thenReturn(Set.of());
@@ -171,7 +180,14 @@ class VwbUserServiceTest {
     stubGetUserPods(email);
 
     UUID podId = UUID.randomUUID();
-    PodDescription pod = new PodDescription().podId(podId).createdBy(email);
+    PodDescription pod =
+        new PodDescription()
+            .podId(podId)
+            .createdBy(email)
+            .environmentData(
+                new PodEnvironment()
+                    .environmentDataGcp(
+                        new PodEnvironmentDataGcp().billingAccountId("test-billing")));
     when(vwbUserManagerClient.listUserPods("test-org-id"))
         .thenReturn(new PodDescriptionList().results(List.of(pod)));
     when(vwbAdminQueryService.queryPodIdsByUserEmail(email)).thenReturn(Set.of());
@@ -189,7 +205,14 @@ class VwbUserServiceTest {
 
     UUID podId = UUID.randomUUID();
     PodDescription pod =
-        new PodDescription().podId(podId).description("Pod for someone-else").createdBy("other");
+        new PodDescription()
+            .podId(podId)
+            .description("Pod for someone-else")
+            .createdBy("other")
+            .environmentData(
+                new PodEnvironment()
+                    .environmentDataGcp(
+                        new PodEnvironmentDataGcp().billingAccountId("test-billing")));
     when(vwbUserManagerClient.listUserPods("test-org-id"))
         .thenReturn(new PodDescriptionList().results(List.of(pod)));
     when(vwbAdminQueryService.queryPodIdsByUserEmail(email)).thenReturn(Set.of(podId.toString()));

--- a/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
@@ -85,7 +85,7 @@ public class WorkspaceMigrationServiceImplTest {
   @BeforeEach
   void setup() {
     DbCdrVersion cdrVersion =
-        createDefaultCdrVersion(1).setAccessTier(new DbAccessTier().setShortName("controlled"));
+        createDefaultCdrVersion(9).setAccessTier(new DbAccessTier().setShortName("controlled"));
     dbWorkspace = new DbWorkspace();
     dbWorkspace.setWorkspaceNamespace(NAMESPACE);
     dbWorkspace.setFirecloudName(TERRA_NAME);
@@ -104,7 +104,7 @@ public class WorkspaceMigrationServiceImplTest {
     config = WorkbenchConfig.createEmptyConfig();
     config.vwb.defaultPodId = "default-pod";
     CdrVersionForMigration cdrVersionForMigration = new CdrVersionForMigration();
-    cdrVersionForMigration.cdrVersionId = 10;
+    cdrVersionForMigration.cdrVersionId = 9;
     cdrVersionForMigration.workspaceId = "ct-data-collection-wsid";
     cdrVersionForMigration.resourceId = UUID.randomUUID().toString();
     config.vwb.cdrVersionsForMigration = List.of(cdrVersionForMigration);

--- a/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.config.WorkbenchConfig;
+import org.pmiops.workbench.config.WorkbenchConfig.VwbConfig.CdrVersionForMigration;
 import org.pmiops.workbench.db.dao.UserDao;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.db.model.DbAccessTier;
@@ -102,9 +103,11 @@ public class WorkspaceMigrationServiceImplTest {
 
     config = WorkbenchConfig.createEmptyConfig();
     config.vwb.defaultPodId = "default-pod";
-    config.vwb.cdrVersionIdsForMigration = List.of(1);
-    config.vwb.dataCollectionsForMigration.controlled.workspaceId = "ct-data-collection-wsid";
-    config.vwb.dataCollectionsForMigration.controlled.resourceId = UUID.randomUUID().toString();
+    CdrVersionForMigration cdrVersionForMigration = new CdrVersionForMigration();
+    cdrVersionForMigration.cdrVersionId = 10;
+    cdrVersionForMigration.workspaceId = "ct-data-collection-wsid";
+    cdrVersionForMigration.resourceId = UUID.randomUUID().toString();
+    config.vwb.cdrVersionsForMigration = List.of(cdrVersionForMigration);
     config.server.projectId = SERVER_PROJECT;
     config.auth.serviceAccountApiUsers = List.of(SERVICE_ACCOUNT_EMAIL);
 
@@ -135,8 +138,8 @@ public class WorkspaceMigrationServiceImplTest {
         .when(
             wsmClient.cloneBQDataset(
                 vwbWorkspace.getId(),
-                config.vwb.dataCollectionsForMigration.controlled.workspaceId,
-                UUID.fromString(config.vwb.dataCollectionsForMigration.controlled.resourceId),
+                config.vwb.cdrVersionsForMigration.get(0).workspaceId,
+                UUID.fromString(config.vwb.cdrVersionsForMigration.get(0).resourceId),
                 JOB_ID))
         .thenReturn(CLONED_DATASET_RESULT);
     try {

--- a/ui/src/app/components/migration/migration-modal.tsx
+++ b/ui/src/app/components/migration/migration-modal.tsx
@@ -95,8 +95,8 @@ export const MigrationModal = ({ onClose }: Props) => {
               w.accessLevel === WorkspaceAccessLevel.OWNER &&
               serverConfigStore
                 .get()
-                .config.cdrVersionIdsForMigration.includes(
-                  +w.workspace.cdrVersionId
+                .config.cdrVersionsForMigration.some(
+                (c) => +w.workspace.cdrVersionId === c.cdrVersionId
                 )
           )
           .map((w: WorkspaceResponse) => {

--- a/ui/src/app/components/migration/migration-modal.tsx
+++ b/ui/src/app/components/migration/migration-modal.tsx
@@ -96,7 +96,7 @@ export const MigrationModal = ({ onClose }: Props) => {
               serverConfigStore
                 .get()
                 .config.cdrVersionsForMigration.some(
-                (c) => +w.workspace.cdrVersionId === c.cdrVersionId
+                  (c) => +w.workspace.cdrVersionId === c.cdrVersionId
                 )
           )
           .map((w: WorkspaceResponse) => {

--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -117,7 +117,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
   const allChecked = Object.values(checks).every(Boolean);
   const profile = profileStore.get().profile;
   const migrationTestingGroup = profile?.migrationTestingGroup ?? false;
-  const { cdrVersionIdsForMigration, enableVwbMigration } =
+  const { cdrVersionsForMigration, enableVwbMigration } =
     serverConfigStore.get().config;
   const { workspace } = props;
 
@@ -171,7 +171,9 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
         <div style={styles.cardButtonArea}>
           {enableVwbMigration &&
             migrationTestingGroup &&
-            cdrVersionIdsForMigration.includes(+workspace.cdrVersionId) && (
+            cdrVersionsForMigration.some(
+              (c) => +workspace.cdrVersionId === c.cdrVersionId
+            ) && (
               <TooltipTrigger
                 content={
                   !writePermission &&

--- a/ui/src/app/pages/workspace/migration.tsx
+++ b/ui/src/app/pages/workspace/migration.tsx
@@ -59,12 +59,12 @@ export const MigrationPage = withCurrentWorkspace()(({ workspace }: Props) => {
   }
 
   const profile = profileStore.get().profile;
-  const { cdrVersionIdsForMigration } = serverConfigStore.get().config;
+  const { cdrVersionsForMigration } = serverConfigStore.get().config;
   const migrationTestingGroup = profile?.migrationTestingGroup ?? false;
 
   if (
     !migrationTestingGroup ||
-    !cdrVersionIdsForMigration.includes(+workspace.cdrVersionId)
+    !cdrVersionsForMigration.some((c) => +workspace.cdrVersionId === c.cdrVersionId)
   ) {
     navigate(['workspaces', workspace.namespace, workspace.terraName, 'data']);
   }

--- a/ui/src/app/pages/workspace/migration.tsx
+++ b/ui/src/app/pages/workspace/migration.tsx
@@ -64,7 +64,9 @@ export const MigrationPage = withCurrentWorkspace()(({ workspace }: Props) => {
 
   if (
     !migrationTestingGroup ||
-    !cdrVersionsForMigration.some((c) => +workspace.cdrVersionId === c.cdrVersionId)
+    !cdrVersionsForMigration.some(
+      (c) => +workspace.cdrVersionId === c.cdrVersionId
+    )
   ) {
     navigate(['workspaces', workspace.namespace, workspace.terraName, 'data']);
   }

--- a/ui/src/app/pages/workspace/pd-warning-modal.tsx
+++ b/ui/src/app/pages/workspace/pd-warning-modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button } from 'app/components/buttons';
+import { Button, StyledExternalLink } from 'app/components/buttons';
 import {
   Modal,
   ModalBody,
@@ -13,6 +13,9 @@ interface Props {
   onCancel: () => void;
   onConfirm: () => void;
 }
+
+const USER_SUPPORT_OFFICE_HOURS_URL =
+  'https://support.researchallofus.org/hc/en-us/sections/6000285700372-Office-Hour-Recordings';
 
 export const PdWarningModal = ({ onCancel, onConfirm }: Props) => {
   return (
@@ -40,15 +43,16 @@ export const PdWarningModal = ({ onCancel, onConfirm }: Props) => {
         >
           Persistent disk data will not be migrated. Make sure you move this
           data to your cloud bucket for it to stay intact.{' '}
-          <span
+          <StyledExternalLink
+            href={USER_SUPPORT_OFFICE_HOURS_URL}
             style={{
-              textDecoration: 'underline',
-              cursor: 'pointer',
               color: colors.accent,
+              textDecoration: 'underline',
             }}
+            target='_blank'
           >
             Learn more
-          </span>
+          </StyledExternalLink>
         </div>
       </ModalBody>
 


### PR DESCRIPTION
- Allow CDR v7 workspaces to migrate to RW 2.0
  - Restructured the config used for migration to make pulling the correct CDR version cleaner 
- Filter user pods list to remove any where billing account is null
- Minor text updates