### PR TITLE
Propagate admin workspace lock/unlock to WSM for VWB workspaces

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/wsm/WsmClient.java
@@ -290,6 +290,37 @@ public class WsmClient {
   }
 
   /**
+   * Locks access to a workspace as a service account. The {@code workspaceId} may be either the WSM
+   * workspace UUID or the user-facing id (namespace).
+   *
+   * @param workspaceId UUID or user-facing id of the workspace
+   * @param reason reason the workspace is being locked
+   */
+  public void lockWorkspaceAsService(String workspaceId, String reason) {
+    wsmRetryHandler.run(
+        context -> {
+          workspaceServiceApi
+              .get()
+              .lockWorkspace(new LockWorkspaceRequest().reason(reason), workspaceId);
+          return null;
+        });
+  }
+
+  /**
+   * Unlocks access to a workspace as a service account. The {@code workspaceId} may be either the
+   * WSM workspace UUID or the user-facing id (namespace).
+   *
+   * @param workspaceId UUID or user-facing id of the workspace
+   */
+  public void unlockWorkspaceAsService(String workspaceId) {
+    wsmRetryHandler.run(
+        context -> {
+          workspaceServiceApi.get().unlockWorkspace(workspaceId);
+          return null;
+        });
+  }
+
+  /**
    * Waits for the workspace creation to complete.
    *
    * @param workspaceId ID of the workspace

--- a/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceImpl.java
@@ -63,6 +63,7 @@ import org.pmiops.workbench.utils.mappers.FeaturedWorkspaceMapper;
 import org.pmiops.workbench.utils.mappers.LeonardoMapper;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapper;
+import org.pmiops.workbench.vwb.wsm.WsmClient;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,6 +96,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   private final WorkspaceMapper workspaceMapper;
   private final WorkspaceService workspaceService;
   private final WorkspaceAuthService workspaceAuthService;
+  private final WsmClient wsmClient;
 
   @Autowired
   public WorkspaceAdminServiceImpl(
@@ -119,7 +121,8 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       WorkspaceDao workspaceDao,
       WorkspaceMapper workspaceMapper,
       WorkspaceService workspaceService,
-      WorkspaceAuthService workspaceAuthService) {
+      WorkspaceAuthService workspaceAuthService,
+      WsmClient wsmClient) {
     this.actionAuditQueryService = actionAuditQueryService;
     this.adminAuditor = adminAuditor;
     this.cloudMonitoringService = cloudMonitoringService;
@@ -142,6 +145,7 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
     this.workspaceMapper = workspaceMapper;
     this.workspaceService = workspaceService;
     this.workspaceAuthService = workspaceAuthService;
+    this.wsmClient = wsmClient;
   }
 
   @Override
@@ -366,9 +370,18 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
       String workspaceNamespace, AdminLockingRequest adminLockingRequest) {
     log.info(String.format("called setAdminLockedState on wsns %s", workspaceNamespace));
 
-    DbWorkspace dbWorkspace =
+    DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
+
+    // For VWB workspaces, access control lives in the Workspace Manager, so propagate the lock
+    // there. Do this before updating local state so a WSM failure aborts before we mark it locked.
+    // The workspace namespace is the WSM user-facing id.
+    if (dbWorkspace.isVwbWorkspace()) {
+      wsmClient.lockWorkspaceAsService(workspaceNamespace, adminLockingRequest.getRequestReason());
+    }
+
+    dbWorkspace =
         workspaceDao.save(
-            getWorkspaceByNamespaceOrThrow(workspaceNamespace)
+            dbWorkspace
                 .setAdminLocked(true)
                 .setAdminLockedReason(adminLockingRequest.getRequestReason()));
     adminAuditor.fireLockWorkspaceAction(dbWorkspace.getWorkspaceId(), adminLockingRequest);
@@ -387,8 +400,16 @@ public class WorkspaceAdminServiceImpl implements WorkspaceAdminService {
   public void setAdminUnlockedState(String workspaceNamespace) {
     log.info(String.format("called setAdminUnlockedState on wsns %s", workspaceNamespace));
 
-    DbWorkspace dbWorkspace =
-        workspaceDao.save(getWorkspaceByNamespaceOrThrow(workspaceNamespace).setAdminLocked(false));
+    DbWorkspace dbWorkspace = getWorkspaceByNamespaceOrThrow(workspaceNamespace);
+
+    // For VWB workspaces, access control lives in the Workspace Manager, so propagate the unlock
+    // there. Do this before updating local state so a WSM failure aborts before we mark it unlocked.
+    // The workspace namespace is the WSM user-facing id.
+    if (dbWorkspace.isVwbWorkspace()) {
+      wsmClient.unlockWorkspaceAsService(workspaceNamespace);
+    }
+
+    dbWorkspace = workspaceDao.save(dbWorkspace.setAdminLocked(false));
     adminAuditor.fireUnlockWorkspaceAction(dbWorkspace.getWorkspaceId());
   }
 

--- a/api/src/main/resources/ws-manager.yaml
+++ b/api/src/main/resources/ws-manager.yaml
@@ -4161,6 +4161,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemVersion'
+  /api/workspaces/v2/{workspaceId}/lock:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Locks access to a workspace.
+      operationId: lockWorkspace
+      tags:
+        - Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LockWorkspaceRequest'
+      responses:
+        '204':
+          description: Workspace locked successfully
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/workspaces/v2/{workspaceId}/unlock:
+    parameters:
+      - $ref: '#/components/parameters/WorkspaceId'
+    post:
+      summary: Unlocks access to a workspace.
+      operationId: unlockWorkspace
+      tags:
+        - Workspace
+      responses:
+        '204':
+          description: Workspace unlocked successfully
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   parameters:
     ApplicationId:
@@ -4758,6 +4802,15 @@ components:
           schema:
             $ref: '#/components/schemas/GcpGcsBucketResource'
   schemas:
+    LockWorkspaceRequest:
+      type: object
+      required:
+        - reason
+      description: Request body for locking a workspace.
+      properties:
+        reason:
+          description: Reason why the workspace is being locked.
+          type: string
     AccessOnDemandOperation:
       type: string
       description: Enum of requested AoD operations

--- a/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaceadmin/WorkspaceAdminServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.pmiops.workbench.utils.TestMockFactory.DEFAULT_GOOGLE_PROJECT;
 import static org.pmiops.workbench.utils.TestMockFactory.createDefaultCdrVersion;
@@ -89,6 +90,7 @@ import org.pmiops.workbench.utils.mappers.FirecloudMapper;
 import org.pmiops.workbench.utils.mappers.LeonardoMapperImpl;
 import org.pmiops.workbench.utils.mappers.UserMapper;
 import org.pmiops.workbench.utils.mappers.WorkspaceMapperImpl;
+import org.pmiops.workbench.vwb.wsm.WsmClient;
 import org.pmiops.workbench.workspaces.WorkspaceAuthService;
 import org.pmiops.workbench.workspaces.WorkspaceService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -140,6 +142,7 @@ public class WorkspaceAdminServiceTest {
   @MockitoBean private MailService mailService;
   @MockitoBean private NotebooksService mockNotebooksService;
   @MockitoBean private WorkspaceService mockWorkspaceService;
+  @MockitoBean private WsmClient mockWsmClient;
 
   @Autowired private CdrVersionDao cdrVersionDao;
   @Autowired private AccessTierDao accessTierDao;
@@ -424,6 +427,43 @@ public class WorkspaceAdminServiceTest {
   @Test
   public void testSetAdminUnlockedStateCallsAuditor() {
     workspaceAdminService.setAdminUnlockedState(WORKSPACE_NAMESPACE);
+    verify(mockAdminAuditor).fireUnlockWorkspaceAction(dbWorkspace.getWorkspaceId());
+  }
+
+  @Test
+  public void testSetAdminLockedState_nonVwbDoesNotCallWsm() {
+    AdminLockingRequest adminLockingRequest =
+        new AdminLockingRequest().requestReason("not a vwb workspace").requestDateInMillis(123L);
+    workspaceAdminService.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest);
+    verifyNoInteractions(mockWsmClient);
+  }
+
+  @Test
+  public void testSetAdminLockedState_vwbCallsWsm() {
+    workspaceDao.save(dbWorkspace.setVwbWorkspace(true));
+    AdminLockingRequest adminLockingRequest =
+        new AdminLockingRequest().requestReason("lock the vwb workspace").requestDateInMillis(123L);
+
+    workspaceAdminService.setAdminLockedState(WORKSPACE_NAMESPACE, adminLockingRequest);
+
+    verify(mockWsmClient).lockWorkspaceAsService(WORKSPACE_NAMESPACE, "lock the vwb workspace");
+    verify(mockAdminAuditor)
+        .fireLockWorkspaceAction(dbWorkspace.getWorkspaceId(), adminLockingRequest);
+  }
+
+  @Test
+  public void testSetAdminUnlockedState_nonVwbDoesNotCallWsm() {
+    workspaceAdminService.setAdminUnlockedState(WORKSPACE_NAMESPACE);
+    verifyNoInteractions(mockWsmClient);
+  }
+
+  @Test
+  public void testSetAdminUnlockedState_vwbCallsWsm() {
+    workspaceDao.save(dbWorkspace.setVwbWorkspace(true));
+
+    workspaceAdminService.setAdminUnlockedState(WORKSPACE_NAMESPACE);
+
+    verify(mockWsmClient).unlockWorkspaceAsService(WORKSPACE_NAMESPACE);
     verify(mockAdminAuditor).fireUnlockWorkspaceAction(dbWorkspace.getWorkspaceId());
   }
 


### PR DESCRIPTION
## Summary

The `ws-manager.yaml` client spec for Workspace Manager (WSM) was outdated and missing the workspace **lock/unlock** endpoints. This PR adds them and wires admin lock/unlock through to WSM for **VWB workspaces**.

## Changes

**1. `ws-manager.yaml`** — add the new WSM endpoints + schema:
- `POST /api/workspaces/v2/{workspaceId}/lock` (body `LockWorkspaceRequest { reason }`)
- `POST /api/workspaces/v2/{workspaceId}/unlock` (no body)
- `LockWorkspaceRequest` schema

These generate `WorkspaceApi.lockWorkspace(...)` / `unlockWorkspace(...)`. The `{workspaceId}` path param accepts a UUID **or** user-facing id.

**2. `WsmClient`** — add `lockWorkspaceAsService(workspaceId, reason)` and `unlockWorkspaceAsService(workspaceId)`, calling the generated client through the existing `WsmRetryHandler`.

**3. `WorkspaceAdminServiceImpl`** — `setAdminLockedState` / `setAdminUnlockedState` now propagate the lock/unlock to WSM when `dbWorkspace.isVwbWorkspace()`. For VWB workspaces, access control lives in WSM, so the admin action must reach it. Notes:
- WSM is called **before** the local DB state change, so a WSM failure aborts before the workspace is marked (un)locked.
- Existing behavior (DB `adminLocked` flag, audit events, owner-notification emails) is preserved for all workspaces.
- The workspace namespace is passed directly as the WSM user-facing id (RW namespace == VWB `userFacingId`).

**4. `WorkspaceAdminServiceTest`** — added coverage: VWB workspaces call WSM lock/unlock; non-VWB workspaces do not.

## Notes / follow-ups
- The WSM lock endpoint is gated by the `WORKSPACE_LOCKING_ENABLED` feature flag on the WSM side; no RW-side flag was added.
- Optional (not included): exposing the new `WorkspaceDescription` fields (`accessRestriction`, `accessRestrictionReason`, `highestRoleBeforeLock`) in the client spec — not needed for the admin flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
