### PR TITLE
[no ticket][risk=low] Send startTime on VWB egress threshold overrides

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/user/UserAdminService.java
+++ b/api/src/main/java/org/pmiops/workbench/user/UserAdminService.java
@@ -61,6 +61,18 @@ public class UserAdminService {
       Long userId, Instant startTime, String description, String vwbWorkspaceId) {
     Instant endTime = startTime.plus(BYPASS_PERIOD_IN_DAY, ChronoUnit.DAYS);
 
+    // If VWB workspace ID is provided, the exfil manager must accept the override before we record
+    // the window. Creating the DB row first would leave a window that looks active to admins even
+    // though no override was ever applied in VWB.
+    if (vwbWorkspaceId != null) {
+      DbUser user = userService.getByDatabaseId(userId).orElseThrow();
+      // Send both bounds so the override spans the same window we persist. Sending only the end
+      // time makes the exfil manager default the start to now, and it then rejects any window we
+      // scheduled ahead: "End time cannot be more than 48 hours from start time."
+      exfilManagerClient.createEgressThresholdOverride(
+          user.getUsername(), vwbWorkspaceId, startTime, endTime, description);
+    }
+
     // Save to database
     userEgressBypassWindowDao.save(
         new DbUserEgressBypassWindow()
@@ -69,13 +81,6 @@ public class UserAdminService {
             .setEndTime(Timestamp.from(endTime))
             .setDescription(description)
             .setVwbWorkspaceId(vwbWorkspaceId));
-
-    // If VWB workspace ID is provided, call exfil manager to create egress threshold override
-    if (vwbWorkspaceId != null) {
-      DbUser user = userService.getByDatabaseId(userId).orElseThrow();
-      exfilManagerClient.createEgressThresholdOverride(
-          user.getUsername(), vwbWorkspaceId, endTime, description);
-    }
   }
 
   public EgressBypassWindow getCurrentEgressBypassWindow(Long userId) {

--- a/api/src/main/java/org/pmiops/workbench/vwb/exfil/ExfilManagerClient.java
+++ b/api/src/main/java/org/pmiops/workbench/vwb/exfil/ExfilManagerClient.java
@@ -68,13 +68,15 @@ public class ExfilManagerClient {
    *
    * @param username The username for the override
    * @param workspaceId The workspace ID (UUID format)
+   * @param startTime Optional start time for the override. If not provided, the exfil manager
+   *     defaults to the time it processes the request
    * @param endTime Optional end time for the override. If not provided, defaults to 48 hours from
-   *     creation
+   *     the start time. May not be more than 48 hours after the start time
    * @param description Optional description of why the override was created
    * @throws BadRequestException if workspaceId is not a valid UUID
    */
   public void createEgressThresholdOverride(
-      String username, String workspaceId, Instant endTime, String description) {
+      String username, String workspaceId, Instant startTime, Instant endTime, String description) {
     UUID workspaceUuid;
     try {
       workspaceUuid = UUID.fromString(workspaceId);
@@ -89,6 +91,9 @@ public class ExfilManagerClient {
     CreateEgressThresholdOverrideBody body =
         new CreateEgressThresholdOverrideBody().username(username).workspaceId(workspaceUuid);
 
+    if (startTime != null) {
+      body.startTime(OffsetDateTime.ofInstant(startTime, ZoneOffset.UTC));
+    }
     if (endTime != null) {
       body.endTime(OffsetDateTime.ofInstant(endTime, ZoneOffset.UTC));
     }

--- a/api/src/main/resources/vwb-exfil-manager.yaml
+++ b/api/src/main/resources/vwb-exfil-manager.yaml
@@ -144,17 +144,21 @@ components:
           type: string
           format: uuid
           description: The workspace ID
+        startTime:
+          type: string
+          format: date-time
+          description: Optional start time for the override. If not provided, defaults to current time.
         endTime:
           type: string
           format: date-time
-          description: Optional end time for the override. If not provided, defaults to 48 hours from creation. Cannot be more than 48 hours in the future.
+          description: Optional end time for the override. If not provided, defaults to 48 hours from start time. Cannot be more than 48 hours from start time.
         description:
           type: string
           description: Optional description of why the override was created
 
     EgressThresholdOverride:
       type: object
-      required: [ egressThresholdOverrideId, username, workspaceId, creationTime, endTime ]
+      required: [ egressThresholdOverrideId, username, workspaceId, startTime, endTime ]
       properties:
         egressThresholdOverrideId:
           type: string
@@ -167,10 +171,10 @@ components:
           type: string
           format: uuid
           description: The workspace ID
-        creationTime:
+        startTime:
           type: string
           format: date-time
-          description: When the override was created
+          description: When the override starts
         endTime:
           type: string
           format: date-time

--- a/api/src/test/java/org/pmiops/workbench/user/UserAdminServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/user/UserAdminServiceTest.java
@@ -1,7 +1,9 @@
 package org.pmiops.workbench.user;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,6 +21,7 @@ import org.pmiops.workbench.db.dao.UserEgressBypassWindowDao;
 import org.pmiops.workbench.db.dao.UserService;
 import org.pmiops.workbench.db.model.DbUser;
 import org.pmiops.workbench.db.model.DbUserEgressBypassWindow;
+import org.pmiops.workbench.exceptions.ServerErrorException;
 import org.pmiops.workbench.model.EgressBypassWindow;
 import org.pmiops.workbench.utils.mappers.CommonMappers;
 import org.pmiops.workbench.utils.mappers.EgressBypassWindowMapperImpl;
@@ -73,7 +76,8 @@ public class UserAdminServiceTest {
         .isEqualTo(Timestamp.from(FakeClockConfiguration.NOW.toInstant().plus(2, ChronoUnit.DAYS)));
 
     // Verify exfil manager was NOT called for regular bypass window
-    verify(exfilManagerClient, never()).createEgressThresholdOverride(any(), any(), any(), any());
+    verify(exfilManagerClient, never())
+        .createEgressThresholdOverride(any(), any(), any(), any(), any());
   }
 
   @Test
@@ -189,9 +193,76 @@ public class UserAdminServiceTest {
     assertThat(dbEntity.getStartTime()).isEqualTo(Timestamp.from(startTime));
     assertThat(dbEntity.getEndTime()).isEqualTo(Timestamp.from(expectedEndTime));
 
-    // Verify exfil manager was called
+    // Verify exfil manager was called with both bounds of the same window we persisted.
     verify(exfilManagerClient)
-        .createEgressThresholdOverride(USERNAME, VWB_WORKSPACE_ID, expectedEndTime, DESCRIPTION);
+        .createEgressThresholdOverride(
+            USERNAME, VWB_WORKSPACE_ID, startTime, expectedEndTime, DESCRIPTION);
+  }
+
+  @Test
+  public void testCreateEgressBypassWindow_withVwbWorkspace_futureStartTime() {
+    DbUser dbUser = new DbUser();
+    dbUser.setUserId(USER_ID);
+    dbUser.setUsername(USERNAME);
+    when(userService.getByDatabaseId(USER_ID)).thenReturn(Optional.of(dbUser));
+
+    Instant startTime = FakeClockConfiguration.NOW.toInstant().plus(7, ChronoUnit.DAYS);
+
+    userAdminService.createEgressBypassWindow(USER_ID, startTime, DESCRIPTION, VWB_WORKSPACE_ID);
+
+    // The persisted window still honors the requested start time.
+    Set<DbUserEgressBypassWindow> dbResults =
+        userEgressBypassWindowDao.getByUserIdOrderByStartTimeDesc(USER_ID);
+    assertThat(dbResults).hasSize(1);
+    DbUserEgressBypassWindow dbEntity = dbResults.stream().findFirst().get();
+    assertThat(dbEntity.getStartTime()).isEqualTo(Timestamp.from(startTime));
+    assertThat(dbEntity.getEndTime()).isEqualTo(Timestamp.from(startTime.plus(2, ChronoUnit.DAYS)));
+
+    // The override carries the same future window. Previously only the end time was sent, so the
+    // exfil manager defaulted the start to now and rejected the 215 hour duration.
+    verify(exfilManagerClient)
+        .createEgressThresholdOverride(
+            USERNAME, VWB_WORKSPACE_ID, startTime, startTime.plus(2, ChronoUnit.DAYS), DESCRIPTION);
+  }
+
+  @Test
+  public void testCreateEgressBypassWindow_withoutVwbWorkspace_futureStartTimeAllowed() {
+    // Non-VWB windows never reach the exfil manager, so they may still be scheduled ahead.
+    Instant startTime = FakeClockConfiguration.NOW.toInstant().plus(7, ChronoUnit.DAYS);
+
+    userAdminService.createEgressBypassWindow(USER_ID, startTime, DESCRIPTION, null);
+
+    Set<DbUserEgressBypassWindow> dbResults =
+        userEgressBypassWindowDao.getByUserIdOrderByStartTimeDesc(USER_ID);
+    assertThat(dbResults).hasSize(1);
+    assertThat(dbResults.stream().findFirst().get().getStartTime())
+        .isEqualTo(Timestamp.from(startTime));
+    verify(exfilManagerClient, never())
+        .createEgressThresholdOverride(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testCreateEgressBypassWindow_exfilManagerFailure_doesNotSaveWindow() {
+    DbUser dbUser = new DbUser();
+    dbUser.setUserId(USER_ID);
+    dbUser.setUsername(USERNAME);
+    when(userService.getByDatabaseId(USER_ID)).thenReturn(Optional.of(dbUser));
+
+    doThrow(new ServerErrorException("exfil manager unavailable"))
+        .when(exfilManagerClient)
+        .createEgressThresholdOverride(any(), any(), any(), any(), any());
+
+    Instant startTime = FakeClockConfiguration.NOW.toInstant();
+
+    assertThrows(
+        ServerErrorException.class,
+        () ->
+            userAdminService.createEgressBypassWindow(
+                USER_ID, startTime, DESCRIPTION, VWB_WORKSPACE_ID));
+
+    // A window that was never applied in VWB must not be recorded, otherwise admins see a bypass
+    // that is not actually in effect.
+    assertThat(userEgressBypassWindowDao.getByUserIdOrderByStartTimeDesc(USER_ID)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes a 400 from the exfil manager when an admin picks a future start time for an egress bypass window:

```
Exception calling ExfilManager API with response:
{"message":"End time cannot be more than 48 hours from start time.
  Provided duration is 215 hours.","statusCode":400,"causes":[]}
org.pmiops.workbench.vwb.exfil.ApiException
    at ...EgressThresholdOverrideApi.createEgressThresholdOverride
    at ...ExfilManagerClient.lambda$createEgressThresholdOverride$2(ExfilManagerClient.java:101)
```

### Root cause

Our vendored copy of the exfil manager spec was stale: `CreateEgressThresholdOverrideBody` was missing `startTime`, so we only ever sent `endTime`. The exfil manager defaults the override's start to the moment it processes the request (`EgressThresholdOverride.fromApi`, lines 28-32) and validates `endTime` against that default, so a window scheduled a week out was measured as a 215-hour duration and rejected. Picking the current time worked only because it landed inside the 48-hour bound.

Nothing was wrong with VWB's contract — we weren't using half of it.

### Changes

**Sync the vendored spec** (`api/src/main/resources/vwb-exfil-manager.yaml`) with `exfil-manager/common/openapi.yml`, which is the codegen source per `exfil-manager/build.gradle:28`. I diffed all five schemas we vendor; exactly the two override schemas had drifted:

| Field | Ours (before) | Source |
|---|---|---|
| `CreateEgressThresholdOverrideBody.startTime` | absent | present |
| `endTime` description | "48 hours from creation... in the future" | "48 hours from **start time**" |
| `EgressThresholdOverride.creationTime` | present | does not exist; it's `startTime` |

**Send both bounds.** `ExfilManagerClient.createEgressThresholdOverride` takes a `startTime`, and `UserAdminService` passes the requested start through, so the override spans the same window we persist. The duration is then exactly 48 hours, which the exfil manager accepts — its check is `duration.compareTo(maxDuration) > 0` (`EgressThresholdOverrideService.java:34`), so the bound is inclusive and no safety margin is needed.

**Create the override before saving the window.** Previously the DB row was written first, so a failed exfil manager call left behind a row that looks like an active bypass to admins even though no override was ever applied in VWB.

## Deployment safety

This restores the ability to schedule bypass windows in advance, which regressed when the VWB workspace ID became required in #9590 (every request now reaches the exfil manager, so every future-dated request was failing).

## Known gap in exfil manager (not fixable here)

`EgressThresholdOverrideDao.getActiveEgressThresholdOverridesByUserAndWorkspace` filters only on `end_time > :now` and never compares `start_time` (it appears solely in `ORDER BY`). That query feeds the `BYPASSED` vs `PENDING` decision in `EgressMonitorService` (lines 174-181), so **an override scheduled for the future suppresses egress detection from the moment it is created.** A bypass scheduled a week out currently suppresses detection for ~9 days rather than 48 hours.

Before this PR that request simply 400'd, so this change makes the gap reachable. The fix belongs in the exfil manager repo (add `AND start_time <= :now` to that query) and should be tracked separately. Reviewers: if you'd rather not widen the window before that lands, say so and I'll gate future start times in the UI/API as an interim measure.

## Testing

`UserAdminServiceTest`, 12/12 pass:

- `testCreateEgressBypassWindow_withVwbWorkspace` — updated: asserts both bounds now reach the client.
- `testCreateEgressBypassWindow_withVwbWorkspace_futureStartTime` — new: a start 7 days out persists the requested window and forwards the same window to the exfil manager. This is the reported bug.
- `testCreateEgressBypassWindow_withoutVwbWorkspace_futureStartTimeAllowed` — new: non-VWB windows never call the exfil manager.
- `testCreateEgressBypassWindow_exfilManagerFailure_doesNotSaveWindow` — new: a failed override leaves no DB row.

Not covered by automated tests: the actual round trip to a deployed exfil manager. Worth one manual check against test with a future start time before merge, since the 48-hour bound is enforced server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)