### PR TITLE
[dt-1224][risk=low] Added check on user groups 

### DIFF
--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserGroupActionDao.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserGroupActionDao.java
@@ -1,9 +1,16 @@
 package org.pmiops.workbench.db.dao;
 
+import java.util.List;
 import org.pmiops.workbench.db.model.DbUserGroupAction;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserGroupActionDao extends CrudRepository<DbUserGroupAction, Long> {
   DbUserGroupAction findFirstByInstitutionIdAndUserGroupActionStatusOrderByAddedTime(
       long institutionId, String status);
+
+  List<DbUserGroupAction> findByUserEmailAndGroupNameAndUserGroupActionStatus(
+      String userEmail, String groupName, String status);
+
+  List<DbUserGroupAction> findByUserEmailAndGroupNameAndInstitutionIdAndUserGroupActionStatus(
+      String userEmail, String groupName, long institutionId, String status);
 }

--- a/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/db/dao/UserServiceImpl.java
@@ -48,6 +48,7 @@ import org.pmiops.workbench.exceptions.NotFoundException;
 import org.pmiops.workbench.firecloud.FireCloudService;
 import org.pmiops.workbench.firecloud.model.FirecloudNihStatus;
 import org.pmiops.workbench.google.DirectoryService;
+import org.pmiops.workbench.institution.InstitutionService;
 import org.pmiops.workbench.mail.MailService;
 import org.pmiops.workbench.model.AccessModuleStatus;
 import org.pmiops.workbench.model.Authority;
@@ -94,6 +95,7 @@ public class UserServiceImpl implements UserService {
   private final MailService mailService;
   private final DiscoverySourceMapper discoverySourceMapper;
   private final AccessSyncService accessSyncService;
+  private final InstitutionService institutionService;
 
   private static final Logger log = Logger.getLogger(UserServiceImpl.class.getName());
 
@@ -114,6 +116,7 @@ public class UserServiceImpl implements UserService {
       AccessTierService accessTierService,
       MailService mailService,
       AccessSyncService accessSyncService,
+      InstitutionService institutionService,
       DiscoverySourceMapper discoverySourceMapper) {
     this.configProvider = configProvider;
     this.userProvider = userProvider;
@@ -130,6 +133,7 @@ public class UserServiceImpl implements UserService {
     this.accessTierService = accessTierService;
     this.mailService = mailService;
     this.accessSyncService = accessSyncService;
+    this.institutionService = institutionService;
     this.discoverySourceMapper = discoverySourceMapper;
   }
 
@@ -378,14 +382,17 @@ public class UserServiceImpl implements UserService {
               latestDuccVersion));
     }
     final Timestamp timestamp = clockNow();
