### PR TITLE
[DT-1150][risk=no] Disable workspace creation for migration group

### DIFF
--- a/ui/src/app/pages/data/data-component.tsx
+++ b/ui/src/app/pages/data/data-component.tsx
@@ -21,7 +21,7 @@ import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { withCurrentWorkspace } from 'app/utils';
 import { AnalyticsTracker } from 'app/utils/analytics';
 import { useNavigation } from 'app/utils/navigation';
-import { profileStore, serverConfigStore } from 'app/utils/stores';
+import { serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 import cohortImg from 'assets/images/cohort-diagram.svg';
 import dataSetImg from 'assets/images/dataset-diagram.svg';
@@ -115,8 +115,6 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
   const [resourceList, setResourceList] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const allChecked = Object.values(checks).every(Boolean);
-  const profile = profileStore.get().profile;
-  const migrationTestingGroup = profile?.migrationTestingGroup ?? false;
   const {
     cdrVersionsForMigration,
     enableVwbMigration,
@@ -173,7 +171,7 @@ export const DataComponent = withCurrentWorkspace()((props: Props) => {
     <React.Fragment>
       <div style={{ paddingLeft: '2.25rem' }}>
         <div style={styles.cardButtonArea}>
-          {(enableVwbMigration || migrationTestingGroup) &&
+          {enableVwbMigration &&
             cdrVersionsForMigration.some(
               (c) => +workspace.cdrVersionId === c.cdrVersionId
             ) && (

--- a/ui/src/app/pages/homepage/homepage.tsx
+++ b/ui/src/app/pages/homepage/homepage.tsx
@@ -87,7 +87,13 @@ const WelcomeHeader = () => {
   );
 };
 
-const Workspaces = ({ onChange }: { onChange: () => void }) => {
+const Workspaces = ({
+  onChange,
+  disableCreation,
+}: {
+  onChange: () => void;
+  disableCreation: boolean;
+}) => {
   const [navigate] = useNavigation();
 
   return (
@@ -109,7 +115,9 @@ const Workspaces = ({ onChange }: { onChange: () => void }) => {
                   height: '2.5rem',
                   marginLeft: '1.5rem',
                   padding: '0 1rem',
+                  opacity: disableCreation ? 0.4 : 1,
                 }}
+                disabled={disableCreation}
                 onClick={() => {
                   AnalyticsTracker.Workspaces.OpenCreatePage();
                   navigate(['workspaces', 'build']);
@@ -331,7 +339,7 @@ export const Homepage = fp.flow(
         <React.Fragment>
           <FlexColumn style={styles.pageWrapper}>
             {serverConfigStore.get().config.enableVWBHomepageBanner ? (
-              enableVwbMigration || migrationTestingGroup ? (
+              enableVwbMigration ? (
                 <VwbMigrationBanner />
               ) : (
                 <VwbBanner />
@@ -342,7 +350,10 @@ export const Homepage = fp.flow(
             <div style={styles.fadeBox}>
               {/* The elements inside this fadeBox will be changed as part of ongoing homepage redesign work */}
               <FlexColumn style={{ justifyContent: 'flex-start' }}>
-                <Workspaces onChange={() => this.fetchWorkspaces()} />
+                <Workspaces
+                  onChange={() => this.fetchWorkspaces()}
+                  disableCreation={migrationTestingGroup}
+                />
                 {userWorkspacesResponse &&
                   (this.userHasWorkspaces() ? (
                     <RecentResources

--- a/ui/src/app/pages/workspace/migration-folder-sync.tsx
+++ b/ui/src/app/pages/workspace/migration-folder-sync.tsx
@@ -18,11 +18,7 @@ import { withCurrentWorkspace } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { displayDate } from 'app/utils/dates';
 import { useNavigation } from 'app/utils/navigation';
-import {
-  cdrVersionStore,
-  profileStore,
-  serverConfigStore,
-} from 'app/utils/stores';
+import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { PdWarningModal } from './pd-warning-modal';
@@ -67,13 +63,11 @@ export const MigrationFolderSync = withCurrentWorkspace()(
       return null;
     }
 
-    const profile = profileStore.get().profile;
     const { cdrVersionsForMigration, enableVwbMigration } =
       serverConfigStore.get().config;
-    const migrationTestingGroup = profile?.migrationTestingGroup ?? false;
 
     if (
-      (!enableVwbMigration && !migrationTestingGroup) ||
+      !enableVwbMigration ||
       !cdrVersionsForMigration.some(
         (c) => +workspace.cdrVersionId === c.cdrVersionId
       ) ||

--- a/ui/src/app/pages/workspace/migration.tsx
+++ b/ui/src/app/pages/workspace/migration.tsx
@@ -19,11 +19,7 @@ import { withCurrentWorkspace } from 'app/utils';
 import { findCdrVersion } from 'app/utils/cdr-versions';
 import { displayDate } from 'app/utils/dates';
 import { currentWorkspaceStore, useNavigation } from 'app/utils/navigation';
-import {
-  cdrVersionStore,
-  profileStore,
-  serverConfigStore,
-} from 'app/utils/stores';
+import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
 import { WorkspaceData } from 'app/utils/workspace-data';
 
 import { PdWarningModal } from './pd-warning-modal';
@@ -59,13 +55,11 @@ export const Migration = withCurrentWorkspace()(({ workspace }: Props) => {
     return null;
   }
 
-  const profile = profileStore.get().profile;
   const { cdrVersionsForMigration, enableVwbMigration } =
     serverConfigStore.get().config;
-  const migrationTestingGroup = profile?.migrationTestingGroup ?? false;
 
   if (
-    (!enableVwbMigration && !migrationTestingGroup) ||
+    !enableVwbMigration ||
     !cdrVersionsForMigration.some(
       (c) => +workspace.cdrVersionId === c.cdrVersionId
     ) ||

--- a/ui/src/app/pages/workspace/new-workspace-button.tsx
+++ b/ui/src/app/pages/workspace/new-workspace-button.tsx
@@ -15,16 +15,20 @@ const styles = reactStyles({
   },
 });
 
-export const NewWorkspaceButton = () => {
+export const NewWorkspaceButton = ({ disabled }: { disabled: boolean }) => {
   const [navigate] = useNavigation();
 
   return (
     <CardButton
+      disabled={disabled}
       onClick={() => {
         AnalyticsTracker.Workspaces.OpenCreatePage();
         navigate(['workspaces', 'build']);
       }}
-      style={styles.addCard}
+      style={{
+        ...styles.addCard,
+        opacity: disabled ? 0.4 : 1,
+      }}
     >
       Create Legacy Workspace
       <ClrIcon shape='plus-circle' style={{ height: '32px', width: '32px' }} />

--- a/ui/src/app/pages/workspace/workspace-edit.tsx
+++ b/ui/src/app/pages/workspace/workspace-edit.tsx
@@ -604,6 +604,12 @@ export const WorkspaceEdit = fp.flow(
     }
 
     async componentDidMount() {
+      if (
+        this.props.profileState.profile.migrationTestingGroup &&
+        this.isMode(WorkspaceEditMode.Create)
+      ) {
+        this.props.navigate([]);
+      }
       this.props.hideSpinner();
       await this.initialBillingAccountLoad();
     }

--- a/ui/src/app/pages/workspace/workspace-list.tsx
+++ b/ui/src/app/pages/workspace/workspace-list.tsx
@@ -127,7 +127,6 @@ export const WorkspaceList = fp.flow(withUserProfile())(
 
       const enableVwbMigration =
         serverConfigStore.get().config.enableVwbMigration;
-      const migrationTestingGroup = profile?.migrationTestingGroup;
 
       const filters = [
         { label: 'Owner', value: ['OWNER'] },
@@ -187,7 +186,7 @@ export const WorkspaceList = fp.flow(withUserProfile())(
                   gap: '12px',
                 }}
               >
-                {(enableVwbMigration || migrationTestingGroup) && (
+                {enableVwbMigration && (
                   <FlexRow style={{ alignItems: 'center', gap: '6px' }}>
                     <CommonToggle
                       name='show-migrated'
@@ -276,7 +275,9 @@ export const WorkspaceList = fp.flow(withUserProfile())(
                           </div>
                         </FlexRow>
                       </div>
-                      <NewWorkspaceButton />
+                      <NewWorkspaceButton
+                        disabled={profile.migrationTestingGroup}
+                      />
                       {filteredList.map((wp) => (
                         <WorkspaceCard
                           key={wp.workspace.namespace + '-l'}
@@ -295,12 +296,14 @@ export const WorkspaceList = fp.flow(withUserProfile())(
                     </>
                   ) : (
                     <>
-                      {(enableVwbMigration || migrationTestingGroup) && (
+                      {enableVwbMigration && (
                         <div style={{ width: '100%', marginBottom: '12px' }}>
                           <SmallHeader>Non-migrated Workspaces</SmallHeader>
                         </div>
                       )}
-                      <NewWorkspaceButton />
+                      <NewWorkspaceButton
+                        disabled={profile.migrationTestingGroup}
+                      />
                       {nonMigratedWorkspaces.map((wp) => (
                         <WorkspaceCard
                           key={wp.workspace.namespace}


### PR DESCRIPTION
- Repurpose the `migrationTestingGroup` profile property to restrict workspace creation
- Currently prevents group members from creating a workspace only for testing.
  - Will change to only allow group members to create after testing 