### PR TITLE
[no ticket][risk=no] Encode strings for workspace migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -766,19 +766,8 @@ jobs:
                       {
                         "type": "mention",
                         "attrs": {
-                          "id": "557058:706ddbed-1979-4f5b-845e-29c4a92b3074",
-                          "text": "Asmita Gauchan"
-                        }
-                      },
-                      {
-                        "text": " or ",
-                        "type": "text"
-                      },
-                      {
-                        "type": "mention",
-                        "attrs": {
-                          "id": "61795b54062f4c0069b69057",
-                          "text": "Moira Dillon"
+                          "id": "557058:95ba8005-a9cf-45cc-bd2c-82cf43169401",
+                          "text": "Keri Wolfe"
                         }
                       },
                       {

--- a/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/WorkbenchStringUtils.java
@@ -1,7 +1,9 @@
 package org.pmiops.workbench.utils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,5 +80,15 @@ public class WorkbenchStringUtils {
     }
 
     return outLines;
+  }
+
+  private static final String BASE64_PREFIX = "BASE64\u001F";
+
+  public static String encodeUserInput(String input) {
+    if (input == null || input.isEmpty()) {
+      return input;
+    }
+    return BASE64_PREFIX
+        + Base64.getEncoder().encodeToString(input.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/admin/VwbAdminQueryServiceImpl.java
@@ -113,7 +113,7 @@ public class VwbAdminQueryServiceImpl implements VwbAdminQueryService {
       "SELECT u.pod_id \n"
           + "FROM %s u \n"
           + "JOIN %s p ON u.pod_id = p.pod_id \n"
-          + "WHERE u.user_email=@USER_EMAIL \n"
+          + "WHERE LOWER(u.user_email)=LOWER(@USER_EMAIL) \n"
           + "AND p.billing_account_id IS NOT NULL \n"
           + "AND p.billing_account_id != '' ";
 

--- a/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
@@ -12,6 +12,7 @@ import org.pmiops.workbench.exceptions.WorkbenchException;
 import org.pmiops.workbench.model.PreprodWorkspace;
 import org.pmiops.workbench.model.ResearchPurpose;
 import org.pmiops.workbench.model.Workspace;
+import org.pmiops.workbench.utils.WorkbenchStringUtils;
 import org.pmiops.workbench.wsmanager.ApiException;
 import org.pmiops.workbench.wsmanager.api.ControlledGcpResourceApi;
 import org.pmiops.workbench.wsmanager.api.WorkspaceApi;
@@ -129,8 +130,12 @@ public class WsmClient {
                   .displayName(targetWorkspace.getDisplayName())
                   .properties(
                       stringMapToProperties(
-                          Map.of("terra-workspace-short-description", shortDescription)))
-                  .description(formatWorkspaceDescription(targetWorkspace))
+                          Map.of(
+                              "terra-workspace-short-description",
+                              WorkbenchStringUtils.encodeUserInput(shortDescription))))
+                  .description(
+                      WorkbenchStringUtils.encodeUserInput(
+                          formatWorkspaceDescription(targetWorkspace)))
                   .cloudResourceGroupId(podId)
                   .organizationId(workbenchConfigProvider.get().vwb.organizationId)
                   .jobControl(new JobControl().id(UUID.randomUUID().toString()));
@@ -154,7 +159,9 @@ public class WsmClient {
                     + ": Create workspace failed, exception from WSM: "
                     + e.getResponseBody());
             throw new WorkbenchException(
-                targetWorkspace.getNamespace() + ": Failed WSM workspace creation exception: " + e);
+                targetWorkspace.getNamespace()
+                    + ": Failed WSM workspace creation exception: "
+                    + e.getResponseBody());
           }
 
           try {
@@ -167,7 +174,7 @@ public class WsmClient {
             throw new WorkbenchException(
                 targetWorkspace.getNamespace()
                     + ": Interrupted waiting for workspace creation, exception from WSM: "
-                    + e);
+                    + e.getMessage());
           } catch (ApiException e) {
             logger.error(
                 targetWorkspace.getNamespace()
@@ -176,7 +183,7 @@ public class WsmClient {
             throw new WorkbenchException(
                 targetWorkspace.getNamespace()
                     + ": Error waiting for workspace creation, exception from WSM: "
-                    + e);
+                    + e.getResponseBody());
           }
 
           return workspaceServiceApi.get().getWorkspace(workspaceId.toString(), null);

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -29,6 +29,7 @@ import org.pmiops.workbench.rawls.model.RawlsWorkspaceACL;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceAccessEntry;
 import org.pmiops.workbench.rawls.model.RawlsWorkspaceDetails;
 import org.pmiops.workbench.user.VwbUserService;
+import org.pmiops.workbench.utils.WorkbenchStringUtils;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
 import org.pmiops.workbench.vwb.user.api.PodApi;
 import org.pmiops.workbench.vwb.user.model.OrganizationMember;
@@ -265,7 +266,9 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
       List<Property> properties =
           List.of(
               new Property().key("terra-default-location").value("us-central1"),
-              new Property().key("terra-required-data-use-metadata").value(researchPurpose),
+              new Property()
+                  .key("terra-required-data-use-metadata")
+                  .value(WorkbenchStringUtils.encodeUserInput(researchPurpose)),
               new Property().key("terra-workspace-short-description").value(""));
       wsmClient.updateWorkspaceProperties(properties, workspaceId.toString());
       logger.log(Level.INFO, namespace + ": Workspace created: " + vwbWorkspace);


### PR DESCRIPTION
- Encode all user-provide text before creating a 2.0 workspace
- Switch business approver for deploys to Keri 
- Make user pod query case insensitive