-    return updateUserWithRetries(
-        (user) -> {
-          accessModuleService.updateCompletionTime(
-              user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, timestamp);
-          return updateDuccAgreement(user, duccSignedVersion, initials, timestamp);
-        },
-        dbUser,
-        Agent.asUser(dbUser));
+    DbUser updatedUser =
+        updateUserWithRetries(
+            (user) -> {
+              accessModuleService.updateCompletionTime(
+                  user, DbAccessModuleName.DATA_USER_CODE_OF_CONDUCT, timestamp);
+              return updateDuccAgreement(user, duccSignedVersion, initials, timestamp);
+            },
+            dbUser,
+            Agent.asUser(dbUser));
+    institutionService.maybeEnqueueUserGroupActionsForUser(updatedUser);
+    return updatedUser;
   }
 
   private Integer getLatestDuccVersion() {

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionService.java
@@ -134,6 +134,12 @@ public interface InstitutionService {
   boolean shouldBypassForCreditsExpiration(DbUser user);
 
   /**
+   * Enqueue add-user-group actions for the specified user if their affiliated institution has user
+   * groups configured and they are currently eligible for provisioning.
+   */
+  void maybeEnqueueUserGroupActionsForUser(DbUser user);
+
+  /**
    * Process the next user to be added or removed for the specified institution.
    *
    * @param institutionId ID for institution for which the group action is being made

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -580,6 +580,44 @@ public class InstitutionServiceImpl implements InstitutionService {
   }
 
   @Override
+  public void maybeEnqueueUserGroupActionsForUser(DbUser user) {
+    if (user == null || Strings.isNullOrEmpty(user.getUsername())) {
+      return;
+    }
+
+    verifiedInstitutionalAffiliationDao
+        .findFirstByUser(user)
+        .map(DbVerifiedInstitutionalAffiliation::getInstitution)
+        .ifPresent(
+            institution -> {
+              List<String> institutionEmails =
+                  userDao.findActiveUserEmailsWithCurrentDuccOrBypassByInstitution(
+                      institution.getInstitutionId());
+              if (!institutionEmails.contains(user.getUsername())) {
+                return;
+              }
+
+              List<String> groupsToAdd =
+                  institutionUserGroupDao.getByInstitution(institution).stream()
+                      .map(DbInstitutionUserGroup::getUserGroup)
+                      .distinct()
+                      .collect(Collectors.toList());
+              if (groupsToAdd.isEmpty()) {
+                return;
+              }
+
+              groupsToAdd.forEach(
+                  group ->
+                      insertUserGroupActions(
+                          List.of(user.getUsername()),
+                          institution.getInstitutionId(),
+                          group,
+                          UserGroupAction.ADD));
+              taskQueueService.pushUserGroupActionTask(institution.getInstitutionId());
+            });
+  }
+
+  @Override
   public void processNextUserGroupAction(long institutionId) {
     // Make sure UserGroupActionDao inserts complete before running task
     try {

--- a/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
+++ b/api/src/main/java/org/pmiops/workbench/institution/InstitutionServiceImpl.java
@@ -606,14 +606,41 @@ public class InstitutionServiceImpl implements InstitutionService {
                 return;
               }
 
-              groupsToAdd.forEach(
-                  group ->
-                      insertUserGroupActions(
-                          List.of(user.getUsername()),
-                          institution.getInstitutionId(),
-                          group,
-                          UserGroupAction.ADD));
-              taskQueueService.pushUserGroupActionTask(institution.getInstitutionId());
+              List<String> groupsToEnqueue = new ArrayList<>();
+              for (String group : groupsToAdd) {
+                // Check if there's already an INCOMPLETE or COMPLETE action for this
+                // user+institution+group combination
+                List<DbUserGroupAction> incompleteActions =
+                    userGroupActionDao
+                        .findByUserEmailAndGroupNameAndInstitutionIdAndUserGroupActionStatus(
+                            user.getUsername(),
+                            group,
+                            institution.getInstitutionId(),
+                            UserGroupActionStatus.INCOMPLETE.toString());
+                List<DbUserGroupAction> completeActions =
+                    userGroupActionDao
+                        .findByUserEmailAndGroupNameAndInstitutionIdAndUserGroupActionStatus(
+                            user.getUsername(),
+                            group,
+                            institution.getInstitutionId(),
+                            UserGroupActionStatus.COMPLETE.toString());
+
+                // Only enqueue if no existing action found (deduplication check)
+                if (incompleteActions.isEmpty() && completeActions.isEmpty()) {
+                  groupsToEnqueue.add(group);
+                }
+              }
+
+              if (!groupsToEnqueue.isEmpty()) {
+                groupsToEnqueue.forEach(
+                    group ->
+                        insertUserGroupActions(
+                            List.of(user.getUsername()),
+                            institution.getInstitutionId(),
+                            group,
+                            UserGroupAction.ADD));
+                taskQueueService.pushUserGroupActionTask(institution.getInstitutionId());
+              }
             });
   }
 

--- a/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
+++ b/api/src/test/java/org/pmiops/workbench/db/dao/UserServiceTest.java
@@ -435,6 +435,16 @@ public class UserServiceTest {
   }
 
   @Test
+  public void testSubmitDucc_triggersInstitutionUserGroupBackfillCheck() {
+    providedWorkbenchConfig.access.latestDuccVersion = 7;
+
+    DbUser user = userDao.findUserByUsername(USERNAME);
+    userService.submitDUCC(user, 7, "AB");
+
+    verify(mockInstitutionService).maybeEnqueueUserGroupActionsForUser(any(DbUser.class));
+  }
+
+  @Test
   public void test_hasAuthority() {
     DbUser user = new DbUser();
     user.setAuthoritiesEnum(Collections.singleton(Authority.ACCESS_CONTROL_ADMIN));


### PR DESCRIPTION
The fix adds a backend check that runs after DUCC submission: if the user is affiliated with an institution that has ECHO-related user groups configured and the user now meets eligibility, the system enqueues ADD group actions and triggers the existing cloud task flow to provision membership in VWB.

---
**PR checklist**

- [ ] I have included an issue ID or "no ticket" in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have included a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title as outlined in [CONTRIBUTING.md](https://github.com/all-of-us/workbench/blob/main/.github/CONTRIBUTING.md).
- [ ] I have manually tested this change and my testing process is described above.
- [ ] This change includes appropriate automated tests, and I have documented any behavior that cannot be tested with code.
- [ ] I have added explanatory comments where the logic is not obvious.
- One or more of the following is true:
  - [ ] This change is intended to complete a JIRA story, so I have checked that all AC are met for that story.
  - [ ] This change fixes a bug, so I have ensured the steps to reproduce are in the Jira ticket or provided above.
  - [ ] This change impacts deployment safety (e.g. removing/altering APIs which are in use), so I have documented the impacts in the description.
  - [ ] This change includes a new feature flag, so I have created and linked new JIRA tickets to (a) turn on the feature flag and (b) remove it later.
  - [ ] This change modifies the UI, so I have taken screenshots or recordings of the new behavior and notified the PO and UX designer in [Slack](https://pmi-engteam.slack.com/archives/C02MWP2RN5P).
  - [ ] This change modifies API behavior, so I have run the relevant E2E tests locally because API changes are not covered by our PR checks.
  - [ ] None of the above apply to this change.
