### PR TITLE
[no ticket][risk=no] Fix workspace dao call for delete cron

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/workspaces/WorkspaceServiceImpl.java
@@ -301,10 +301,11 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     // This automatically handles access control to the workspace.
     fireCloudService.deleteWorkspaceAsService(
         dbWorkspace.getWorkspaceNamespace(), dbWorkspace.getFirecloudName());
-    dbWorkspace =
-        workspaceDao.saveWithLastModified(
-            dbWorkspace.setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED),
-            userProvider.get());
+    dbWorkspace
+        .setWorkspaceActiveStatusEnum(WorkspaceActiveStatus.DELETED)
+        .setLastModifiedTime(new Timestamp(clock.instant().toEpochMilli()))
+        .setLastModifiedBy(workbenchConfigProvider.get().auth.serviceAccountApiUsers.get(0));
+    workspaceDao.save(dbWorkspace);
     // Since deleted workspace entry still exist in database we have to explicitly remove it from
     // featured_workspace
     // if they exist


### PR DESCRIPTION
Saves the workspace object directly to avoid calling `userProvider` which will cause a failure when called in a cloud task