### PR TITLE
[no ticket][risk=no] Move recovery pod selection to user ui

### DIFF
--- a/api/db/changelog/db.changelog-284-add-workspace-recovery-pod-id-column.xml
+++ b/api/db/changelog/db.changelog-284-add-workspace-recovery-pod-id-column.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="dolbeew" id="changelog-284-add-workspace-recovery-pod-id-column">
+
+        <addColumn tableName="workspace">
+
+            <column name="recovery_pod_id" type="varchar(128)">
+                <constraints nullable="true"/>
+            </column>
+
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/db/changelog/db.changelog-master.xml
+++ b/api/db/changelog/db.changelog-master.xml
@@ -291,6 +291,7 @@
   <include file="changelog/db.changelog-281-folder-sync-transfer.xml"/>
   <include file="changelog/db.changelog-282-add-workspace-archive-status-column.xml"/>
   <include file="changelog/db.changelog-283-add-workspace-recovery-state-column.xml"/>
+  <include file="changelog/db.changelog-284-add-workspace-recovery-pod-id-column.xml"/>
   <!--
    Note: to update the DB locally, do the following:
    - Migrate schema changes: `./project.rb run-local-all-migrations`

--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -838,18 +838,18 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Void> startWorkspaceRecovery(
-      String namespace, String terraName, WorkspaceRecoveryRequest body) {
+  public ResponseEntity<Void> startWorkspaceRecovery(String namespace, String terraName) {
 
-    workspaceMigrationService.startWorkspaceRecovery(namespace, terraName, body.getPodId());
+    workspaceMigrationService.startWorkspaceRecovery(namespace, terraName);
 
     return ResponseEntity.ok().build();
   }
 
   @Override
-  public ResponseEntity<Void> requestWorkspaceRecovery(String namespace, String terraName) {
+  public ResponseEntity<Void> requestWorkspaceRecovery(
+      String namespace, String terraName, String podId) {
 
-    workspaceMigrationService.requestWorkspaceRecovery(namespace, terraName);
+    workspaceMigrationService.requestWorkspaceRecovery(namespace, terraName, podId);
 
     return ResponseEntity.ok().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/WorkspaceDao.java
@@ -194,7 +194,7 @@ public interface WorkspaceDao extends CrudRepository<DbWorkspace, Long>, Workspa
           + "join DbVerifiedInstitutionalAffiliation via on w.creator.userId = via.user.userId "
           + "where w.migratedVwbWorkspaceId is null "
           + "and w.activeStatus = 0 "
-          + "and via.verifiedInstitutionalAffiliationId != 1 "
+          + "and via.institution.institutionId != 1 "
           + "and w.workspaceId not in (SELECT legacyWorkspaceId from DbWorkspaceBucketArchive )"
           + "order by w.lastModifiedTime desc limit 1")
   WorkspaceArchiveView findNextWorkspaceToArchive();

--- a/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
+++ b/api/src/main/java/org/pmiops/workbench/db/model/DbWorkspace.java
@@ -107,6 +107,7 @@ public class DbWorkspace {
   private String migratedVwbWorkspaceId;
   private String migrationState;
   private String recoveryState;
+  private String recoveryPodId;
 
   private AIANResearchType aianResearchType;
   private String aianResearchDetails;
@@ -758,6 +759,18 @@ public class DbWorkspace {
   public DbWorkspace setRecoveryState(String recoveryState) {
 
     this.recoveryState = recoveryState;
+
+    return this;
+  }
+
+  @Column(name = "recovery_pod_id")
+  public String getRecoveryPodId() {
+    return recoveryPodId;
+  }
+
+  public DbWorkspace setRecoveryPodId(String recoveryPodId) {
+
+    this.recoveryPodId = recoveryPodId;
 
     return this;
   }

--- a/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
+++ b/api/src/main/java/org/pmiops/workbench/utils/mappers/WorkspaceMapper.java
@@ -238,6 +238,7 @@ public interface WorkspaceMapper {
   @Mapping(target = "migratedVwbWorkspaceId", ignore = true)
   @Mapping(target = "migrationState", ignore = true)
   @Mapping(target = "recoveryState", ignore = true)
+  @Mapping(target = "recoveryPodId", ignore = true)
   void mergeResearchPurposeIntoWorkspace(
       @MappingTarget DbWorkspace workspace, ResearchPurpose researchPurpose);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
@@ -36,9 +36,9 @@ public interface WorkspaceMigrationService {
 
   void checkArchiveStatus(String workspaceNamespace, String workspaceName);
 
-  void startWorkspaceRecovery(String namespace, String terraName, String podId);
+  void startWorkspaceRecovery(String namespace, String terraName);
 
-  void requestWorkspaceRecovery(String namespace, String terraName);
+  void requestWorkspaceRecovery(String namespace, String terraName, String podId);
 
   void checkRecoveryStatus(String namespace, String terraName);
 }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -963,7 +963,7 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   }
 
   @Override
-  public void requestWorkspaceRecovery(String namespace, String terraName) {
+  public void requestWorkspaceRecovery(String namespace, String terraName, String podId) {
     logger.log(Level.INFO, namespace + ": Requesting workspace recovery");
 
     DbWorkspace dbWorkspace = workspaceDao.getRequired(namespace, terraName);
@@ -991,8 +991,9 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
           namespace + ": Workspace is not archived. Current state=" + archive.getStatus());
     }
 
-    // Update recovery state to REQUESTED
+    // Update recovery state to REQUESTED and set recoveryPodId
     dbWorkspace.setRecoveryState(WorkspaceRecoveryStatus.REQUESTED.name());
+    dbWorkspace.setRecoveryPodId(podId);
     dbWorkspace.setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()));
     workspaceDao.save(dbWorkspace);
 
@@ -1015,7 +1016,7 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   }
 
   @Override
-  public void startWorkspaceRecovery(String namespace, String terraName, String podId) {
+  public void startWorkspaceRecovery(String namespace, String terraName) {
 
     Duration bucketDelay = Duration.ofSeconds(10);
 
@@ -1074,8 +1075,8 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
           workspaceMapper.toApiWorkspace(dbWorkspace, fcWorkspace, initialCreditsService);
 
       String resolvedPodId =
-          podId != null
-              ? podId
+          dbWorkspace.getRecoveryPodId() != null
+              ? dbWorkspace.getRecoveryPodId()
               : Optional.ofNullable(userDao.findUserByUsername(workspace.getCreator()))
                   .map(DbUser::getVwbUserPod)
                   .map(DbVwbUserPod::getVwbPodId)

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -1103,17 +1103,28 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
               .filter(c -> c.cdrVersionId == cdrVersionId)
               .findFirst()
               .orElse(null);
-
+      String sourceWorkspaceId;
+      String resourceId;
       if (cdrVersionForMigration == null) {
-        throw new RuntimeException(namespace + ": CDR version unavailable");
+        // Outdated CDR version, set v9 ids
+        if (dbWorkspace.getCdrVersion().getAccessTier().getShortName().equals("controlled")) {
+          sourceWorkspaceId = "3d83ef80-77d7-43e8-a479-52946619b769";
+          resourceId = "1a27006f-6aea-4a10-bdc1-c4d562d7828d";
+        } else {
+          sourceWorkspaceId = "698c6700-afbe-454a-b73a-c675e629336c";
+          resourceId = "d6ac7edd-2fe6-4221-8680-2cf828665cd3";
+        }
+      } else {
+        sourceWorkspaceId = cdrVersionForMigration.workspaceId;
+        resourceId = cdrVersionForMigration.resourceId;
       }
 
       logger.log(Level.INFO, namespace + ": Starting BQ clone");
 
       wsmClient.cloneBQDataset(
           workspaceId,
-          cdrVersionForMigration.workspaceId,
-          UUID.fromString(cdrVersionForMigration.resourceId),
+          sourceWorkspaceId,
+          UUID.fromString(resourceId),
           UUID.randomUUID().toString());
 
       logger.log(Level.INFO, namespace + ": BQ clone complete");

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4676,11 +4676,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WorkspaceRecoveryRequest'
       responses:
         200:
           description: Recovery started successfully
@@ -4698,6 +4693,11 @@ paths:
             type: string
         - name: terraName
           in: path
+          required: true
+          schema:
+            type: string
+        - name: podId
+          in: query
           required: true
           schema:
             type: string
@@ -8327,11 +8327,6 @@ components:
         namespace:
           type: string
         terraName:
-          type: string
-    WorkspaceRecoveryRequest:
-      type: object
-      properties:
-        podId:
           type: string
     StartWorkspaceMigrationRequest:
       type: object

--- a/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
@@ -480,8 +480,7 @@ public class WorkspaceMigrationServiceImplTest {
 
     RuntimeException ex =
         assertThrows(
-            RuntimeException.class,
-            () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME, POD_ID));
+            RuntimeException.class, () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME));
 
     assertThat(ex.getMessage()).contains("Recovery failed to start");
     assertThat(ex.getCause()).isNotNull();
@@ -494,8 +493,7 @@ public class WorkspaceMigrationServiceImplTest {
 
     RuntimeException ex =
         assertThrows(
-            RuntimeException.class,
-            () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME, POD_ID));
+            RuntimeException.class, () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME));
 
     assertThat(ex.getMessage())
         .contains("Workspace recovery can only start when state is REQUESTED");

