### PR TITLE
[no ticket][risk=no] Add research purpose to recovery workspace creation

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
+++ b/api/src/main/java/org/pmiops/workbench/api/WorkspacesController.java
@@ -838,9 +838,11 @@ public class WorkspacesController implements WorkspacesApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Void> startWorkspaceRecovery(String namespace, String terraName) {
+  public ResponseEntity<Void> startWorkspaceRecovery(
+      String namespace, String terraName, StartWorkspaceRecoveryRequest request) {
 
-    workspaceMigrationService.startWorkspaceRecovery(namespace, terraName);
+    workspaceMigrationService.startWorkspaceRecovery(
+        namespace, terraName, request.getResearchPurpose());
 
     return ResponseEntity.ok().build();
   }

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationService.java
@@ -36,7 +36,7 @@ public interface WorkspaceMigrationService {
 
   void checkArchiveStatus(String workspaceNamespace, String workspaceName);
 
-  void startWorkspaceRecovery(String namespace, String terraName);
+  void startWorkspaceRecovery(String namespace, String terraName, String researchPurpose);
 
   void requestWorkspaceRecovery(String namespace, String terraName, String podId);
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -1020,7 +1020,7 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   }
 
   @Override
-  public void startWorkspaceRecovery(String namespace, String terraName) {
+  public void startWorkspaceRecovery(String namespace, String terraName, String researchPurpose) {
 
     Duration bucketDelay = Duration.ofSeconds(10);
 
@@ -1101,6 +1101,15 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
       wsmClient.shareWorkspaceAsService(
           workspaceId.toString(), workspace.getCreator(), IamRole.OWNER);
 
+      List<Property> properties =
+          List.of(
+              new Property().key("terra-default-location").value("us-central1"),
+              new Property()
+                  .key("terra-required-data-use-metadata")
+                  .value(WorkbenchStringUtils.encodeUserInput(researchPurpose)),
+              new Property().key("terra-workspace-short-description").value(""));
+      wsmClient.updateWorkspaceProperties(properties, workspaceId.toString());
+
       long cdrVersionId = dbWorkspace.getCdrVersion().getCdrVersionId();
 
       CdrVersionForMigration cdrVersionForMigration =
@@ -1124,20 +1133,29 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
         resourceId = cdrVersionForMigration.resourceId;
       }
 
-      logger.log(Level.INFO, namespace + ": Starting BQ clone");
+      try {
+        logger.log(Level.INFO, namespace + ": Starting BQ clone");
+        wsmClient.cloneBQDataset(
+            workspaceId,
+            sourceWorkspaceId,
+            UUID.fromString(resourceId),
+            UUID.randomUUID().toString());
 
-      wsmClient.cloneBQDataset(
-          workspaceId,
-          sourceWorkspaceId,
-          UUID.fromString(resourceId),
-          UUID.randomUUID().toString());
-
-      logger.log(Level.INFO, namespace + ": BQ clone complete");
+        logger.log(Level.INFO, namespace + ": BQ clone complete");
+      } catch (Exception e) {
+        throw new RuntimeException(namespace + ": BQ clone failed", e);
+      }
 
       CreatedControlledGcpGcsBucket controlledBucket =
           wsmClient.createControlledBucket(workspaceId.toString(), namespace);
 
       Thread.sleep(bucketDelay.toMillis());
+
+      WorkspaceDescription vwbWorkspaceWithPolicies =
+          wsmClient.getWorkspaceAsService(vwbWorkspace.getUserFacingId());
+
+      logger.log(
+          Level.INFO, namespace + ": New workspace with policies: " + vwbWorkspaceWithPolicies);
 
       String destinationBucket = controlledBucket.getGcpBucket().getAttributes().getBucketName();
 

--- a/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImpl.java
@@ -1200,6 +1200,8 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
   @Override
   public void checkRecoveryStatus(String namespace, String terraName) {
 
+    logger.log(Level.INFO, namespace + ": Checking recovery queue status");
+
     DbWorkspace dbWorkspace = workspaceDao.getRequired(namespace, terraName);
 
     String projectId = workbenchConfigProvider.get().server.projectId;
@@ -1216,11 +1218,17 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
     switch (jobStatus) {
       case IN_PROGRESS:
       case QUEUED:
+        logger.log(Level.INFO, namespace + ": Recovery transfer in progress, requeue");
         taskQueueService.pushWorkspaceRecoveryStatusTask(namespace, terraName);
 
         return;
 
       case FAILED:
+        logger.log(
+            Level.INFO,
+            namespace
+                + ": Recovery transfer failed: "
+                + transferOperation.getErrorBreakdownsList());
         dbWorkspace.setRecoveryState(WorkspaceRecoveryStatus.FAILED.name());
 
         workspaceDao.save(dbWorkspace);
@@ -1230,6 +1238,7 @@ public class WorkspaceMigrationServiceImpl implements WorkspaceMigrationService 
         return;
 
       case SUCCESS:
+        logger.log(Level.INFO, namespace + ": Recovery transfer success");
         dbWorkspace.setRecoveryState(WorkspaceRecoveryStatus.RECOVERED.name());
 
         workspaceDao.save(dbWorkspace);

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4658,7 +4658,8 @@ paths:
               $ref: '#/components/schemas/CheckWorkspaceRecoveryStatusRequest'
       responses:
         200:
-          description: Recovery status checked successfully＀
+          description: Recovery status checked successfully
+          content: { }
   /v1/workspaces/{namespace}/{terraName}/recovery:
     post:
       tags:

--- a/api/src/main/resources/workbench-api.yaml
+++ b/api/src/main/resources/workbench-api.yaml
@@ -4676,6 +4676,13 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        description: Research purpose for the workspace to recover
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartWorkspaceRecoveryRequest'
+        required: true
       responses:
         200:
           description: Recovery started successfully
@@ -8338,6 +8345,11 @@ components:
           items:
             type: string
           description: List of folder prefixes to migrate. If empty, migrates entire bucket.
+        researchPurpose:
+          type: string
+    StartWorkspaceRecoveryRequest:
+      type: object
+      properties:
         researchPurpose:
           type: string
     SyncWorkspaceFoldersRequest:

--- a/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
+++ b/api/src/test/java/org/pmiops/workbench/workspaces/migration/WorkspaceMigrationServiceImplTest.java
@@ -483,7 +483,8 @@ public class WorkspaceMigrationServiceImplTest {
 
     RuntimeException ex =
         assertThrows(
-            RuntimeException.class, () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME));
+            RuntimeException.class,
+            () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME, RESEARCH_PURPOSE));
 
     assertThat(ex.getMessage()).contains("Recovery failed to start");
     assertThat(ex.getCause()).isNotNull();
@@ -496,7 +497,8 @@ public class WorkspaceMigrationServiceImplTest {
 
     RuntimeException ex =
         assertThrows(
-            RuntimeException.class, () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME));
+            RuntimeException.class,
+            () -> service.startWorkspaceRecovery(NAMESPACE, TERRA_NAME, RESEARCH_PURPOSE));
 
     assertThat(ex.getMessage())
         .contains("Workspace recovery can only start when state is REQUESTED");

--- a/ui/src/app/pages/admin/workspace/admin-workspace-recovery-modal.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspace-recovery-modal.tsx
@@ -11,6 +11,7 @@ import {
   ModalTitle,
 } from 'app/components/modals';
 import { SpinnerOverlay } from 'app/components/spinners';
+import { rwToVwbResearchPurpose } from 'app/pages/admin/vwb/vwb-research-purpose-text';
 import { workspacesApi } from 'app/services/swagger-fetch-clients';
 import colors, { colorWithWhiteness } from 'app/styles/colors';
 import { reactStyles } from 'app/utils';
@@ -170,7 +171,12 @@ export const AdminWorkspaceRecoveryModal = ({
       setStartingRecovery(true);
       await workspacesApi().startWorkspaceRecovery(
         workspace.namespace,
-        workspace.terraName
+        workspace.terraName,
+        {
+          researchPurpose: JSON.stringify(
+            rwToVwbResearchPurpose(workspace.researchPurpose)
+          ),
+        }
       );
 
       await reload();


### PR DESCRIPTION
- Add research purpose to new 2.0 workspace before cloning BQ dataset, otherwise the data collection/policies won't get applied
- Add logging for troubleshooting the recovery status queue. Queue currently does not run and status gets stuck at 'RECOVERING' after process is complete