### PR TITLE
[no ticket][risk=no] Exempt GCS and internal VPC traffic from wondershaper rate limit

### DIFF
--- a/api/src/main/webapp/static/start_notebook_runtime.sh
+++ b/api/src/main/webapp/static/start_notebook_runtime.sh
@@ -13,3 +13,17 @@ IFACE=$(ip route show default | awk '{print $5}' | head -1)
 pushd /usr/local/share/wondershaper
 wondershaper -a "$IFACE" -u 16384 # kilobits; 16Mib/s (2MiB/s)
 popd
+
+# Exempt restricted.googleapis.com and internal VPC traffic from the upload
+# rate limit. These exemptions are safe because:
+#   - restricted.googleapis.com (199.36.153.4/30): access is scoped by the
+#     VPC Service Perimeter; cross-perimeter exfiltration is blocked at the
+#     platform level regardless of bandwidth.
+#   - Internal VPC (10.0.0.0/8): covers intra-VM and Dataproc master-to-worker
+#     communication that never leaves the VPC.
+ROOT=$(tc qdisc show dev "$IFACE" | grep -E 'htb|cbq|tbf|hfsc' | head -1 | awk '{print $3}')
+ROOT="${ROOT:-1:}"
+tc filter add dev "$IFACE" parent "$ROOT" protocol ip prio 1 \
+  u32 match ip dst 199.36.153.4/30 flowid "$ROOT" 2>/dev/null
+tc filter add dev "$IFACE" parent "$ROOT" protocol ip prio 1 \
+  u32 match ip dst 10.0.0.0/8 flowid "$ROOT" 2>/dev/null


### PR DESCRIPTION
## Summary
- Wondershaper rate-limits **all** egress to 2 MiB/s, including traffic to `restricted.googleapis.com` (GCS/BigQuery) and internal VPC (Dataproc master-to-worker communication)
- Adds `tc filter` rules to exempt `restricted.googleapis.com` (`199.36.153.4/30`) and internal VPC (`10.0.0.0/8`) from the upload rate limit
- Internet egress remains capped at ~2 MiB/s

## Why these exemptions are safe
- **restricted.googleapis.com (199.36.153.4/30)**: Access is scoped by the VPC Service Perimeter; cross-perimeter exfiltration is blocked at the platform level regardless of bandwidth. IAM, OAuth scopes, and Cloud Audit Logs remain enforced.
- **Internal VPC (10.0.0.0/8)**: Covers intra-VM and Dataproc master-to-worker communication that never leaves the VPC network boundary.

## Related
- Companion VWB PRs: [verily1#119877](https://github.com/verily-src/verily1/pull/119877), [verily1#119873](https://github.com/verily-src/verily1/pull/119873)
- Prior fix for interface detection: [#9493](https://github.com/all-of-us/workbench/pull/9493)

## Test plan
- [ ] Create a new Dataproc runtime
- [ ] Verify GCS uploads are no longer throttled (expect >> 2 MB/s)
- [ ] Verify internal VPC traffic is no longer throttled
- [ ] Verify public internet uploads remain rate-limited (~1.3 MB/s)
- [ ] Verify GCE runtimes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)