--- a/ui/src/app/pages/admin/workspace/admin-workspace-recovery-modal.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace-recovery-modal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { Dropdown } from 'primereact/dropdown';
 
 import { Workspace, WorkspaceRecoveryStatus } from 'generated/fetch';
 
@@ -12,10 +11,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { SpinnerOverlay } from 'app/components/spinners';
-import {
-  vwbWorkspaceAdminApi,
-  workspacesApi,
-} from 'app/services/swagger-fetch-clients';
+import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
 
@@ -163,36 +159,10 @@ export const AdminWorkspaceRecoveryModal = ({
   onClose: () => void;
   reload: () => void;
 }) => {
-  const [pods, setPods] = useState<string[]>([]);
-  const [selectedPod, setSelectedPod] = useState('');
-  const [loadingPods, setLoadingPods] = useState(false);
   const [startingRecovery, setStartingRecovery] = useState(false);
-  const getPods = async () => {
-    if (!workspace) {
-      return;
-    }
-
-    try {
-      setLoadingPods(true);
-
-      const username = workspace.creatorUser.userName;
-
-      const response = await vwbWorkspaceAdminApi().getPods(username);
-
-      setPods([
-        'nph-consortium-users',
-        ...(response || []),
-        'aou-system-billing-prod',
-      ]);
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoadingPods(false);
-    }
-  };
 
   const handleRecovery = async () => {
-    if (!workspace || !selectedPod) {
+    if (!workspace) {
       return;
     }
 
@@ -200,7 +170,7 @@ export const AdminWorkspaceRecoveryModal = ({
       setStartingRecovery(true);
       await workspacesApi().startWorkspaceRecovery(
         workspace.namespace,
-        selectedPod
+        workspace.terraName
       );
 
       await reload();
@@ -222,6 +192,7 @@ export const AdminWorkspaceRecoveryModal = ({
     <Modal
       data-test-id='workspace-archive-recovery-modal'
       aria={{ label: 'Workspace Archive Recovery' }}
+      width={650}
     >
       <ModalTitle>Workspace archive recovery</ModalTitle>
 
@@ -242,36 +213,6 @@ export const AdminWorkspaceRecoveryModal = ({
               value={workspace.migratedVwbWorkspaceId || 'N/A'}
             />
           </div>
-
-          <hr style={styles.divider} />
-
-          <div style={styles.podSection}>
-            <span style={styles.sectionLabel}>
-              Researcher Workbench 2.0 billing pod
-            </span>
-            <div style={styles.podRow}>
-              <Dropdown
-                value={selectedPod}
-                options={pods}
-                placeholder={
-                  loadingPods ? 'Loading pods...' : 'Select a billing pod'
-                }
-                onChange={(e) => setSelectedPod(e.value)}
-                disabled={loadingPods}
-                style={{
-                  flex: 1,
-                  borderRadius: '6px',
-                }}
-              />
-              <Button
-                type='secondarySmall'
-                onClick={getPods}
-                disabled={loadingPods || startingRecovery}
-              >
-                {loadingPods ? 'Loading...' : 'Load pods'}
-              </Button>
-            </div>
-          </div>
         </div>
       </ModalBody>
 
@@ -282,7 +223,7 @@ export const AdminWorkspaceRecoveryModal = ({
         <Button
           type='primary'
           onClick={handleRecovery}
-          disabled={startingRecovery || !selectedPod}
+          disabled={startingRecovery}
         >
           {recoveryButtonLabel}
         </Button>

--- a/ui/src/app/pages/admin/workspace/workspace-archival-info.tsx
+++ b/ui/src/app/pages/admin/workspace/workspace-archival-info.tsx
@@ -19,7 +19,9 @@ export const WorkspaceArchiveInfo = ({ workspace, onRecover }: Props) => {
   const migrated = workspace.migrationState === MigrationState.FINISHED;
 
   const archiveStatus =
-    workspace.recoveryState === null ? 'Not Archived' : 'Archived';
+    typeof workspace.recoveryState === 'undefined'
+      ? 'Not Archived'
+      : 'Archived';
 
   const recoveryStatus = (() => {
     switch (workspace.recoveryState) {

--- a/ui/src/app/pages/workspace/workspace-recovery.tsx
+++ b/ui/src/app/pages/workspace/workspace-recovery.tsx
@@ -2,19 +2,26 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import fp from 'lodash/fp';
 import { Button } from 'primereact/button';
+import { Dropdown } from 'primereact/dropdown';
 
 import { Workspace, WorkspaceRecoveryStatus } from 'generated/fetch';
 
+import { environment } from 'environments/environment';
+import { ClrIcon } from 'app/components/icons';
 import { WorkspaceRecoverySuccessModal } from 'app/components/migration/workspace-recovery-success-modal';
+import { TooltipTrigger } from 'app/components/popups';
 import {
   withSpinnerOverlay,
   WithSpinnerOverlayProps,
 } from 'app/components/with-spinner-overlay';
-import { workspacesApi } from 'app/services/swagger-fetch-clients';
+import { userApi, workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
-import { withCurrentWorkspace } from 'app/utils';
-import { reactStyles } from 'app/utils';
+import { reactStyles, withCurrentWorkspace } from 'app/utils';
+import { findCdrVersion } from 'app/utils/cdr-versions';
 import { useNavigation } from 'app/utils/navigation';
+import { cdrVersionStore, serverConfigStore } from 'app/utils/stores';
+
+import { VwbImportantBanner } from './vwb-important-banner';
 
 const styles = reactStyles({
   page: {
@@ -143,11 +150,42 @@ export const WorkspaceRecovery = fp.flow(
   withCurrentWorkspace()
 )(({ workspace, hideSpinner }: Props) => {
   const [recovering, setRecovering] = useState(false);
+  const [selectedPod, setSelectedPod] = useState('');
+  const [pods, setPods] = useState<any[]>([]);
+  const [loadingPods, setLoadingPods] = useState(false);
+  const [loadingTos, setLoadingTos] = useState(true);
+  const [hasAcceptedTos, setHasAcceptedTos] = useState<boolean | null>(null);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [navigate] = useNavigation();
+  const { cdrVersionsForMigration } = serverConfigStore.get().config;
 
   useEffect(() => {
     hideSpinner();
+    const loadPods = async () => {
+      setLoadingPods(true);
+      try {
+        const response = await workspacesApi().getUserPods();
+        setPods(response || []);
+      } catch (e) {
+        console.error('Failed to load pods', e);
+      } finally {
+        setLoadingPods(false);
+      }
+    };
+    const fetchTos = async () => {
+      try {
+        const res = await userApi().getUserTosStatus();
+        setHasAcceptedTos(res);
+      } catch (e) {
+        console.error('Failed to fetch ToS state', e);
+        setHasAcceptedTos(false);
+      } finally {
+        setLoadingTos(false);
+      }
+    };
+
+    loadPods();
+    fetchTos();
   }, []);
 
   const startRecovery = async () => {
@@ -156,7 +194,8 @@ export const WorkspaceRecovery = fp.flow(
 
       await workspacesApi().requestWorkspaceRecovery(
         workspace.namespace,
-        workspace.terraName
+        workspace.terraName,
+        selectedPod
       );
       setShowSuccessModal(true);
     } catch (e) {
@@ -169,6 +208,17 @@ export const WorkspaceRecovery = fp.flow(
   return (
     <>
       <div style={styles.page}>
+        {!hasAcceptedTos && (
+          <VwbImportantBanner
+            title='Important'
+            message={`Before starting migration, log into Researcher Workbench 2.0 
+to agree to the terms of service. You only need to do this once.`}
+            actionText='Open Researcher Workbench 2.0'
+            onAction={() => window.open(environment.vwbUiUrl, '_blank')}
+            onClose={() => setHasAcceptedTos(true)}
+            loadingText={loadingTos && 'Checking Terms of Service'}
+          />
+        )}
         <div style={styles.cards}>
           {/* LEFT CARD */}
 
@@ -259,13 +309,72 @@ export const WorkspaceRecovery = fp.flow(
               <div>
                 <div style={styles.fieldLabel}>Workspace Dataset Version</div>
 
-                <div style={styles.fieldValue}>{workspace.cdrVersionId}</div>
-
-                <div style={styles.warning}>
-                  This dataset version is no longer supported. Upon recovery,
-                  the workspace will automatically be upgraded to the newest
-                  supported dataset version.
+                <div style={styles.fieldValue}>
+                  {
+                    findCdrVersion(
+                      workspace.cdrVersionId,
+                      cdrVersionStore.get()
+                    ).name
+                  }
                 </div>
+
+                {!cdrVersionsForMigration.some(
+                  (c) => +workspace.cdrVersionId === c.cdrVersionId
+                ) && (
+                  <div style={styles.warning}>
+                    This dataset version is no longer supported. Upon recovery,
+                    the workspace will automatically be upgraded to the newest
+                    supported dataset version.
+                  </div>
+                )}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '12px',
+                  flex: 1,
+                  justifyContent: 'center',
+                }}
+              >
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  <div style={styles.fieldLabel}>
+                    Researcher Workbench 2.0 billing pod
+                  </div>
+
+                  <Dropdown
+                    value={selectedPod}
+                    options={pods}
+                    optionLabel='userFacingId'
+                    optionValue='podId'
+                    placeholder={
+                      loadingPods ? 'Loading pods...' : 'Select a pod'
+                    }
+                    onChange={(e) => setSelectedPod(e.value)}
+                    disabled={loadingPods}
+                    style={{
+                      width: '300px',
+                      borderRadius: '6px',
+                    }}
+                  />
+                </div>
+
+                <TooltipTrigger
+                  content={
+                    'You are selecting a pod for workspace storage costs in Verily Workbench. There is no cost to recover your workspace.'
+                  }
+                  side='top'
+                >
+                  <ClrIcon
+                    shape='info-circle'
+                    size={24}
+                    style={{
+                      cursor: 'pointer',
+                      color: colors.accent,
+                      marginTop: '18px',
+                    }}
+                  />
+                </TooltipTrigger>
               </div>
             </div>
 
@@ -283,7 +392,10 @@ export const WorkspaceRecovery = fp.flow(
                 }
                 disabled={
                   recovering ||
-                  workspace.recoveryState === WorkspaceRecoveryStatus.REQUESTED
+                  workspace.recoveryState ===
+                    WorkspaceRecoveryStatus.REQUESTED ||
+                  !hasAcceptedTos ||
+                  !selectedPod
                 }
                 loading={recovering}
                 onClick={startRecovery}


### PR DESCRIPTION
- Add `recovery_pod_id` to `workspace` table
- Move pod dropdown from admin to user recovery ui
- minor ui updates
- Fix for archive query pulling workspaces for ops users