### PR TITLE
[dt-1183][risk=no]Added ui for admin side waiting for retrieval workspaces

### DIFF
--- a/ui/src/app/components/side-nav.tsx
+++ b/ui/src/app/components/side-nav.tsx
@@ -130,7 +130,18 @@ const userAuditActive = () => {
 };
 
 const workspaceAdminActive = () => {
-  return window.location.pathname.startsWith('/admin/workspaces');
+  return (
+    window.location.pathname.startsWith('/admin/workspaces') &&
+    !window.location.pathname.startsWith(
+      '/admin/workspaces/waiting-for-retrieval'
+    )
+  );
+};
+
+const workspaceWaitingForRetrievalActive = () => {
+  return window.location.pathname.startsWith(
+    '/admin/workspaces/waiting-for-retrieval'
+  );
 };
 
 const vwbWorkspaceAdminActive = () => {
@@ -432,6 +443,15 @@ export const SideNav = (props: SideNavProps) => {
             onToggleSideNav={() => onToggleSideNav()}
             href='/admin/workspaces'
             active={workspaceAdminActive()}
+          />
+        )}
+      {hasAuthorityForAction(profile, AuthorityGuardedAction.WORKSPACE_ADMIN) &&
+        showAdminOptions && (
+          <SideNavItem
+            content='Waiting for Retrieval'
+            onToggleSideNav={() => onToggleSideNav()}
+            href='/admin/workspaces/waiting-for-retrieval'
+            active={workspaceWaitingForRetrievalActive()}
           />
         )}
       {environment.enableVwbAdmin &&

--- a/ui/src/app/pages/admin/workspace/admin-workspaces-waiting-for-retrieval.tsx
+++ b/ui/src/app/pages/admin/workspace/admin-workspaces-waiting-for-retrieval.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Column } from 'primereact/column';
+import { DataTable } from 'primereact/datatable';
+
+import { WorkspaceRecoveryStatus, WorkspaceResponse } from 'generated/fetch';
+
+import { Button, StyledRouterLink } from 'app/components/buttons';
+import { ListPageHeader } from 'app/components/headers';
+import { Error as ErrorMessage } from 'app/components/inputs';
+import { SpinnerOverlay } from 'app/components/spinners';
+import { WithSpinnerOverlayProps } from 'app/components/with-spinner-overlay';
+import { workspacesApi } from 'app/services/swagger-fetch-clients';
+
+export const AdminWorkspacesWaitingForRetrieval = (
+  spinnerProps: WithSpinnerOverlayProps
+) => {
+  const [workspaceResponses, setWorkspaceResponses] = useState<
+    WorkspaceResponse[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+
+  useEffect(() => spinnerProps.hideSpinner(), []);
+
+  const loadWorkspaces = async () => {
+    try {
+      setFetchError(false);
+      setLoading(true);
+      const response = await workspacesApi().getWorkspaces();
+      setWorkspaceResponses(response.items || []);
+    } catch (error) {
+      console.error(error);
+      setFetchError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadWorkspaces();
+  }, []);
+
+  const waitingWorkspaces = useMemo(
+    () =>
+      workspaceResponses
+        .filter(
+          ({ workspace }) =>
+            workspace.recoveryState === WorkspaceRecoveryStatus.REQUESTED
+        )
+        .sort(
+          (a, b) =>
+            (b.workspace.lastModifiedTime || 0) -
+            (a.workspace.lastModifiedTime || 0)
+        ),
+    [workspaceResponses]
+  );
+
+  return (
+    <div style={{ margin: '1.5rem' }}>
+      <ListPageHeader>Workspaces Waiting for Retrieval</ListPageHeader>
+      <p>
+        These archived workspaces have recovery requested by researchers and are
+        waiting for admin retrieval action.
+      </p>
+
+      <Button style={{ height: '2.25rem' }} onClick={() => loadWorkspaces()}>
+        Refresh
+      </Button>
+
+      <div style={{ marginTop: '1.5rem' }}>
+        {fetchError && (
+          <ErrorMessage>
+            Error loading data. Please refresh the page or contact the
+            development team.
+          </ErrorMessage>
+        )}
+
+        {loading ? (
+          <SpinnerOverlay />
+        ) : (
+          <DataTable
+            paginator
+            rows={10}
+            emptyMessage='No workspaces waiting for retrieval'
+            value={waitingWorkspaces}
+          >
+            <Column
+              header='Namespace'
+              body={({ workspace }: WorkspaceResponse) => (
+                <StyledRouterLink
+                  path={`/admin/workspaces/${workspace.namespace}`}
+                >
+                  {workspace.namespace}
+                </StyledRouterLink>
+              )}
+            />
+            <Column
+              header='Workspace Name'
+              body={({ workspace }: WorkspaceResponse) =>
+                workspace.displayName || workspace.name
+              }
+            />
+            <Column
+              header='Creator'
+              body={({ workspace }: WorkspaceResponse) =>
+                workspace.creatorUser?.userName || workspace.creator || 'N/A'
+              }
+            />
+            <Column
+              header='Last Updated'
+              body={({ workspace }: WorkspaceResponse) =>
+                workspace.lastModifiedTime
+                  ? new Date(workspace.lastModifiedTime).toLocaleString()
+                  : 'N/A'
+              }
+            />
+          </DataTable>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/app/routing/signed-in-app-routing.tsx
+++ b/ui/src/app/routing/signed-in-app-routing.tsx
@@ -32,6 +32,7 @@ import { AdminVwbWorkspace } from 'app/pages/admin/vwb/admin-vwb-workspace';
 import { AdminVwbWorkspaceSearch } from 'app/pages/admin/vwb/admin-vwb-workspace-search';
 import { AdminWorkspace } from 'app/pages/admin/workspace/admin-workspace';
 import { AdminWorkspaceSearch } from 'app/pages/admin/workspace/admin-workspace-search';
+import { AdminWorkspacesWaitingForRetrieval } from 'app/pages/admin/workspace/admin-workspaces-waiting-for-retrieval';
 import { DemographicSurvey } from 'app/pages/demographic-survey';
 import { Homepage } from 'app/pages/homepage/homepage';
 import { ProfileComponent } from 'app/pages/profile/profile-component';
@@ -165,6 +166,10 @@ const WorkspaceSearchAdminPage = fp.flow(
   withRouteData,
   withRoutingSpinner
 )(AdminWorkspaceSearch);
+const AdminWorkspacesWaitingForRetrievalPage = fp.flow(
+  withRouteData,
+  withRoutingSpinner
+)(AdminWorkspacesWaitingForRetrieval);
 
 export const SignedInRoutes = () => {
   const location = useLocation();
@@ -296,6 +301,18 @@ export const SignedInRoutes = () => {
       >
         <WorkspaceSearchAdminPage
           routeData={{ title: 'Workspace Admin', minimizeChrome: true }}
+        />
+      </AppRoute>
+      <AppRoute
+        exact
+        path='/admin/workspaces/waiting-for-retrieval'
+        guards={[authorityGuard(AuthorityGuardedAction.WORKSPACE_ADMIN)]}
+      >
+        <AdminWorkspacesWaitingForRetrievalPage
+          routeData={{
+            title: 'Workspaces Waiting for Retrieval',
+            minimizeChrome: true,
+          }}
         />
       </AppRoute>
       <AppRoute


### PR DESCRIPTION


---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
