### PR TITLE
[risk=no][RW-17706] Change order of operations to create save before adding tiers

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/access/AccessSyncServiceImpl.java
@@ -73,8 +73,19 @@ public class AccessSyncServiceImpl implements AccessSyncService {
   @Override
   public DbUser updateUserAccessTiers(DbUser dbUser, Agent agent) {
     final List<DbAccessTier> previousAccessTiers = accessTierService.getAccessTiersForUser(dbUser);
-
     final List<DbAccessTier> newAccessTiers = getUserAccessTiersList(dbUser);
+
+    log.info(
+        String.format(
+            "Updating access tiers for user %s (id: %d). Previous tiers: %s, New tiers: %s",
+            dbUser.getUsername(),
+            dbUser.getUserId(),
+            previousAccessTiers.stream()
+                .map(DbAccessTier::getShortName)
+                .collect(java.util.stream.Collectors.joining(", ")),
+            newAccessTiers.stream()
+                .map(DbAccessTier::getShortName)
+                .collect(java.util.stream.Collectors.joining(", "))));
 
     if (!newAccessTiers.equals(previousAccessTiers)) {
       userServiceAuditor.fireUpdateAccessTiersAction(
@@ -82,6 +93,21 @@ public class AccessSyncServiceImpl implements AccessSyncService {
     }
 
     addInitialCreditsExpirationIfAppropriate(dbUser, previousAccessTiers, newAccessTiers);
+
+    // Save the user first
+    log.info("Saving user " + dbUser.getUsername() + " before updating tier memberships");
+    DbUser savedUser;
+    try {
+      savedUser = userDao.save(dbUser);
+      log.info("Successfully saved user " + savedUser.getUsername());
+    } catch (DataIntegrityViolationException e) {
+      log.warning(
+          String.format(
+              "Failed to save user %s due to DataIntegrityViolationException: %s. "
+                  + "Tier operations not performed. Exception will propagate for retry.",
+              dbUser.getUsername(), e.getMessage()));
+      throw e;
+    }
 
     // Tiers to add are those present in the new set of tiers but not in the previous set.
     // We use ListUtils.subtract() to find the difference: (new - previous) = toAdd.
@@ -92,22 +118,55 @@ public class AccessSyncServiceImpl implements AccessSyncService {
     final List<DbAccessTier> tiersToRemove =
         ListUtils.subtract(previousAccessTiers, newAccessTiers);
 
+    if (!tiersToRemove.isEmpty()) {
+      log.info(
+          String.format(
+              "Removing user %s from tiers: %s",
+              dbUser.getUsername(),
+              tiersToRemove.stream()
+                  .map(DbAccessTier::getShortName)
+                  .collect(java.util.stream.Collectors.joining(", "))));
+    }
     // remove user from all other Access Tier DB tables and the tiers' Terra Auth Domains
     tiersToRemove.forEach(tier -> accessTierService.removeUserFromTier(dbUser, tier));
 
+    if (!tiersToAdd.isEmpty()) {
+      log.info(
+          String.format(
+              "Adding user %s to tiers: %s",
+              dbUser.getUsername(),
+              tiersToAdd.stream()
+                  .map(DbAccessTier::getShortName)
+                  .collect(java.util.stream.Collectors.joining(", "))));
+    }
     // add user to each Access Tier DB table and the tiers' Terra Auth Domains
     tiersToAdd.forEach(tier -> accessTierService.addUserToTier(dbUser, tier));
 
-    // Save the user first
-    DbUser savedUser = userDao.save(dbUser);
-
     // Only after successful save, create the pod lock and push the task
     if (userHasFirstAccessToTiers(previousAccessTiers, newAccessTiers)) {
+      log.info(
+          String.format(
+              "User %s is gaining first-time tier access. Attempting to create VWB pod.",
+              savedUser.getUsername()));
       // Try to create the lock row - only push task if we successfully created it
       boolean podLockCreated = createVwbUserLockIfNeeded(savedUser);
       if (podLockCreated) {
+        log.info(
+            String.format(
+                "Successfully created VWB pod lock for user %s. Pushing pod creation task.",
+                savedUser.getUsername()));
         taskQueueService.pushVwbPodCreationTask(savedUser.getUsername());
+      } else {
+        log.info(
+            String.format(
+                "VWB pod lock already exists for user %s. Skipping pod creation task.",
+                savedUser.getUsername()));
       }
+    } else {
+      log.info(
+          String.format(
+              "User %s is not gaining first-time tier access (prev: %d tiers, new: %d tiers). Skipping pod creation.",
+              savedUser.getUsername(), previousAccessTiers.size(), newAccessTiers.size()));
     }
 
     return savedUser;

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.access;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -409,4 +410,82 @@ public class AccessSyncServiceTest {
     // Verify that the VWB pod creation task was NOT pushed since save failed
     verify(taskQueueService, times(0)).pushVwbPodCreationTask(any());
   }
+
+  @Test
+  public void testUpdateUserAccessTiers_retryAfterUserSaveFailure_createsPodTask() {
+    DbUser dbUser = createDbUser();
+    Agent agent = Agent.asUser(dbUser);
+
+    // Set up workbench config
+    stubWorkbenchConfig_enableInitialCreditsExpiration(false);
+
+    // Set up required modules for registered tier
+    for (DbAccessModuleName moduleName : getRequiredModulesForRegisteredTierAccess()) {
+      when(accessModuleService.isModuleCompliant(dbUser, moduleName)).thenReturn(true);
+    }
+
+    // Track whether addUserToTier was called (simulating the persistence side effect)
+    AtomicReference<List<DbAccessTier>> simulatedPersistedTiers = new AtomicReference<>(List.of());
+
+    // Mock getAccessTiersForUser to simulate that tiers persist after addUserToTier
+    when(accessTierService.getAccessTiersForUser(dbUser))
+        .thenAnswer(invocation -> simulatedPersistedTiers.get());
+
+    // Track when addUserToTier is called and simulate the persistence
+    doAnswer(invocation -> {
+      DbAccessTier tier = (DbAccessTier) invocation.getArguments()[1];
+      List<DbAccessTier> currentTiers = new java.util.ArrayList<>(simulatedPersistedTiers.get());
+      if (!currentTiers.contains(tier)) {
+        currentTiers.add(tier);
+        simulatedPersistedTiers.set(currentTiers);
+      }
+      return null;
+    }).when(accessTierService).addUserToTier(any(), any());
+
+    // Mock userDao.save to fail on first call, succeed on second (simulating retry)
+    when(userDao.save(dbUser))
+        .thenThrow(new DataIntegrityViolationException("Duplicate user_code_of_conduct_agreement"))
+        .thenReturn(dbUser);
+
+    // Mock VWB pod DAO
+    when(vwbUserPodDao.findByUserUserId(any())).thenReturn(null);
+    when(vwbUserPodDao.save(any())).thenAnswer(i -> i.getArguments()[0]);
+
+    // Mock audit and task queue
+    doNothing().when(userServiceAuditor).fireUpdateAccessTiersAction(any(), any(), any(), any());
+    doNothing().when(taskQueueService).pushVwbPodCreationTask(any());
+
+    // First attempt - should fail
+    try {
+      accessSyncService.updateUserAccessTiers(dbUser, agent);
+      fail("Expected DataIntegrityViolationException");
+    } catch (DataIntegrityViolationException e) {
+      // Expected exception
+    }
+
+    // WITH THE FIX: addUserToTier should NOT have been called because user save failed first
+    verify(accessTierService, times(0)).addUserToTier(any(), any());
+    verify(vwbUserPodDao, times(0)).save(any());
+    verify(taskQueueService, times(0)).pushVwbPodCreationTask(any());
+
+    // Reset mock invocation counts for clearer verification
+    Mockito.clearInvocations(accessTierService, taskQueueService, vwbUserPodDao);
+
+    // Second attempt (retry) - should succeed
+    DbUser result = accessSyncService.updateUserAccessTiers(dbUser, agent);
+
+    assertEquals(dbUser, result);
+
+    // WITH THE FIX: On retry, previousAccessTiers is still empty (no tiers were persisted in the failed attempt)
+    // So userHasFirstAccessToTiers([], [registeredTier]) returns true
+    // Pod creation task should be triggered
+
+    // Verify tier operations happen on the successful retry
+    verify(accessTierService, times(1)).addUserToTier(dbUser, registeredTier);
+
+    // Verify pod creation happens on the successful retry
+    verify(vwbUserPodDao, times(1)).save(any());
+    verify(taskQueueService, times(1)).pushVwbPodCreationTask(dbUser.getUsername());
+  }
+
 }

--- a/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/access/AccessSyncServiceTest.java
@@ -432,15 +432,19 @@ public class AccessSyncServiceTest {
         .thenAnswer(invocation -> simulatedPersistedTiers.get());
 
     // Track when addUserToTier is called and simulate the persistence
-    doAnswer(invocation -> {
-      DbAccessTier tier = (DbAccessTier) invocation.getArguments()[1];
-      List<DbAccessTier> currentTiers = new java.util.ArrayList<>(simulatedPersistedTiers.get());
-      if (!currentTiers.contains(tier)) {
-        currentTiers.add(tier);
-        simulatedPersistedTiers.set(currentTiers);
-      }
-      return null;
-    }).when(accessTierService).addUserToTier(any(), any());
+    doAnswer(
+            invocation -> {
+              DbAccessTier tier = (DbAccessTier) invocation.getArguments()[1];
+              List<DbAccessTier> currentTiers =
+                  new java.util.ArrayList<>(simulatedPersistedTiers.get());
+              if (!currentTiers.contains(tier)) {
+                currentTiers.add(tier);
+                simulatedPersistedTiers.set(currentTiers);
+              }
+              return null;
+            })
+        .when(accessTierService)
+        .addUserToTier(any(), any());
 
     // Mock userDao.save to fail on first call, succeed on second (simulating retry)
     when(userDao.save(dbUser))
@@ -476,7 +480,8 @@ public class AccessSyncServiceTest {
 
     assertEquals(dbUser, result);
 
-    // WITH THE FIX: On retry, previousAccessTiers is still empty (no tiers were persisted in the failed attempt)
+    // WITH THE FIX: On retry, previousAccessTiers is still empty (no tiers were persisted in the
+    // failed attempt)
     // So userHasFirstAccessToTiers([], [registeredTier]) returns true
     // Pod creation task should be triggered
 
@@ -487,5 +492,4 @@ public class AccessSyncServiceTest {
     verify(vwbUserPodDao, times(1)).save(any());
     verify(taskQueueService, times(1)).pushVwbPodCreationTask(dbUser.getUsername());
   }
-
 }


### PR DESCRIPTION
<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
