### PR TITLE
[no ticket][risk=no] Require VWB Workspace ID for admin egress bypass

### DIFF
--- a/ui/src/app/pages/admin/user/admin-user-egress-bypass.spec.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-egress-bypass.spec.tsx
@@ -35,10 +35,15 @@ const getBypassReasonText = () =>
     name: /Enter description for large file download request./i,
   });
 
+const getVwbWorkspaceIdText = () =>
+  screen.getByRole('textbox', { name: /VWB Workspace ID \(required\)/i });
+
 const getBypassButton = () =>
   screen.getByRole('button', {
     name: 'Temporarily Enable Large File Downloads',
   });
+
+const VWB_WORKSPACE_ID = '7f1c0e2a-1b3d-4c5e-8a9b-0d1e2f3a4b5c';
 
 describe(AdminUserEgressBypass.name, () => {
   const defaultProps: AdminUserEgressBypassProps = {
@@ -65,6 +70,9 @@ describe(AdminUserEgressBypass.name, () => {
     await user.click(getBypassReasonText());
     await user.paste(byPassDescription);
 
+    await user.click(getVwbWorkspaceIdText());
+    await user.paste(VWB_WORKSPACE_ID);
+
     const bypassButton = getBypassButton();
 
     await expectTooltipAbsence(
@@ -81,8 +89,38 @@ describe(AdminUserEgressBypass.name, () => {
       {
         startTime: expect.any(Number),
         byPassDescription,
+        vwbWorkspaceId: VWB_WORKSPACE_ID,
       }
     );
+  });
+
+  it('should disallow egress bypass without a VWB workspace ID', async () => {
+    const user = userEvent.setup();
+
+    component();
+
+    await user.click(getBypassReasonText());
+    await user.paste('test bypass reason');
+
+    const bypassButton = getBypassButton();
+    await expectTooltip(bypassButton, /VWB Workspace ID \(UUID\)/i, user);
+    expectButtonElementDisabled(bypassButton);
+  });
+
+  it('should disallow egress bypass with a whitespace-only VWB workspace ID', async () => {
+    const user = userEvent.setup();
+
+    component();
+
+    await user.click(getBypassReasonText());
+    await user.paste('test bypass reason');
+
+    await user.click(getVwbWorkspaceIdText());
+    await user.paste('   ');
+
+    const bypassButton = getBypassButton();
+    await expectTooltip(bypassButton, /VWB Workspace ID \(UUID\)/i, user);
+    expectButtonElementDisabled(bypassButton);
   });
 
   it('should disallow egress bypass with a too short reason', async () => {

--- a/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
+++ b/ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx
@@ -51,8 +51,14 @@ export const AdminUserEgressBypass = (props: AdminUserEgressBypassProps) => {
     bypassDescription.length < MIN_BYPASS_DESCRIPTION ||
     bypassDescription.length > MAX_BYPASS_DESCRIPTION;
 
+  const missingVwbWorkspaceId = !vwbWorkspaceId.trim();
+
   const egressBypassButtonDisabled =
-    bypassing || apiError || invalidReason || !isDateValid(startTime);
+    bypassing ||
+    apiError ||
+    invalidReason ||
+    missingVwbWorkspaceId ||
+    !isDateValid(startTime);
 
   const toolTipContent = apiError ? (
     'Error occurred while creating egress bypass request'
@@ -66,6 +72,7 @@ export const AdminUserEgressBypass = (props: AdminUserEgressBypassProps) => {
             {MAX_BYPASS_DESCRIPTION})
           </li>
         )}
+        {missingVwbWorkspaceId && <li>VWB Workspace ID (UUID)</li>}
         {!isDateValid(startTime) && (
           <li>Valid Request Date (in YYYY-MM-DD Format)</li>
         )}
@@ -78,7 +85,7 @@ export const AdminUserEgressBypass = (props: AdminUserEgressBypassProps) => {
     const createEgressBypassWindowRequest: CreateEgressBypassWindowRequest = {
       startTime: startTime.valueOf(),
       byPassDescription: bypassDescription,
-      vwbWorkspaceId: vwbWorkspaceId || undefined,
+      vwbWorkspaceId: vwbWorkspaceId.trim(),
     };
     setBypassDescription('');
     setVwbWorkspaceId('');
@@ -132,13 +139,13 @@ export const AdminUserEgressBypass = (props: AdminUserEgressBypassProps) => {
           />
         </FlexColumn>
 
-        {/* VWB Workspace ID (optional) */}
+        {/* VWB Workspace ID (required) */}
         <FlexRow style={{ paddingTop: '1rem' }}>
           <label
             htmlFor='VWB Workspace ID'
             style={{ fontWeight: 'bold', color: colors.primary }}
           >
-            VWB Workspace ID (optional - for VWB workspaces only)
+            VWB Workspace ID (required)
           </label>
         </FlexRow>
         <FlexRow>
@@ -149,7 +156,7 @@ export const AdminUserEgressBypass = (props: AdminUserEgressBypassProps) => {
               setApiError(false);
               setVwbWorkspaceId(s);
             }}
-            placeholder='Enter VWB workspace ID (UUID) if applicable'
+            placeholder='Enter VWB workspace ID (UUID)'
             style={{ width: '60%' }}
           />
         </FlexRow>


### PR DESCRIPTION
## Summary

Makes **VWB Workspace ID** a required field on the admin user's egress bypass tab (Admin > User > Enable Large File Downloads). Previously it was optional and labeled as VWB-workspaces-only.

Changes in `ui/src/app/pages/admin/user/admin-user-egress-bypass.tsx`:

- **Label** — `VWB Workspace ID (optional - for VWB workspaces only)` → `VWB Workspace ID (required)`. Dropped "for VWB workspaces only", since it contradicts the field now being mandatory for every request.
- **Placeholder** — `Enter VWB workspace ID (UUID) if applicable` → `Enter VWB workspace ID (UUID)`.
- **Button gating** — added `missingVwbWorkspaceId` to `egressBypassButtonDisabled`, so **Temporarily Enable Large File Downloads** is only clickable once an ID is entered. Uses `.trim()`, so whitespace alone does not satisfy it.
- **Tooltip** — the existing disabled-button tooltip ("Required to enable large file downloads") now lists `VWB Workspace ID (UUID)` alongside the reason/date items, so the admin can see why the button is disabled.
- **Request payload** — `vwbWorkspaceId: vwbWorkspaceId || undefined` → `vwbWorkspaceId: vwbWorkspaceId.trim()`. The `|| undefined` fallback is unreachable now that blank input is blocked.

## Scope notes

- **UI-only enforcement.** `CreateEgressBypassWindowRequest.vwbWorkspaceId` remains optional in the OpenAPI schema, so a direct API call can still omit it. Happy to tighten the schema + add server-side validation in a follow-up if reviewers want that.
- **No format validation.** The field accepts any non-blank string; the "(UUID)" hint is not enforced. A UUID regex check would be a small follow-up.

## Testing

`ui/src/app/pages/admin/user/admin-user-egress-bypass.spec.tsx`:

- Updated the existing happy-path test — it never filled in the ID, so it would have begun failing. It now enters a UUID and asserts `vwbWorkspaceId` reaches `createEgressBypassWindow`.
- Added: blank ID disables the button and shows the tooltip.
- Added: whitespace-only ID disables the button and shows the tooltip.

All 5 tests in the suite pass; ESLint clean on both changed files.

```
Tests:       5 passed, 5 total
```

Note: this modifies the UI, so screenshots + PO/UX notification are still outstanding on the checklist below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)