### PR TITLE
[no ticket][risk=no] Fix reporting SQL for folder_sync_transfer

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/jdbc/ReportingQueryServiceImpl.java
@@ -797,7 +797,7 @@ public class ReportingQueryServiceImpl implements ReportingQueryService {
                 + "  fst.finished,\n"
                 + "  fst.transfer_job_name,\n"
                 + "  fst.transfer_state,\n"
-                + "  fst.source_workspace_namespace,\n"
+                + "  fst.source_workspace_namespace\n"
                 + "FROM folder_sync_transfer fst\n"
                 + "  LIMIT %d\n"
                 + "  OFFSET %d",


### PR DESCRIPTION
`folder_sync_transfer` table was successfully added but SQL to populate the table due to trailing comma in the field list