### PR TITLE
[DT-1132][risk=no] Fix hidden results in workspace share autocomplete

### DIFF
--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -64,7 +64,7 @@ const styles = reactStyles({
   },
 
   open: {
-    overflow: 'hidden',
+    overflow: 'auto',
     position: 'absolute',
     backgroundColor: colors.white,
     border: '1px solid',
@@ -74,7 +74,7 @@ const styles = reactStyles({
     border: 'none',
     background: 'none',
     width: '90%',
-    marginTop: '8px',
+    marginTop: '10px',
   },
 
   spinner: {
@@ -170,6 +170,7 @@ interface State {
   workspaceFound: boolean;
   workspaceUpdateConflictError: boolean;
   loadingUserRoles: boolean;
+  loadingCollaborators: boolean;
   userRoles: UserRole[];
   userRolesToChange: UserRole[];
   searchTerm: string;
@@ -201,6 +202,7 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
         workspaceFound: this.props.workspace !== null,
         workspaceUpdateConflictError: false,
         loadingUserRoles: true,
+        loadingCollaborators: false,
         userRoles: [],
         userRolesToChange: [],
         searchTerm: '',
@@ -358,7 +360,7 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
             this.state.userRoles
           );
           this.setState({
-            autocompleteUsers: response.users.splice(0, 4),
+            autocompleteUsers: response.users,
             autocompleteLoading: false,
             dropDown: true,
           });
@@ -504,14 +506,18 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
                   ref={(node) => (this.searchingNode = node)}
                   style={styles.dropdown}
                 >
-                  <ClrIcon
-                    shape='search'
-                    style={{
-                      width: '21px',
-                      height: '21px',
-                      paddingLeft: '3px',
-                    }}
-                  />
+                  {this.state.autocompleteLoading ? (
+                    <Spinner size={18} style={{ margin: '0 0 -4px 6px' }} />
+                  ) : (
+                    <ClrIcon
+                      shape='search'
+                      style={{
+                        width: '21px',
+                        height: '21px',
+                        paddingLeft: '3px',
+                      }}
+                    />
+                  )}
                   <input
                     data-test-id='search'
                     style={styles.noBorder}
@@ -523,9 +529,6 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
                     }
                     onFocus={() => this.openDropdown()}
                   />
-                  {this.state.autocompleteLoading && (
-                    <span style={styles.spinner} />
-                  )}
                   {this.showAutocompleteNoResults && (
                     <div
                       data-test-id='drop-down'

--- a/ui/src/app/pages/workspace/workspace-share.tsx
+++ b/ui/src/app/pages/workspace/workspace-share.tsx
@@ -170,7 +170,6 @@ interface State {
   workspaceFound: boolean;
   workspaceUpdateConflictError: boolean;
   loadingUserRoles: boolean;
-  loadingCollaborators: boolean;
   userRoles: UserRole[];
   userRolesToChange: UserRole[];
   searchTerm: string;
@@ -202,7 +201,6 @@ export const WorkspaceShare = fp.flow(withUserProfile())(
         workspaceFound: this.props.workspace !== null,
         workspaceUpdateConflictError: false,
         loadingUserRoles: true,
-        loadingCollaborators: false,
         userRoles: [],
         userRolesToChange: [],
         searchTerm: '',


### PR DESCRIPTION
- Remove 4 result limit from UI, set `overflow: auto` to allow scrolling
- Add spinner when autocomplete is loading

https://github.com/user-attachments/assets/87ba5715-7891-4b79-a387-c6a6607349a5

