### PR TITLE
[risk=low][RW-18074] Fix the case when all legacy user workspaces use user-provided billing

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -503,12 +503,23 @@ public class InitialCreditsService {
   /**
    * Check if all of the user's active workspaces use user-provided billing accounts. Returns true
    * if the user has at least one active workspace and none of them use initial credits billing.
-   * Returns false if the user has no active workspaces.
+   * Returns false if the user has no active workspaces, or if the user has a VWB pod actively using
+   * initial credits (regardless of their Terra workspaces' billing).
    *
    * @param user The user to check
    * @return True if all active workspaces use user-provided billing
    */
   public boolean hasOnlyUserProvidedBillingWorkspaces(DbUser user) {
+    // A user with a VWB pod on the initial credits billing account still has initial credits
+    // exposure, even if all of their Terra workspaces use user-provided billing. Such users must not
+    // be skipped, otherwise their VWB billing is never unlinked on exhaustion/expiration (RW-18074).
+    DbVwbUserPod vwbUserPod = user.getVwbUserPod();
+    if (vwbUserPod != null
+        && vwbUserPod.getVwbPodId() != null
+        && Boolean.TRUE.equals(vwbUserPod.isInitialCreditsActive())) {
+      return false;
+    }
+
     List<DbWorkspace> activeWorkspaces =
         workspaceDao.findAllByCreator(user).stream()
             .filter(ws -> ws.getWorkspaceActiveStatusEnum() == WorkspaceActiveStatus.ACTIVE)

--- a/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
+++ b/api/src/main/java/org/pmiops/workbench/initialcredits/InitialCreditsService.java
@@ -511,8 +511,10 @@ public class InitialCreditsService {
    */
   public boolean hasOnlyUserProvidedBillingWorkspaces(DbUser user) {
     // A user with a VWB pod on the initial credits billing account still has initial credits
-    // exposure, even if all of their Terra workspaces use user-provided billing. Such users must not
-    // be skipped, otherwise their VWB billing is never unlinked on exhaustion/expiration (RW-18074).
+    // exposure, even if all of their Terra workspaces use user-provided billing. Such users must
+    // not
+    // be skipped, otherwise their VWB billing is never unlinked on exhaustion/expiration
+    // (RW-18074).
     DbVwbUserPod vwbUserPod = user.getVwbUserPod();
     if (vwbUserPod != null
         && vwbUserPod.getVwbPodId() != null

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -1458,7 +1458,8 @@ public class InitialCreditsServiceTest {
 
   @Test
   public void hasOnlyUserProvidedBillingWorkspaces_falseWhenVwbPodUsesInitialCredits() {
-    // RW-18074: a user whose active Terra workspaces all use user-provided billing but who has a VWB
+    // RW-18074: a user whose active Terra workspaces all use user-provided billing but who has a
+    // VWB
     // pod actively on initial credits must NOT be treated as user-provided-billing-only. Otherwise
     // they are filtered out of the exhaustion/expiration flow and their VWB billing is never
     // unlinked.

--- a/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/initialcredits/InitialCreditsServiceTest.java
@@ -1456,6 +1456,40 @@ public class InitialCreditsServiceTest {
     assertWithinBillingTolerance(dbEntry.getCost(), cost);
   }
 
+  @Test
+  public void hasOnlyUserProvidedBillingWorkspaces_falseWhenVwbPodUsesInitialCredits() {
+    // RW-18074: a user whose active Terra workspaces all use user-provided billing but who has a VWB
+    // pod actively on initial credits must NOT be treated as user-provided-billing-only. Otherwise
+    // they are filtered out of the exhaustion/expiration flow and their VWB billing is never
+    // unlinked.
+    DbUser user = createUser("vwb-credits@test.com");
+    createUserProvidedBillingWorkspace(user, "byo-project");
+    user.setVwbUserPod(createVwbPodForUser(user, true));
+
+    assertThat(initialCreditsService.hasOnlyUserProvidedBillingWorkspaces(user)).isFalse();
+  }
+
+  @Test
+  public void hasOnlyUserProvidedBillingWorkspaces_trueWhenVwbPodInitialCreditsInactive() {
+    // A user with only user-provided-billing workspaces and an inactive VWB pod is still
+    // user-provided-billing-only.
+    DbUser user = createUser("inactive-vwb@test.com");
+    createUserProvidedBillingWorkspace(user, "byo-project");
+    user.setVwbUserPod(createVwbPodForUser(user, false));
+
+    assertThat(initialCreditsService.hasOnlyUserProvidedBillingWorkspaces(user)).isTrue();
+  }
+
+  private DbWorkspace createUserProvidedBillingWorkspace(DbUser creator, String project) {
+    return workspaceDao.save(
+        new DbWorkspace()
+            .setCreator(creator)
+            .setWorkspaceNamespace(project + "-ns")
+            .setGoogleProject(project)
+            .setBillingAccountName("billingAccounts/user-provided-account")
+            .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.ACTIVE));
+  }
+
   private DbUser createUser(String email) {
     return userDao.save(new DbUser().setUsername(email));
   }


### PR DESCRIPTION
## Summary

  Users whose active Terra workspaces all use user-provided billing, but who have a VWB pod on the initial-credits billing account, were never having their VWB billing unlinked when they exceeded their initial-credits limit — so they kept accruing charges well past the cap.

  ## Problem

  `CloudTaskInitialCreditsExhaustionController.handleInitialCreditsExhaustionBatch` filters out users for whom
  `InitialCreditsService.hasOnlyUserProvidedBillingWorkspaces(...)` returns `true`. That method only inspected the user's **Terra `DbWorkspace`** billing accounts
  and never looked at their **`DbVwbUserPod`**.

  So a user with:
  - active Terra workspaces all on user-provided billing, **and**
  - a VWB pod actively on the initial-credits billing account

  was classified as "user-provided billing only," removed from the batch (along with their cost entries), and never reached `handleExhaustedUsers` → `updateInitialCreditsExhaustion(user, true)` → `vwbUserService.unlinkBillingAccountForUserPod(user)`.

<!--
Reminder: If you decide to merge with any failing checks, add an explanatory comment before doing so.
-->

---
**PR checklist**

- [x] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [x] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [x] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [x] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
