### PR TITLE
[DT-1164][risk=no] Add endpoint and cron job for archive

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/OfflineWorkspaceController.java
@@ -6,6 +6,7 @@ import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
+import org.pmiops.workbench.workspaces.migration.WorkspaceMigrationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,21 +18,34 @@ public class OfflineWorkspaceController implements OfflineWorkspaceApiDelegate {
   private final TaskQueueService taskQueueService;
   private final WorkspaceService workspaceService;
   private final WorkspaceUserCacheService workspaceUserCacheService;
+  private final WorkspaceMigrationService workspaceMigrationService;
 
   @Autowired
   public OfflineWorkspaceController(
       TaskQueueService taskQueueService,
       WorkspaceService workspaceService,
-      WorkspaceUserCacheService workspaceUserCacheService) {
+      WorkspaceUserCacheService workspaceUserCacheService,
+      WorkspaceMigrationService workspaceMigrationService) {
     this.taskQueueService = taskQueueService;
     this.workspaceService = workspaceService;
     this.workspaceUserCacheService = workspaceUserCacheService;
+    this.workspaceMigrationService = workspaceMigrationService;
   }
 
   @Override
   public ResponseEntity<Void> cleanupOrphanedWorkspaces() {
     List<String> orphanedNamespaces = workspaceService.getOrphanedWorkspaceNamespacesAsService();
     taskQueueService.groupAndPushCleanupOrphanedWorkspacesTasks(orphanedNamespaces);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> archiveNextLegacyWorkspace() {
+    WorkspaceDao.WorkspaceArchiveView workspaceArchiveView =
+        workspaceMigrationService.getNextWorkspaceToArchive();
+    workspaceMigrationService.startWorkspaceArchive(
+        workspaceArchiveView.getWorkspaceNamespace(), workspaceArchiveView.getFirecloudName());
 
     return ResponseEntity.noContent().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -180,4 +180,34 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
           + "where w.activeStatus = 0 "
           + "and (wuc.workspaceId is null or w.lastModifiedTime > wuc.lastUpdated)")
   List<WorkspaceUserCacheView> findAllActiveWorkspacesNeedingCacheUpdate();
+
+  interface WorkspaceArchiveView {
+
+    String getWorkspaceNamespace();
+
+    String getFirecloudName();
+  }
+
+  @Query(
+      "SELECT w.workspaceNamespace as workspaceNamespace, w.firecloudName as firecloudName "
+          + "from DbWorkspace w "
+          + "join DbVerifiedInstitutionalAffiliation via on w.creator.userId = via.user.userId "
+          + "where w.migratedVwbWorkspaceId is null "
+          + "and w.activeStatus = 0 "
+          + "and via.verifiedInstitutionalAffiliationId != 1 "
+          + "and w.workspaceId not in (SELECT legacyWorkspaceId from DbWorkspaceBucketArchive )"
+          + "order by w.lastModifiedTime desc limit 1")
+  WorkspaceArchiveView findNextWorkspaceToArchive();
+
+  @Query(
+      "SELECT w.workspaceNamespace as workspaceNamespace, w.firecloudName as firecloudName "
+          + "from DbWorkspace w "
+          + "join DbVerifiedInstitutionalAffiliation via on w.creator.userId = via.user.userId "
+          + "where w.migratedVwbWorkspaceId is null "
+          + "and w.activeStatus = 0 "
+          + "and w.cdrVersion.cdrVersionId < 9 "
+          + "and via.verifiedInstitutionalAffiliationId != 1 "
+          + "and w.workspaceId not in (SELECT legacyWorkspaceId from DbWorkspaceBucketArchive )"
+          + "order by w.lastModifiedTime asc limit 1")
+  WorkspaceArchiveView findNextLowRiskWorkspaceToArchive();
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
@@ -135,11 +135,38 @@ public class WsmClient {
                   .organizationId(workbenchConfigProvider.get().vwb.organizationId)
                   .jobControl(new JobControl().id(UUID.randomUUID().toString()));
 
-          workspaceServiceApi.get().createWorkspaceV2(createWorkspaceRequest);
+          try {
+            CreateWorkspaceV2Result createWorkspaceV2Result =
+                workspaceServiceApi.get().createWorkspaceV2(createWorkspaceRequest);
+            if (createWorkspaceV2Result.getErrorReport() != null) {
+              logger.error(
+                  targetWorkspace.getNamespace()
+                      + ": Create workspace response with error report: "
+                      + createWorkspaceV2Result.getErrorReport());
+              throw new WorkbenchException(
+                  targetWorkspace.getNamespace() + ": WSM workspace creation failed");
+            }
+          } catch (ApiException e) {
+            logger.error(
+                targetWorkspace.getNamespace()
+                    + ": Create workspace failed, exception from WSM: "
+                    + e.getResponseBody());
+            throw new WorkbenchException(e);
+          }
 
           try {
             waitForWorkspaceCreation(workspaceId.toString()); // ← reuse existing poller!
-          } catch (InterruptedException | ApiException e) {
+          } catch (InterruptedException e) {
+            logger.error(
+                targetWorkspace.getNamespace()
+                    + ": Interrupted waiting for workspace creation, exception from WSM: "
+                    + e.getMessage());
+            throw new WorkbenchException(e);
+          } catch (ApiException e) {
+            logger.error(
+                targetWorkspace.getNamespace()
+                    + ": Error waiting for workspace creation, exception from WSM: "
+                    + e.getResponseBody());
             throw new WorkbenchException(e);
           }
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
@@ -1,6 +1,7 @@
 package org.pmiops.workbench.workspaces.migration;
 
 import java.util.List;
+import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.model.MigrationBucketContentsResponse;
 import org.pmiops.workbench.model.PreprodWorkspace;
 
@@ -26,6 +27,8 @@ public interface WorkspaceMigrationService {
       String researchPurpose,
       String bucketName,
       String billingPod);
+
+  WorkspaceDao.WorkspaceArchiveView getNextWorkspaceToArchive();
 
   void startWorkspaceArchive(String namespace, String terraName);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -70,9 +70,11 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   private final Provider<DbUser> userProvider;
   private final Clock clock;
   private final WorkspaceBucketArchiveDao workspaceBucketArchiveDao;
-  private static final String CONTROLLED_TIER_ARCHIVE_BUCKET = "all-of-us-archive-ct-bucket";
+  private static final String CONTROLLED_TIER_ARCHIVE_BUCKET =
+      "all-of-us-archive-ct-bucket-wb-blazing-lime-5817";
 
-  private static final String REGISTERED_TIER_ARCHIVE_BUCKET = "all-of-us-archive-rt-bucket";
+  private static final String REGISTERED_TIER_ARCHIVE_BUCKET =
+      "all-of-us-archive-rt-bucket-wb-potent-lentil-2807";
 
   @Autowired
   public WorkspaceMigrationServiceImpl(
@@ -160,6 +162,8 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
 
             vwbWorkspace = wsmClient.createWorkspaceAsService(workspace, resolvedPodId);
           } catch (Exception e) {
+            logger.log(
+                Level.INFO, namespace + ": Workspace creation failed message: " + e.getMessage());
             dbWorkspace.setMigrationState(MigrationState.NOT_STARTED.name());
             dbWorkspace.setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()));
             workspaceDao.save(dbWorkspace);
@@ -657,6 +661,11 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   }
 
   @Override
+  public WorkspaceDao.WorkspaceArchiveView getNextWorkspaceToArchive() {
+    return workspaceDao.findNextLowRiskWorkspaceToArchive();
+  }
+
+  @Override
   public void startWorkspaceArchive(String namespace, String terraName) {
 
     DbWorkspace dbWorkspace = workspaceDao.getRequired(namespace, terraName);
@@ -825,8 +834,6 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
         archive.setStatus(WorkspaceArchiveStatus.FAILED.toString());
 
         workspaceBucketArchiveDao.save(archive);
-
-        storageTransferClient.deleteTransferJob(projectId, jobName);
 
         return;
 

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -2688,6 +2688,18 @@ paths:
         204:
           description: No content.
           content: {}
+  /v1/cron/archiveNextLegacyWorkspace:
+    get:
+      tags:
+      - offlineWorkspace
+      - cron
+      description: Will transfer all files for a legacy workspace to an archive bucket in RW 2.0
+      operationId: archiveNextLegacyWorkspace
+      security: []
+      responses:
+        204:
+          description: No content.
+          content: {}
   /v1/cron/deleteTestUserWorkspacesOrphanedInRawls:
     get:
       tags:

--- a/api/src/main/webapp/WEB-INF/cron_base.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_base.yaml
@@ -103,3 +103,11 @@ cron:
   schedule: every day 21:30
   timezone: America/Chicago
   target: api
+- description: Archives next legacy workspace to RW 2.0 archive bucket
+  url: /v1/cron/archiveNextLegacyWorkspace
+  schedule: every day 20:15
+  timezone: America/Chicago
+  target: api
+  retry_parameters:
+    job_retry_limit: 3
+    min_backoff_seconds: 5

--- a/api/src/main/webapp/WEB-INF/cron_preprod.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_preprod.yaml
@@ -1,0 +1,3 @@
+cron:
+- url: /v1/cron/archiveNextLegacyWorkspace
+  aou_skip_reason: Only run in prod

--- a/api/src/main/webapp/WEB-INF/cron_stable.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_stable.yaml
@@ -1,0 +1,3 @@
+cron:
+- url: /v1/cron/archiveNextLegacyWorkspace
+  aou_skip_reason: Only run in prod

--- a/api/src/main/webapp/WEB-INF/cron_staging.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_staging.yaml
@@ -1,0 +1,3 @@
+cron:
+- url: /v1/cron/archiveNextLegacyWorkspace
+  aou_skip_reason: Only run in prod

--- a/api/src/main/webapp/WEB-INF/cron_test.yaml
+++ b/api/src/main/webapp/WEB-INF/cron_test.yaml
@@ -3,3 +3,5 @@ cron:
   schedule: every 24 hours
 - url: /v1/cron/checkInitialCreditsUsage
   schedule: every 24 hours
+- url: /v1/cron/archiveNextLegacyWorkspace
+  aou_skip_reason: Only run in prod

--- a/api/src/test/java/org/pmiops/workbench/api/OfflineWorkspaceControllerTest.java
+++ b/api/src/test/java/org/pmiops/workbench/api/OfflineWorkspaceControllerTest.java
@@ -14,6 +14,7 @@ import org.pmiops.workbench.cloudtasks.TaskQueueService;
 import org.pmiops.workbench.db.dao.WorkspaceDao;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.pmiops.workbench.workspaces.WorkspaceUserCacheService;
+import org.pmiops.workbench.workspaces.migration.WorkspaceMigrationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -21,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 public class OfflineWorkspaceControllerTest {
 
   @Mock private WorkspaceService workspaceService;
+  @Mock private WorkspaceMigrationService workspaceMigrationService;
   @Mock private WorkspaceUserCacheService mockWorkspaceUserCacheService;
   @Mock private TaskQueueService mockTaskQueueService;
 
@@ -33,7 +35,10 @@ public class OfflineWorkspaceControllerTest {
   public void setUp() {
     offlineWorkspaceController =
         new OfflineWorkspaceController(
-            mockTaskQueueService, workspaceService, mockWorkspaceUserCacheService);
+            mockTaskQueueService,
+            workspaceService,
+            mockWorkspaceUserCacheService,
+            workspaceMigrationService);
   }
 
   @Test

--- a/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
@@ -297,7 +297,7 @@ public class WorkspaceMigrationServiceImplTest {
     verify(storageTransferClient)
         .createTransferJob(
             eq(SOURCE_BUCKET),
-            eq("all-of-us-archive-ct-bucket"),
+            eq("all-of-us-archive-ct-bucket-wb-blazing-lime-5817"),
             eq(NAMESPACE + "/" + dbWorkspace.getWorkspaceId() + "/"),
             eq("archive-" + NAMESPACE),
             eq(SERVER_PROJECT),
@@ -398,9 +398,6 @@ public class WorkspaceMigrationServiceImplTest {
     assertThat(archive.getStatus()).isEqualTo(WorkspaceArchiveStatus.FAILED.toString());
 
     verify(workspaceBucketArchiveDao).save(archive);
-
-    verify(storageTransferClient)
-        .deleteTransferJob(SERVER_PROJECT, "transferJobs/migration-archive-" + NAMESPACE);
   }
 
   private void setupRecoveryStubs() {


### PR DESCRIPTION
- Add `archiveNextLegacyWorkspace` endpoint for archive cron job
- Cron job set to run just once a day, will run manually from GCP for initial testing
- Added two dao methods to find the next workspace to archive, currently using `findNextLowRiskWorkspaceToArchive` for testing
- Add logging around 2.0 workspace creation to get better messaging for failures